### PR TITLE
feat:[#16]연습모드-질문 목록 화면 API 연동

### DIFF
--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -1,28 +1,121 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '@/app/components/ui/card';
 import { Input } from '@/app/components/ui/input';
 import { Badge } from '@/app/components/ui/badge';
 import { Button } from '@/app/components/ui/button';
 import BottomNav from '@/app/components/BottomNav';
-import { QUESTIONS } from '@/data/questions';
-import { Search, ArrowLeft, Filter } from 'lucide-react';
+import { Search, Filter } from 'lucide-react';
+import { fetchQuestions, searchQuestions } from '@/utils/questionApi';
+import debounce from 'lodash/debounce';
+import { useInfiniteScroll } from '@/app/hooks/useInfiniteScroll';
 
 import { AppHeader } from '@/app/components/AppHeader';
 
+const INITIAL_SEARCH_QUERY = '';
+const INITIAL_CATEGORY = '전체';
+const INITIAL_SUB_CATEGORY = '전체';
+const CATEGORY_OPTIONS = ['전체', 'CS기초', '시스템디자인'];
+const CS_SUB_CATEGORY_OPTIONS = ['전체', '운영체제', '네트워크', '데이터베이스', '컴퓨터 구조', '알고리즘'];
+const CS_CATEGORY_MAP = {
+    운영체제: 'OS',
+    네트워크: 'NETWORK',
+    데이터베이스: 'DB',
+    '컴퓨터 구조': 'COMPUTER_ARCHITECTURE',
+    알고리즘: 'ALGORITHM',
+};
+const CATEGORY_LABEL_MAP = {
+    OS: '운영체제',
+    NETWORK: '네트워크',
+    DB: '데이터베이스',
+    COMPUTER_ARCHITECTURE: '컴퓨터 구조',
+    ALGORITHM: '알고리즘',
+};
+const SEARCH_DEBOUNCE_MS = 300;
+const SEARCH_MIN_LENGTH = 2;
+const PAGE_SIZE = 10;
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_LOADING_MORE = '더 불러오는 중...';
+const TEXT_EMPTY = '검색 결과가 없습니다';
+const TEXT_ERROR_FALLBACK = '질문 목록을 불러오지 못했습니다.';
+
 const PracticeMain = () => {
     const navigate = useNavigate();
-    const [searchQuery, setSearchQuery] = useState('');
-    const [selectedCategory, setSelectedCategory] = useState('전체');
+    const [searchQuery, setSearchQuery] = useState(INITIAL_SEARCH_QUERY);
+    const [selectedCategory, setSelectedCategory] = useState(INITIAL_CATEGORY);
+    const [selectedSubCategory, setSelectedSubCategory] = useState(INITIAL_SUB_CATEGORY);
+    const filtersRef = useRef({ query: '', type: undefined, category: undefined });
+    const isFirstFilterLoad = useRef(true);
 
-    const categories = ['전체', 'CS기초', '시스템디자인'];
+    useEffect(() => {
+        setSelectedSubCategory(INITIAL_SUB_CATEGORY);
+    }, [selectedCategory]);
 
-    const filteredQuestions = QUESTIONS.filter((q) => {
-        const matchesSearch = q.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            q.description.toLowerCase().includes(searchQuery.toLowerCase());
-        const matchesCategory = selectedCategory === '전체' || q.category === selectedCategory;
-        return matchesSearch && matchesCategory;
-    });
+    const fetchQuestionPage = useCallback(async ({ cursor = null, limit = PAGE_SIZE } = {}) => {
+        const { query, type, category } = filtersRef.current;
+        const response =
+            query.length >= SEARCH_MIN_LENGTH
+                ? await searchQuestions({ q: query, type, category, cursor, size: limit })
+                : await fetchQuestions({ type, category, cursor, size: limit });
+
+        const items = response?.data?.questions ?? [];
+        const pagination = response?.data?.pagination ?? {};
+        const records = items.map((question) => ({
+            id: question.questionId ?? question.id,
+            title: question.content ?? question.title ?? '',
+            description: question.content ?? '',
+            category: question.category ?? '',
+            keywords: Array.isArray(question.keywords) ? question.keywords : [],
+        }));
+
+        return { data: { records, pagination } };
+    }, []);
+
+    const {
+        data: questions,
+        loading: isLoading,
+        error,
+        hasMore,
+        observerRef,
+        reset,
+        refetch,
+    } = useInfiniteScroll(fetchQuestionPage, { limit: PAGE_SIZE, enabled: true });
+    const isLoadingMore = isLoading && questions.length > 0;
+
+    useEffect(() => {
+        const type =
+            selectedCategory === 'CS기초'
+                ? 'CS'
+                : selectedCategory === '시스템디자인'
+                    ? 'SYSTEM_DESIGN'
+                    : undefined;
+        const category =
+            selectedCategory === 'CS기초' && selectedSubCategory !== INITIAL_SUB_CATEGORY
+                ? CS_CATEGORY_MAP[selectedSubCategory]
+                : undefined;
+        filtersRef.current = { query: searchQuery.trim(), type, category };
+    }, [searchQuery, selectedCategory, selectedSubCategory]);
+
+    const debouncedReload = useMemo(
+        () =>
+            debounce(() => {
+                reset();
+                refetch();
+            }, SEARCH_DEBOUNCE_MS),
+        [reset, refetch]
+    );
+
+    useEffect(() => {
+        if (isFirstFilterLoad.current) {
+            isFirstFilterLoad.current = false;
+            return () => debouncedReload.cancel();
+        }
+
+        debouncedReload();
+        return () => debouncedReload.cancel();
+    }, [searchQuery, selectedCategory, selectedSubCategory]);
+
+    const errorMessage = error?.message || TEXT_ERROR_FALLBACK;
 
     return (
         <div className="min-h-screen bg-background pb-20">
@@ -47,7 +140,7 @@ const PracticeMain = () => {
                 <div className="px-4 pb-3 max-w-lg mx-auto">
                     <div className="flex items-center gap-2 overflow-x-auto pb-2">
                         <Filter className="w-4 h-4 text-muted-foreground flex-shrink-0" />
-                        {categories.map((category) => (
+                        {CATEGORY_OPTIONS.map((category) => (
                             <Button
                                 key={category}
                                 variant={selectedCategory === category ? 'default' : 'outline'}
@@ -60,50 +153,82 @@ const PracticeMain = () => {
                         ))}
                     </div>
                 </div>
+                {selectedCategory === 'CS기초' && (
+                    <div className="px-4 pb-4 max-w-lg mx-auto">
+                        <div className="flex items-center gap-2 overflow-x-auto pb-2">
+                            {CS_SUB_CATEGORY_OPTIONS.map((category) => (
+                                <Button
+                                    key={category}
+                                    variant={selectedSubCategory === category ? 'default' : 'outline'}
+                                    size="sm"
+                                    onClick={() => setSelectedSubCategory(category)}
+                                    className="rounded-full whitespace-nowrap"
+                                >
+                                    {category}
+                                </Button>
+                            ))}
+                        </div>
+                    </div>
+                )}
             </div>
 
             {/* Question List */}
             <div className="p-4 space-y-3 max-w-lg mx-auto">
-                {filteredQuestions.length === 0 ? (
+                {isLoading && questions.length === 0 ? (
                     <div className="text-center py-12 text-muted-foreground">
-                        <p>검색 결과가 없습니다</p>
+                        <p>{TEXT_LOADING}</p>
+                    </div>
+                ) : error ? (
+                    <div className="text-center py-12 text-rose-500">
+                        <p>{errorMessage}</p>
+                    </div>
+                ) : questions.length === 0 ? (
+                    <div className="text-center py-12 text-muted-foreground">
+                        <p>{TEXT_EMPTY}</p>
                     </div>
                 ) : (
-                    filteredQuestions.map((question) => (
-                        <Card
-                            key={question.id}
-                            className="p-4 hover:shadow-md transition-shadow cursor-pointer"
-                            onClick={() => navigate(`/practice/answer/${question.id}`)}
-                        >
-                            <div className="flex items-start justify-between mb-2">
-                                <Badge variant="secondary" className="bg-rose-100 text-rose-700">
-                                    {question.category}
-                                </Badge>
-                                <Badge variant="outline">{question.difficulty}</Badge>
-                            </div>
+                    <>
+                        {questions.map((question) => (
+                            <Card
+                                key={question.id}
+                                className="p-4 hover:shadow-md transition-shadow cursor-pointer"
+                                onClick={() => navigate(`/practice/answer/${question.id}`)}
+                            >
+                                <div className="flex items-start justify-between mb-2">
+                                    <Badge variant="secondary" className="bg-rose-100 text-rose-700">
+                                        {CATEGORY_LABEL_MAP[question.category] || question.category}
+                                    </Badge>
+                                </div>
 
-                            <h3 className="mb-2">{question.title}</h3>
-                            <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
-                                {question.description}
-                            </p>
+                                <h3 className="mb-2">{question.title}</h3>
+                                <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+                                    {question.description}
+                                </p>
 
-                            <div className="flex flex-wrap gap-1">
-                                {question.keywords.slice(0, 3).map((keyword, idx) => (
-                                    <span
-                                        key={idx}
-                                        className="text-xs px-2 py-1 bg-rose-50 text-rose-700 rounded-full"
-                                    >
-                                        #{keyword}
-                                    </span>
-                                ))}
-                                {question.keywords.length > 3 && (
-                                    <span className="text-xs px-2 py-1 text-gray-500">
-                                        +{question.keywords.length - 3}
-                                    </span>
-                                )}
+                                <div className="flex flex-wrap gap-1">
+                                    {question.keywords.slice(0, 3).map((keyword, idx) => (
+                                        <span
+                                            key={idx}
+                                            className="text-xs px-2 py-1 bg-rose-50 text-rose-700 rounded-full"
+                                        >
+                                            #{keyword}
+                                        </span>
+                                    ))}
+                                    {question.keywords.length > 3 && (
+                                        <span className="text-xs px-2 py-1 text-gray-500">
+                                            +{question.keywords.length - 3}
+                                        </span>
+                                    )}
+                                </div>
+                            </Card>
+                        ))}
+                        {isLoadingMore && (
+                            <div className="text-center py-6 text-muted-foreground">
+                                <p>{TEXT_LOADING_MORE}</p>
                             </div>
-                        </Card>
-                    ))
+                        )}
+                        {hasMore && <div ref={observerRef} />}
+                    </>
                 )}
             </div>
 

--- a/src/utils/questionApi.js
+++ b/src/utils/questionApi.js
@@ -1,0 +1,73 @@
+import { api } from './apiUtils';
+
+// 빈 값 제외하고 쿼리 문자열을 생성한다.
+const buildQuery = (params = {}) => {
+    const query = new URLSearchParams();
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            query.set(key, String(value));
+        }
+    });
+
+    const queryString = query.toString();
+    return queryString ? `?${queryString}` : '';
+};
+
+// 질문 목록 조회
+export async function fetchQuestions({ category, type, cursor, size } = {}) {
+    const query = buildQuery({ category, type, cursor, size });
+    return api.get(`/api/questions${query}`, { parseResponse: true });
+}
+
+// 질문 상세 조회
+export async function fetchQuestionById(questionId) {
+    return api.get(`/api/questions/${questionId}`, { parseResponse: true });
+}
+
+// 질문 검색
+export async function searchQuestions({ q, category, type, cursor, size } = {}) {
+    const query = buildQuery({ q, category, type, cursor, size });
+    return api.get(`/api/questions/search${query}`, { parseResponse: true });
+}
+
+// 질문 생성
+export async function createQuestion(payload) {
+    return api.post('/api/questions', payload, { parseResponse: true });
+}
+
+// 질문 수정
+export async function updateQuestion(questionId, payload) {
+    return api.patch(`/api/questions/${questionId}`, payload, { parseResponse: true });
+}
+
+// 질문 삭제
+export async function deleteQuestion(questionId) {
+    return api.delete(`/api/questions/${questionId}`, { parseResponse: true });
+}
+
+// 질문 핵심 키워드 조회
+export async function fetchQuestionKeywords(questionId) {
+    return api.get(`/api/questions/${questionId}/keywords`, { parseResponse: true });
+}
+
+// 질문 핵심 키워드 포함 여부 확인
+export async function checkQuestionKeywords(questionId, payload) {
+    return api.post(`/api/questions/${questionId}/keyword-checks`, payload, { parseResponse: true });
+}
+
+// 시스템 디자인 질문 목록 조회
+export async function fetchSystemDesignQuestions({ type, category, difficulty, page, size } = {}) {
+    const query = buildQuery({ type, category, difficulty, page, size });
+    return api.get(`/api/v1/questions/system-design${query}`, { parseResponse: true });
+}
+
+// 태그 목록 조회
+export async function fetchTags() {
+    return api.get('/api/tags', { parseResponse: true });
+}
+
+// 질문 태그 목록 조회
+export async function fetchQuestionTags(questionId) {
+    return api.get(`/api/questions/${questionId}/tags`, { parseResponse: true });
+}


### PR DESCRIPTION
  ## 요약

  연습 모드 질문 목록을 API 연동으로 전환하고, CS 하위 카테고리 매핑/한글 라벨 표시를 추가했습니다. 또한 커서 기반 인피니티 스크롤과 lodash 기반 디바운스/스로틀을 적용했습니다.
  질문 관련 API 모듈에 목록/상세/검색/생성/수정/삭제/키워드/태그 기능을 추가해 재사용 가능하게 정리했습니다.

  ## 변경사항

  - 질문 API 모듈 추가(기능 포함)
      - src/utils/questionApi.js
          - 질문 목록/상세/검색
          - 질문 생성/수정/삭제
          - 질문 키워드 조회/키워드 포함 여부 체크
          - 시스템 디자인 질문 목록
          - 태그 목록/질문 태그 목록
  - 연습 모드 질문 목록 API 연동/인피니티 스크롤/카테고리 매핑/라벨 처리
      - src/app/pages/PracticeMain.jsx

  ## 관련 Commit, Issue

  - #16 
  - #13 
  - #12 
  - #11

  ### 관련 이슈 배경

  - 연습 모드 질문 목록을 실제 API 기반으로 전환 필요
  - CS 하위 카테고리 필터링 및 한국어 표기 요구
  - 대량 목록 탐색을 위한 인피니티 스크롤 및 호출 최적화 필요