### PR TITLE
feat:[#17] 음성 답변 녹음/STT 연동 및 상태 관리 기능 구현

### DIFF
--- a/src/api/fileApi.js
+++ b/src/api/fileApi.js
@@ -1,0 +1,45 @@
+import { api, handleResponse } from '@/utils/apiUtils'
+
+/**
+ * S3 presigned URL 요청
+ * @param {Object} params
+ * @param {string} params.fileName - 파일명
+ * @param {string} params.contentType - MIME 타입 (예: audio/webm)
+ * @returns {Promise<{data: {fileId: string, presignedUrl: string}}>}
+ */
+export async function getPresignedUrl({ fileName, contentType }) {
+  const response = await api.post('/api/files/presigned-url', {
+    fileName,
+    contentType,
+  })
+  return handleResponse(response)
+}
+
+/**
+ * S3 직접 업로드 (presigned URL 사용)
+ * @param {string} presignedUrl - S3 presigned URL
+ * @param {Blob} file - 업로드할 파일
+ * @param {string} contentType - MIME 타입
+ */
+export async function uploadToS3(presignedUrl, file, contentType) {
+  const response = await fetch(presignedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': contentType,
+    },
+  })
+  if (!response.ok) {
+    throw new Error('S3 업로드 실패')
+  }
+}
+
+/**
+ * 파일 업로드 확인
+ * @param {string} fileId - 파일 ID
+ * @returns {Promise<{data: {fileUrl: string}}>}
+ */
+export async function confirmFileUpload(fileId) {
+  const response = await api.post(`/api/files/${fileId}/confirm`)
+  return handleResponse(response)
+}

--- a/src/api/sttApi.js
+++ b/src/api/sttApi.js
@@ -1,0 +1,16 @@
+import { api, handleResponse } from '@/utils/apiUtils'
+
+/**
+ * STT 요청 - 음성 파일을 텍스트로 변환
+ * @param {Object} params
+ * @param {string} params.audioUrl - S3 음성 파일 URL
+ * @param {string} params.questionId - 질문 ID
+ * @returns {Promise<{data: {text: string}}>}
+ */
+export async function requestSTT({ audioUrl, questionId }) {
+  const response = await api.post('/api/stt', {
+    audioUrl,
+    questionId,
+  })
+  return handleResponse(response)
+}

--- a/src/app/hooks/useAudioRecorder.js
+++ b/src/app/hooks/useAudioRecorder.js
@@ -1,0 +1,205 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+
+/**
+ * 녹음기 상태 enum
+ * @typedef {'idle' | 'recording' | 'paused' | 'permission_error' | 'device_error'} RecorderState
+ */
+
+/**
+ * 오디오 녹음 커스텀 훅
+ * @returns {Object} { recorderState, isRecording, audioBlob, audioLevel, startRecording, stopRecording, pauseRecording, resumeRecording, discardRecording, error, resetAudioBlob }
+ */
+export function useAudioRecorder() {
+  const [recorderState, setRecorderState] = useState('idle')
+  const [audioBlob, setAudioBlob] = useState(null)
+  const [audioLevel, setAudioLevel] = useState(0)
+  const [error, setError] = useState(null)
+
+  const mediaRecorderRef = useRef(null)
+  const audioContextRef = useRef(null)
+  const analyserRef = useRef(null)
+  const streamRef = useRef(null)
+  const chunksRef = useRef([])
+  const animationFrameRef = useRef(null)
+
+  // isRecording은 recorderState 기반으로 계산
+  const isRecording = recorderState === 'recording' || recorderState === 'paused'
+
+  const updateAudioLevel = useCallback(() => {
+    if (!analyserRef.current) return
+
+    const dataArray = new Uint8Array(analyserRef.current.frequencyBinCount)
+    analyserRef.current.getByteFrequencyData(dataArray)
+
+    const average = dataArray.reduce((a, b) => a + b, 0) / dataArray.length
+    setAudioLevel(average / 255)
+
+    animationFrameRef.current = requestAnimationFrame(updateAudioLevel)
+  }, [])
+
+  const cleanupAudioContext = useCallback(() => {
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current)
+      animationFrameRef.current = null
+    }
+
+    if (audioContextRef.current && audioContextRef.current.state !== 'closed') {
+      audioContextRef.current.close()
+      audioContextRef.current = null
+    }
+
+    analyserRef.current = null
+  }, [])
+
+  const cleanupStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop())
+      streamRef.current = null
+    }
+  }, [])
+
+  const startRecording = useCallback(async () => {
+    try {
+      setError(null)
+      setAudioBlob(null)
+      chunksRef.current = []
+
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      streamRef.current = stream
+
+      // 오디오 레벨 분석 설정
+      audioContextRef.current = new AudioContext()
+      const source = audioContextRef.current.createMediaStreamSource(stream)
+      analyserRef.current = audioContextRef.current.createAnalyser()
+      analyserRef.current.fftSize = 256
+      source.connect(analyserRef.current)
+
+      // MediaRecorder 설정 (mp4 우선 - Safari AAC/m4a 호환)
+      const mimeType = MediaRecorder.isTypeSupported('audio/mp4')
+        ? 'audio/mp4'
+        : MediaRecorder.isTypeSupported('audio/webm')
+          ? 'audio/webm'
+          : ''
+
+      const options = mimeType ? { mimeType } : {}
+      mediaRecorderRef.current = new MediaRecorder(stream, options)
+
+      mediaRecorderRef.current.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data)
+        }
+      }
+
+      mediaRecorderRef.current.onstop = () => {
+        const mimeTypeUsed = mediaRecorderRef.current?.mimeType || 'audio/webm'
+        const blob = new Blob(chunksRef.current, { type: mimeTypeUsed })
+        setAudioBlob(blob)
+        cleanupStream()
+        cleanupAudioContext()
+      }
+
+      mediaRecorderRef.current.start(100) // 100ms마다 데이터 수집
+      setRecorderState('recording')
+      updateAudioLevel()
+    } catch (err) {
+      cleanupStream()
+      cleanupAudioContext()
+
+      // 에러 유형에 따라 상태 구분
+      if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
+        setRecorderState('permission_error')
+        setError('마이크 권한을 허용해주세요.')
+      } else if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
+        setRecorderState('device_error')
+        setError('마이크를 확인해주세요.')
+      } else {
+        setRecorderState('device_error')
+        setError(err.message || '마이크 접근에 실패했습니다.')
+      }
+    }
+  }, [updateAudioLevel, cleanupStream, cleanupAudioContext])
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      mediaRecorderRef.current.stop()
+      setRecorderState('idle')
+      setAudioLevel(0)
+    }
+  }, [])
+
+  const pauseRecording = useCallback(() => {
+    if (mediaRecorderRef.current?.state === 'recording') {
+      mediaRecorderRef.current.pause()
+      setRecorderState('paused')
+      // 일시정지 시 오디오 레벨 업데이트 중지
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current)
+        animationFrameRef.current = null
+      }
+      setAudioLevel(0)
+    }
+  }, [])
+
+  const resumeRecording = useCallback(() => {
+    if (mediaRecorderRef.current?.state === 'paused') {
+      mediaRecorderRef.current.resume()
+      setRecorderState('recording')
+      // 오디오 레벨 업데이트 재개
+      updateAudioLevel()
+    }
+  }, [updateAudioLevel])
+
+  const discardRecording = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      // onstop 이벤트 제거하여 블롭 생성 방지
+      mediaRecorderRef.current.onstop = null
+      if (mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop()
+      }
+    }
+    cleanupStream()
+    cleanupAudioContext()
+    setRecorderState('idle')
+    setAudioBlob(null)
+    setAudioLevel(0)
+    chunksRef.current = []
+  }, [cleanupStream, cleanupAudioContext])
+
+  const resetAudioBlob = useCallback(() => {
+    setAudioBlob(null)
+  }, [])
+
+  const resetError = useCallback(() => {
+    setError(null)
+    if (recorderState === 'permission_error' || recorderState === 'device_error') {
+      setRecorderState('idle')
+    }
+  }, [recorderState])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.onstop = null
+        mediaRecorderRef.current.stop()
+      }
+      cleanupStream()
+      cleanupAudioContext()
+    }
+  }, [cleanupStream, cleanupAudioContext])
+
+  return {
+    recorderState,
+    isRecording,
+    audioBlob,
+    audioLevel,
+    startRecording,
+    stopRecording,
+    pauseRecording,
+    resumeRecording,
+    discardRecording,
+    error,
+    resetAudioBlob,
+    resetError,
+  }
+}

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Textarea } from '@/app/components/ui/textarea';
 import { Card } from '@/app/components/ui/card';
@@ -18,14 +18,16 @@ import { Edit3, Eye } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { toast } from 'sonner';
 
+const DEFAULT_ANSWER = '프로세스는 실행 중인 프로그램의 인스턴스로, 독립적인 메모리 공간을 가지고 있습니다. 반면 스레드는 프로세스 내에서 실행되는 작업의 단위로, 같은 프로세스의 다른 스레드와 메모리를 공유합니다. 멀티프로세싱은 여러 프로세스를 동시에 실행하는 것이고, 멀티스레딩은 하나의 프로세스 내에서 여러 스레드를 실행하는 것입니다. 스레드는 메모리를 공유하기 때문에 컨스트 스위칭 비용이 적고 통신이 빠르지만, 동기화 문제에 주의해야 합니다.';
+
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
+    const { state } = useLocation();
+
     const [isEditing, setIsEditing] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
-    const [answer, setAnswer] = useState(
-        '프로세스는 실행 중인 프로그램의 인스턴스로, 독립적인 메모리 공간을 가지고 있습니다. 반면 스레드는 프로세스 내에서 실행되는 작업의 단위로, 같은 프로세스의 다른 스레드와 메모리를 공유합니다. 멀티프로세싱은 여러 프로세스를 동시에 실행하는 것이고, 멀티스레딩은 하나의 프로세스 내에서 여러 스레드를 실행하는 것입니다. 스레드는 메모리를 공유하기 때문에 컨스트 스위칭 비용이 적고 통신이 빠르지만, 동기화 문제에 주의해야 합니다.'
-    );
+    const [answer, setAnswer] = useState(state?.transcribedText || DEFAULT_ANSWER);
 
     const question = QUESTIONS.find((q) => q.id === questionId);
 

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -1,30 +1,119 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { QUESTIONS } from '@/data/questions';
 import { motion as Motion } from 'motion/react';
 import { AppHeader } from '@/app/components/AppHeader';
+import { useAudioRecorder } from '@/app/hooks/useAudioRecorder';
+import { getPresignedUrl, uploadToS3, confirmFileUpload } from '@/api/fileApi';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import {
+    AlertDialog,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogFooter,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogAction,
+    AlertDialogCancel,
+} from '@/app/components/ui/alert-dialog';
+
+const MAX_RECORDING_SECONDS = 300; // 5분
 
 const PracticeAnswerVoice = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
-    const [isRecording, setIsRecording] = useState(false);
     const [seconds, setSeconds] = useState(0);
-    const [audioLevel, setAudioLevel] = useState(0);
+    const [isUploading, setIsUploading] = useState(false);
+    const [showBackModal, setShowBackModal] = useState(false);
+    const [showStopModal, setShowStopModal] = useState(false);
+    const [showTimeoutModal, setShowTimeoutModal] = useState(false);
+    const timerRef = useRef(null);
+
+    const {
+        recorderState,
+        isRecording,
+        audioBlob,
+        audioLevel,
+        startRecording,
+        stopRecording,
+        pauseRecording,
+        resumeRecording,
+        discardRecording,
+        error: recorderError,
+        resetAudioBlob,
+    } = useAudioRecorder();
 
     const question = QUESTIONS.find((q) => q.id === questionId);
 
+    // 녹음 타이머 (recording 상태일 때만 동작)
     useEffect(() => {
-        let interval;
-        if (isRecording) {
-            interval = setInterval(() => {
+        if (recorderState === 'recording') {
+            timerRef.current = setInterval(() => {
                 setSeconds((s) => s + 1);
-                // Simulate audio level
-                setAudioLevel(Math.random());
             }, 1000);
         }
-        return () => clearInterval(interval);
-    }, [isRecording]);
+        return () => {
+            if (timerRef.current) {
+                clearInterval(timerRef.current);
+            }
+        };
+    }, [recorderState]);
+
+    // 5분 제한 체크
+    useEffect(() => {
+        if (seconds >= MAX_RECORDING_SECONDS && recorderState === 'recording') {
+            pauseRecording();
+            setShowTimeoutModal(true);
+        }
+    }, [seconds, recorderState, pauseRecording]);
+
+    // 녹음 에러 처리
+    useEffect(() => {
+        if (recorderError) {
+            toast.error(recorderError);
+        }
+    }, [recorderError]);
+
+    // 녹음 완료 후 업로드 처리
+    useEffect(() => {
+        if (!audioBlob) return;
+
+        const processAudio = async () => {
+            setIsUploading(true);
+            try {
+                // 파일 확장자 결정
+                const extension = audioBlob.type.includes('mp4') ? 'm4a' : 'webm';
+
+                // 1. Presigned URL 획득
+                const presignedResult = await getPresignedUrl({
+                    fileName: `voice_${questionId}_${Date.now()}.${extension}`,
+                    contentType: audioBlob.type || 'audio/webm',
+                });
+                const { fileId, presignedUrl } = presignedResult.data;
+
+                // 2. S3 업로드
+                await uploadToS3(presignedUrl, audioBlob, audioBlob.type || 'audio/webm');
+
+                // 3. 업로드 확인 및 S3 URL 획득
+                const confirmResult = await confirmFileUpload(fileId);
+                const { fileUrl } = confirmResult.data;
+
+                // 4. STT 페이지로 이동 (S3 URL과 questionId 전달)
+                navigate(`/practice/stt/${questionId}`, {
+                    state: { audioUrl: fileUrl },
+                });
+            } catch (err) {
+                toast.error(err.message || '업로드에 실패했습니다');
+                resetAudioBlob();
+            } finally {
+                setIsUploading(false);
+            }
+        };
+
+        processAudio();
+    }, [audioBlob, questionId, navigate, resetAudioBlob]);
 
     const formatTime = (secs) => {
         const mins = Math.floor(secs / 60);
@@ -32,14 +121,93 @@ const PracticeAnswerVoice = () => {
         return `${mins.toString().padStart(2, '0')}:${remainingSecs.toString().padStart(2, '0')}`;
     };
 
-    const handleToggleRecording = () => {
-        if (isRecording) {
-            // Stop recording and move to STT
-            navigate(`/practice/stt/${questionId}`);
+    // 뒤로가기 처리
+    const handleBackClick = () => {
+        if (recorderState === 'recording') {
+            pauseRecording();
+            setShowBackModal(true);
+        } else if (recorderState === 'paused') {
+            setShowBackModal(true);
         } else {
-            setIsRecording(true);
+            navigate(`/practice/answer/${questionId}`);
         }
     };
+
+    const handleBackConfirm = () => {
+        setShowBackModal(false);
+        discardRecording();
+        navigate(`/practice/answer/${questionId}`);
+    };
+
+    const handleBackCancel = () => {
+        setShowBackModal(false);
+        // paused 상태에서 취소하면 녹음 재개
+        if (recorderState === 'paused' && !showStopModal && !showTimeoutModal) {
+            resumeRecording();
+        }
+    };
+
+    // 답변 종료 버튼 처리
+    const handleStopClick = () => {
+        pauseRecording();
+        setShowStopModal(true);
+    };
+
+    // 답변 종료 확인 (업로드 진행)
+    const handleStopConfirm = () => {
+        setShowStopModal(false);
+        setShowTimeoutModal(false);
+        stopRecording(); // 업로드 진행
+    };
+
+    // 다시 답변하기 - 초기 화면으로 복귀, 녹음 파일 삭제
+    const handleRetry = () => {
+        setShowStopModal(false);
+        setShowTimeoutModal(false);
+        discardRecording();
+        setSeconds(0);
+    };
+
+    // 답변 시작/종료 토글
+    const handleToggleRecording = () => {
+        if (recorderState === 'recording') {
+            handleStopClick();
+        } else if (recorderState === 'paused') {
+            // paused 상태에서 버튼 클릭 시 답변 종료 모달
+            setShowStopModal(true);
+        } else {
+            setSeconds(0);
+            startRecording();
+        }
+    };
+
+    // 비주얼라이저 상태
+    const getVisualizerState = () => {
+        if (recorderState === 'permission_error') return 'permission';
+        if (recorderState === 'device_error') return 'error';
+        if (recorderState === 'recording' && audioLevel > 0.05) return 'active';
+        if (recorderState === 'paused') return 'paused';
+        return 'idle';
+    };
+
+    // 상태 메시지
+    const getStatusMessage = () => {
+        if (isUploading) return '업로드 중...';
+        if (recorderState === 'recording') return '녹음 중...';
+        if (recorderState === 'paused') return '일시정지';
+        if (recorderState === 'permission_error') return '마이크 권한이 필요합니다';
+        if (recorderState === 'device_error') return '마이크를 확인해주세요';
+        return '답변 시작 버튼을 눌러주세요';
+    };
+
+    // 버튼 텍스트
+    const getButtonText = () => {
+        if (isUploading) return '업로드 중...';
+        if (recorderState === 'recording' || recorderState === 'paused') return '답변 종료';
+        return '답변 시작';
+    };
+
+    const visualizerState = getVisualizerState();
 
     if (!question) return <div>질문을 찾을 수 없습니다</div>;
 
@@ -47,7 +215,7 @@ const PracticeAnswerVoice = () => {
         <div className="min-h-screen bg-gradient-to-br from-rose-400 to-pink-500 text-white flex flex-col">
             <AppHeader
                 title="음성 답변"
-                onBack={() => navigate(`/practice/answer/${questionId}`)}
+                onBack={handleBackClick}
                 showNotifications={false}
                 tone="dark"
             />
@@ -61,17 +229,35 @@ const PracticeAnswerVoice = () => {
                 {/* Audio Visualizer */}
                 <div className="relative mb-12">
                     <Motion.div
-                        className="w-40 h-40 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center"
+                        className={`w-40 h-40 rounded-full backdrop-blur-sm flex items-center justify-center ${
+                            visualizerState === 'paused' ? 'bg-white/30' : 'bg-white/20'
+                        }`}
                         animate={{
-                            scale: isRecording ? [1, 1 + audioLevel * 0.3, 1] : 1,
+                            scale: visualizerState === 'active'
+                                ? [1, 1 + audioLevel * 0.3, 1]
+                                : visualizerState === 'idle' && recorderState === 'idle'
+                                    ? [1, 1.02, 1]
+                                    : 1,
                         }}
-                        transition={{ duration: 0.5, repeat: Infinity }}
+                        transition={{
+                            duration: visualizerState === 'active' ? 0.3 : 2,
+                            repeat: visualizerState === 'active' || (visualizerState === 'idle' && recorderState === 'idle') ? Infinity : 0,
+                        }}
                     >
                         <div className="w-32 h-32 rounded-full bg-white/30 backdrop-blur-sm flex items-center justify-center">
                             <div className="w-24 h-24 rounded-full bg-white/40 backdrop-blur-sm flex items-center justify-center">
-                                <svg className="w-16 h-16 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                                </svg>
+                                {isUploading ? (
+                                    <Loader2 className="w-12 h-12 text-white animate-spin" />
+                                ) : visualizerState === 'paused' ? (
+                                    <svg className="w-12 h-12 text-white" fill="currentColor" viewBox="0 0 24 24">
+                                        <rect x="6" y="4" width="4" height="16" />
+                                        <rect x="14" y="4" width="4" height="16" />
+                                    </svg>
+                                ) : (
+                                    <svg className="w-16 h-16 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                                    </svg>
+                                )}
                             </div>
                         </div>
                     </Motion.div>
@@ -80,28 +266,81 @@ const PracticeAnswerVoice = () => {
                 {/* Timer */}
                 <div className="text-center mb-8">
                     <div className="text-5xl font-mono mb-2">{formatTime(seconds)}</div>
-                    <p className="text-white/70 text-sm">
-                        {isRecording ? '녹음 중...' : '답변 시작 버튼을 눌러주세요'}
-                    </p>
+                    <p className="text-white/70 text-sm">{getStatusMessage()}</p>
+                    {recorderState === 'recording' && (
+                        <p className="text-white/50 text-xs mt-1">
+                            최대 {Math.floor(MAX_RECORDING_SECONDS / 60)}분까지 녹음 가능
+                        </p>
+                    )}
                 </div>
 
                 {/* Controls */}
                 <Button
                     onClick={handleToggleRecording}
-                    className={`w-48 h-14 rounded-full text-lg ${isRecording
+                    disabled={isUploading}
+                    className={`w-48 h-14 rounded-full text-lg ${
+                        recorderState === 'recording' || recorderState === 'paused'
                             ? 'bg-red-500 hover:bg-red-600'
                             : 'bg-white text-pink-600 hover:bg-white/90'
-                        }`}
+                    } disabled:opacity-50`}
                 >
-                    {isRecording ? '답변 종료' : '답변 시작'}
+                    {getButtonText()}
                 </Button>
 
-                {isRecording && (
+                {recorderState === 'recording' && (
                     <p className="text-white/60 text-sm mt-4">
                         편안하게 답변해주세요
                     </p>
                 )}
             </div>
+
+            {/* 뒤로가기 모달 */}
+            <AlertDialog open={showBackModal} onOpenChange={setShowBackModal}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>녹음 중입니다</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            종료하시겠습니까? (녹음 내용은 저장되지 않습니다!)
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={handleBackCancel}>취소</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleBackConfirm}>확인</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            {/* 답변 종료 확인 모달 */}
+            <AlertDialog open={showStopModal} onOpenChange={setShowStopModal}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>답변을 종료하고 분석을 시작하시겠습니까?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            *다시 답변할 시 답변 시작 전으로 돌아갑니다.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={handleRetry}>다시 답변하기</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleStopConfirm}>답변 종료</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            {/* 5분 초과 모달 */}
+            <AlertDialog open={showTimeoutModal}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>답변 시간이 초과되었습니다.</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            그대로 제출 하시겠습니까?
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={handleRetry}>다시 답변하기</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleStopConfirm}>예 (답변 제출)</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 };

--- a/src/app/pages/PracticeSTT.jsx
+++ b/src/app/pages/PracticeSTT.jsx
@@ -1,27 +1,50 @@
-import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { motion as Motion } from 'motion/react';
 import { Loader2 } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
+import { requestSTT } from '@/api/sttApi';
+import { toast } from 'sonner';
 
 const PracticeSTT = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
+    const { state } = useLocation();
+    const audioUrl = state?.audioUrl;
+
+    const [statusMessage, setStatusMessage] = useState('음성을 분석하고 있어요');
 
     useEffect(() => {
-        // Simulate STT processing
-        const timer = setTimeout(() => {
-            navigate(`/practice/answer-edit/${questionId}`);
-        }, 3000);
+        if (!audioUrl) {
+            toast.error('음성 파일 정보가 없습니다');
+            navigate(`/practice/answer/${questionId}`);
+            return;
+        }
 
-        return () => clearTimeout(timer);
-    }, [navigate, questionId]);
+        const processSTT = async () => {
+            try {
+                setStatusMessage('답변을 텍스트로 변환 중입니다...');
+
+                const result = await requestSTT({ audioUrl, questionId });
+                const { text } = result.data;
+
+                navigate(`/practice/answer-edit/${questionId}`, {
+                    state: { transcribedText: text },
+                });
+            } catch (err) {
+                toast.error(err.message || '음성 변환에 실패했습니다');
+                navigate(`/practice/answer/${questionId}`);
+            }
+        };
+
+        processSTT();
+    }, [audioUrl, questionId, navigate]);
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-rose-400 to-pink-500 flex flex-col">
             <AppHeader
                 title="음성 분석"
-                onBack={() => navigate(-1)}
+                onBack={() => navigate(`/practice/answer/${questionId}`)}
                 showNotifications={false}
                 tone="dark"
             />
@@ -40,9 +63,9 @@ const PracticeSTT = () => {
                         <Loader2 className="w-16 h-16" />
                     </Motion.div>
 
-                    <h2 className="text-2xl mb-3">음성을 분석하고 있어요</h2>
+                    <h2 className="text-2xl mb-3">{statusMessage}</h2>
                     <p className="text-white/80">
-                        답변을 텍스트로 변환 중입니다...
+                        잠시만 기다려주세요
                     </p>
                 </Motion.div>
             </div>


### PR DESCRIPTION
  ## 요약

  음성 답변 기능의 전체 플로우를 구현합니다. 
  녹음 상태 관리(일시정지/재개/폐기), 확인 모달, 5분 녹음 제한을 추가하고, S3 파일 업로드 및 STT API 연동을 통해 음성 → 텍스트 변환 파이프라인을 완성합니다.

  ## 변경 사항

  **1. useAudioRecorder.js (신규)**
  - recorderState 상태 enum (idle/recording/paused/permission_error/device_error)
  - pauseRecording(), resumeRecording(), discardRecording(), resetError() 함수 추가
  - mimeType 우선순위 변경 (mp4 우선 - Safari 호환)

  **2. PracticeAnswerVoice.jsx (수정)**
  - 뒤로가기/답변종료/5분초과 확인 모달 추가
  - 비주얼라이저 상태 확장 (idle/active/paused/permission/error)
  - 타이머 일시정지 지원

  **3. fileApi.js (신규)**
  - getPresignedUrl(), uploadToS3(), confirmFileUpload() API 함수

  **4. sttApi.js (신규)**
  - requestSTT() API 함수

  **5. PracticeSTT.jsx (수정)**
  - Mock → 실제 STT API 연동
  - 변환 결과를 PracticeAnswerEdit로 전달

  **6. PracticeAnswerEdit.jsx (수정)**
  - useLocation으로 transcribedText 수신 및 초기화

  ## 관련 Commit, Issue

  - Closes #17