### PR TITLE
feat:[#23]홈화면-오늘의 추천 질문 API 연동

### DIFF
--- a/src/utils/questionApi.js
+++ b/src/utils/questionApi.js
@@ -25,6 +25,11 @@ export async function fetchQuestionById(questionId) {
     return api.get(`/api/questions/${questionId}`, { parseResponse: true });
 }
 
+// 오늘의 추천 질문 조회
+export async function fetchRecommendedQuestion() {
+    return api.get('/api/questions/recommendation', { parseResponse: true });
+}
+
 // 질문 검색
 export async function searchQuestions({ q, category, type, cursor, size } = {}) {
     const query = buildQuery({ q, category, type, cursor, size });


### PR DESCRIPTION
## 요약

  오늘의 추천 질문 조회 API를 연동해 홈 화면에서 최신 추천 질문을 표시하도록 구현했습니다. 로딩/에러/없음 상태를 분리하고 카테고리 한글 매핑도 적용했습니다.

  ## 변경사항

  - 추천 질문 조회 API 호출 함수 추가
      - fetchRecommendedQuestion
  - 홈 화면 추천 질문 카드 API 연동
      - 로딩/에러/없음 상태 처리
      - 카테고리 한글 매핑 적용
      - 응답 스키마 content 기반 렌더링

  수정 파일

  - src/utils/questionApi.js
  - src/app/pages/Home.jsx

  ## 관련 Commit, Issue
  - #23 