### PR TITLE
fix: [#27] Question Category - 알고리즘&자료구조 분리

### DIFF
--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -16,12 +16,13 @@ const INITIAL_SEARCH_QUERY = '';
 const INITIAL_CATEGORY = '전체';
 const INITIAL_SUB_CATEGORY = '전체';
 const CATEGORY_OPTIONS = ['전체', 'CS기초', '시스템디자인'];
-const CS_SUB_CATEGORY_OPTIONS = ['전체', '운영체제', '네트워크', '데이터베이스', '컴퓨터 구조', '알고리즘'];
+const CS_SUB_CATEGORY_OPTIONS = ['전체', '운영체제', '네트워크', '데이터베이스', '컴퓨터 구조', '자료구조', '알고리즘'];
 const CS_CATEGORY_MAP = {
     운영체제: 'OS',
     네트워크: 'NETWORK',
     데이터베이스: 'DB',
     '컴퓨터 구조': 'COMPUTER_ARCHITECTURE',
+    자료구조: 'DATA_STRUCTURE',
     알고리즘: 'ALGORITHM',
 };
 const CATEGORY_LABEL_MAP = {
@@ -29,6 +30,7 @@ const CATEGORY_LABEL_MAP = {
     NETWORK: '네트워크',
     DB: '데이터베이스',
     COMPUTER_ARCHITECTURE: '컴퓨터 구조',
+    DATA_STRUCTURE: '자료구조',
     ALGORITHM: '알고리즘',
 };
 const SEARCH_DEBOUNCE_MS = 300;


### PR DESCRIPTION
## 요약

  PracticeMain의 CS 하위 카테고리에 자료구조를 추가하고, API 카테고리 값 DATA_STRUCTURE와 한글 라벨 매핑을 반영했습니다.

  ## 변경사항

  - CS 하위 카테고리 항목 추가
      - 자료구조
  - 카테고리 매핑 추가
      - 자료구조 → DATA_STRUCTURE
  - 카드 라벨 매핑 추가
      - DATA_STRUCTURE → 자료구조

  수정 파일

  - src/app/pages/PracticeMain.jsx

  ## 관련 Commit, Issue

 -  #27 