### PR TITLE
feat:[#29]연습모드-선택한 질문 Context 처리

### DIFF
--- a/src/api/questionApi.js
+++ b/src/api/questionApi.js
@@ -1,0 +1,78 @@
+import { api } from '../utils/apiUtils';
+
+// 빈 값 제외하고 쿼리 문자열을 생성한다.
+const buildQuery = (params = {}) => {
+    const query = new URLSearchParams();
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            query.set(key, String(value));
+        }
+    });
+
+    const queryString = query.toString();
+    return queryString ? `?${queryString}` : '';
+};
+
+// 질문 목록 조회
+export async function fetchQuestions({ category, type, cursor, size } = {}) {
+    const query = buildQuery({ category, type, cursor, size });
+    return api.get(`/api/questions${query}`, { parseResponse: true });
+}
+
+// 질문 상세 조회
+export async function fetchQuestionById(questionId) {
+    return api.get(`/api/questions/${questionId}`, { parseResponse: true });
+}
+
+// 오늘의 추천 질문 조회
+export async function fetchRecommendedQuestion() {
+    return api.get('/api/questions/recommendation', { parseResponse: true });
+}
+
+// 질문 검색
+export async function searchQuestions({ q, category, type, cursor, size } = {}) {
+    const query = buildQuery({ q, category, type, cursor, size });
+    return api.get(`/api/questions/search${query}`, { parseResponse: true });
+}
+
+// 질문 생성
+export async function createQuestion(payload) {
+    return api.post('/api/questions', payload, { parseResponse: true });
+}
+
+// 질문 수정
+export async function updateQuestion(questionId, payload) {
+    return api.patch(`/api/questions/${questionId}`, payload, { parseResponse: true });
+}
+
+// 질문 삭제
+export async function deleteQuestion(questionId) {
+    return api.delete(`/api/questions/${questionId}`, { parseResponse: true });
+}
+
+// 질문 핵심 키워드 조회
+export async function fetchQuestionKeywords(questionId) {
+    return api.get(`/api/questions/${questionId}/keywords`, { parseResponse: true });
+}
+
+// 질문 핵심 키워드 포함 여부 확인
+export async function checkQuestionKeywords(questionId, payload) {
+    return api.post(`/api/questions/${questionId}/keyword-checks`, payload, { parseResponse: true });
+}
+
+// 시스템 디자인 질문 목록 조회
+export async function fetchSystemDesignQuestions({ type, category, difficulty, page, size } = {}) {
+    const query = buildQuery({ type, category, difficulty, page, size });
+    return api.get(`/api/v1/questions/system-design${query}`, { parseResponse: true });
+}
+
+// 태그 목록 조회
+export async function fetchTags() {
+    return api.get('/api/tags', { parseResponse: true });
+}
+
+// 질문 태그 목록 조회
+export async function fetchQuestionTags(questionId) {
+    return api.get(`/api/questions/${questionId}/tags`, { parseResponse: true });
+}

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -17,6 +17,7 @@ import PracticeResultAI from '@/app/pages/PracticeResultAI';
 import ProfileMain from '@/app/pages/ProfileMain';
 import SettingMain from '@/app/pages/SettingMain';
 import RealInterview from '@/app/pages/RealInterview';
+import { PracticeQuestionProvider } from '@/app/contexts/practiceQuestionContext.jsx';
 
 function AppRoutes() {
     const isLoggedIn = storage.isLoggedIn();
@@ -64,7 +65,9 @@ function AppRoutes() {
 function App() {
     return (
         <BrowserRouter>
-            <AppRoutes />
+            <PracticeQuestionProvider>
+                <AppRoutes />
+            </PracticeQuestionProvider>
         </BrowserRouter>
     );
 }

--- a/src/app/hooks/usePracticeQuestionLoader.js
+++ b/src/app/hooks/usePracticeQuestionLoader.js
@@ -1,0 +1,91 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchQuestionById } from '@/api/questionApi';
+import { usePracticeQuestion } from '@/app/contexts/practiceQuestionContext.jsx';
+import { QUESTIONS } from '@/data/questions';
+
+const TEXT_ERROR = '질문을 불러오지 못했습니다.';
+
+export function usePracticeQuestionLoader(questionId) {
+    const { selectedQuestion, setSelectedQuestion } = usePracticeQuestion();
+    const [question, setQuestion] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    const hasMatchedContextQuestion = useMemo(() => {
+        return selectedQuestion && String(selectedQuestion.id) === String(questionId);
+    }, [selectedQuestion, questionId]);
+
+    const fallbackQuestion = useMemo(() => {
+        const matched = QUESTIONS.find((q) => String(q.id) === String(questionId));
+        if (matched) return matched;
+        return QUESTIONS[0] || null;
+    }, [questionId]);
+
+    useEffect(() => {
+        let isActive = true;
+
+        const loadQuestion = async () => {
+            if (!questionId) {
+                setIsLoading(false);
+                return;
+            }
+
+            if (hasMatchedContextQuestion) {
+                setQuestion(selectedQuestion);
+                setIsLoading(false);
+                return;
+            }
+
+            setIsLoading(true);
+            setErrorMessage('');
+
+            try {
+                const response = await fetchQuestionById(questionId);
+                const data = response?.data ?? response ?? {};
+                const mapped = {
+                    id: data.questionId ?? data.id ?? questionId,
+                    title: data.content ?? data.title ?? '',
+                    description: data.content ?? '',
+                    category: data.category ?? '',
+                    keywords: Array.isArray(data.keywords) ? data.keywords : [],
+                };
+
+                if (!isActive) return;
+                if (!mapped.title) {
+                    setQuestion(fallbackQuestion);
+                    setErrorMessage(fallbackQuestion ? '' : TEXT_ERROR);
+                    return;
+                }
+                setQuestion(mapped);
+                setSelectedQuestion(mapped);
+            } catch (error) {
+                if (!isActive) return;
+                if (fallbackQuestion) {
+                    setQuestion(fallbackQuestion);
+                    setErrorMessage('');
+                } else {
+                    setErrorMessage(error?.message || TEXT_ERROR);
+                }
+            } finally {
+                if (isActive) setIsLoading(false);
+            }
+        };
+
+        loadQuestion();
+        return () => {
+            isActive = false;
+        };
+    }, [
+        questionId,
+        hasMatchedContextQuestion,
+        selectedQuestion,
+        setSelectedQuestion,
+        fallbackQuestion,
+    ]);
+
+    return {
+        question,
+        isLoading,
+        errorMessage,
+    };
+}

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -6,7 +6,7 @@ import { Badge } from '@/app/components/ui/badge';
 import BottomNav from '@/app/components/BottomNav';
 import { Sparkles, TrendingUp, Calendar } from 'lucide-react';
 import { storage } from '@/utils/storage';
-import { fetchRecommendedQuestion } from '@/utils/questionApi';
+import { fetchRecommendedQuestion } from '@/api/questionApi';
 
 import { AppHeader } from '@/app/components/AppHeader';
 

--- a/src/app/pages/PracticeAnswer.jsx
+++ b/src/app/pages/PracticeAnswer.jsx
@@ -1,56 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
 import { Checkbox } from '@/app/components/ui/checkbox';
 import { Mic, Keyboard } from 'lucide-react';
-import { fetchQuestionById } from '@/utils/questionApi';
 import { AppHeader } from '@/app/components/AppHeader';
+import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 
 const PracticeAnswer = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const [cannotSpeak, setCannotSpeak] = useState(false);
-    const [question, setQuestion] = useState(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [errorMessage, setErrorMessage] = useState('');
-
-    useEffect(() => {
-        let isActive = true;
-
-        const loadQuestion = async () => {
-            setIsLoading(true);
-            setErrorMessage('');
-
-            try {
-                const response = await fetchQuestionById(questionId);
-                const data = response?.data ?? response ?? {};
-                const mapped = {
-                    id: data.questionId ?? data.id ?? questionId,
-                    title: data.content ?? data.title ?? '',
-                    description: data.content ?? '',
-                    keywords: Array.isArray(data.keywords) ? data.keywords : [],
-                };
-
-                if (isActive) setQuestion(mapped);
-            } catch (error) {
-                if (isActive) setErrorMessage(error?.message || '질문을 불러오지 못했습니다.');
-            } finally {
-                if (isActive) setIsLoading(false);
-            }
-        };
-
-        if (questionId) {
-            loadQuestion();
-        }
-
-        return () => {
-            isActive = false;
-        };
-    }, [questionId]);
+    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     if (isLoading) {
-        return <div>질문을 불러오는 중...</div>;
+        return <div>{TEXT_LOADING}</div>;
     }
 
     if (errorMessage) {
@@ -58,7 +25,7 @@ const PracticeAnswer = () => {
     }
 
     if (!question) {
-        return <div>질문을 찾을 수 없습니다</div>;
+        return <div>{TEXT_NOT_FOUND}</div>;
     }
 
     const handleStart = () => {

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -13,12 +13,14 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '@/app/components/ui/alert-dialog';
-import { QUESTIONS } from '@/data/questions';
 import { Edit3, Eye } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { toast } from 'sonner';
+import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
 
 const DEFAULT_ANSWER = '프로세스는 실행 중인 프로그램의 인스턴스로, 독립적인 메모리 공간을 가지고 있습니다. 반면 스레드는 프로세스 내에서 실행되는 작업의 단위로, 같은 프로세스의 다른 스레드와 메모리를 공유합니다. 멀티프로세싱은 여러 프로세스를 동시에 실행하는 것이고, 멀티스레딩은 하나의 프로세스 내에서 여러 스레드를 실행하는 것입니다. 스레드는 메모리를 공유하기 때문에 컨스트 스위칭 비용이 적고 통신이 빠르지만, 동기화 문제에 주의해야 합니다.';
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
@@ -28,8 +30,7 @@ const PracticeAnswerEdit = () => {
     const [isEditing, setIsEditing] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
     const [answer, setAnswer] = useState(state?.transcribedText || DEFAULT_ANSWER);
-
-    const question = QUESTIONS.find((q) => q.id === questionId);
+    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleToggleEdit = () => {
         if (isEditing) {
@@ -49,7 +50,9 @@ const PracticeAnswerEdit = () => {
         navigate(`/practice/result-keyword/${questionId}`);
     };
 
-    if (!question) return <div>질문을 찾을 수 없습니다</div>;
+    if (isLoading) return <div>{TEXT_LOADING}</div>;
+    if (errorMessage) return <div>{errorMessage}</div>;
+    if (!question) return <div>{TEXT_NOT_FOUND}</div>;
 
     return (
         <div className="min-h-screen bg-background">

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -13,16 +13,18 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '@/app/components/ui/alert-dialog';
-import { QUESTIONS } from '@/data/questions';
 import { AppHeader } from '@/app/components/AppHeader';
+import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 
 const PracticeAnswerText = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const [answer, setAnswer] = useState('');
     const [showConfirm, setShowConfirm] = useState(false);
-
-    const question = QUESTIONS.find((q) => q.id === questionId);
+    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleSubmit = () => {
         if (!answer.trim()) {
@@ -36,7 +38,9 @@ const PracticeAnswerText = () => {
         navigate(`/practice/result-keyword/${questionId}`);
     };
 
-    if (!question) return <div>질문을 찾을 수 없습니다</div>;
+    if (isLoading) return <div>{TEXT_LOADING}</div>;
+    if (errorMessage) return <div>{errorMessage}</div>;
+    if (!question) return <div>{TEXT_NOT_FOUND}</div>;
 
     return (
         <div className="min-h-screen bg-background">

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -1,13 +1,13 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
-import { QUESTIONS } from '@/data/questions';
 import { motion as Motion } from 'motion/react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { useAudioRecorder } from '@/app/hooks/useAudioRecorder';
 import { getPresignedUrl, uploadToS3, confirmFileUpload } from '@/api/fileApi';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
+import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
 import {
     AlertDialog,
     AlertDialogContent,
@@ -20,6 +20,8 @@ import {
 } from '@/app/components/ui/alert-dialog';
 
 const MAX_RECORDING_SECONDS = 300; // 5분
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 
 const PracticeAnswerVoice = () => {
     const navigate = useNavigate();
@@ -30,6 +32,8 @@ const PracticeAnswerVoice = () => {
     const [showStopModal, setShowStopModal] = useState(false);
     const [showTimeoutModal, setShowTimeoutModal] = useState(false);
     const timerRef = useRef(null);
+    const { question, isLoading: isQuestionLoading, errorMessage: questionError } =
+        usePracticeQuestionLoader(questionId);
 
     const {
         recorderState,
@@ -44,8 +48,6 @@ const PracticeAnswerVoice = () => {
         error: recorderError,
         resetAudioBlob,
     } = useAudioRecorder();
-
-    const question = QUESTIONS.find((q) => q.id === questionId);
 
     // 녹음 타이머 (recording 상태일 때만 동작)
     useEffect(() => {
@@ -209,7 +211,9 @@ const PracticeAnswerVoice = () => {
 
     const visualizerState = getVisualizerState();
 
-    if (!question) return <div>질문을 찾을 수 없습니다</div>;
+    if (isQuestionLoading) return <div>{TEXT_LOADING}</div>;
+    if (questionError) return <div>{questionError}</div>;
+    if (!question) return <div>{TEXT_NOT_FOUND}</div>;
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-rose-400 to-pink-500 text-white flex flex-col">

--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -6,9 +6,10 @@ import { Badge } from '@/app/components/ui/badge';
 import { Button } from '@/app/components/ui/button';
 import BottomNav from '@/app/components/BottomNav';
 import { Search, Filter } from 'lucide-react';
-import { fetchQuestions, searchQuestions } from '@/utils/questionApi';
+import { fetchQuestions, searchQuestions } from '@/api/questionApi';
 import debounce from 'lodash/debounce';
 import { useInfiniteScroll } from '@/app/hooks/useInfiniteScroll';
+import { usePracticeQuestion } from '@/app/contexts/practiceQuestionContext.jsx';
 
 import { AppHeader } from '@/app/components/AppHeader';
 
@@ -41,6 +42,7 @@ const TEXT_ERROR_FALLBACK = '질문 목록을 불러오지 못했습니다.';
 
 const PracticeMain = () => {
     const navigate = useNavigate();
+    const { setSelectedQuestion } = usePracticeQuestion();
     const [searchQuery, setSearchQuery] = useState(INITIAL_SEARCH_QUERY);
     const [selectedCategory, setSelectedCategory] = useState(INITIAL_CATEGORY);
     const [selectedSubCategory, setSelectedSubCategory] = useState(INITIAL_SUB_CATEGORY);
@@ -117,6 +119,11 @@ const PracticeMain = () => {
 
     const errorMessage = error?.message || TEXT_ERROR_FALLBACK;
 
+    const handleSelectQuestion = (question) => {
+        setSelectedQuestion(question);
+        navigate(`/practice/answer/${question.id}`);
+    };
+
     return (
         <div className="min-h-screen bg-background pb-20">
             {/* Header */}
@@ -192,7 +199,7 @@ const PracticeMain = () => {
                             <Card
                                 key={question.id}
                                 className="p-4 hover:shadow-md transition-shadow cursor-pointer"
-                                onClick={() => navigate(`/practice/answer/${question.id}`)}
+                                onClick={() => handleSelectQuestion(question)}
                             >
                                 <div className="flex items-start justify-between mb-2">
                                     <Badge variant="secondary" className="bg-rose-100 text-rose-700">

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -1,17 +1,18 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
-import { Badge } from '@/app/components/ui/badge';
-import { QUESTIONS } from '@/data/questions';
 import { ThumbsUp, AlertCircle, Home } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, ResponsiveContainer } from 'recharts';
+import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 
 const PracticeResultAI = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
-
-    const question = QUESTIONS.find((q) => q.id === questionId);
+    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const radarData = [
         { subject: '논리성', value: 85 },
@@ -22,7 +23,9 @@ const PracticeResultAI = () => {
         { subject: '전달력', value: 88 },
     ];
 
-    if (!question) return <div>질문을 찾을 수 없습니다</div>;
+    if (isLoading) return <div>{TEXT_LOADING}</div>;
+    if (errorMessage) return <div>{errorMessage}</div>;
+    if (!question) return <div>{TEXT_NOT_FOUND}</div>;
 
     return (
         <div className="min-h-screen bg-background">

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -1,20 +1,23 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
 import { Badge } from '@/app/components/ui/badge';
 import { Progress } from '@/app/components/ui/progress';
-import { QUESTIONS } from '@/data/questions';
 import { Sparkles } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
+import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+
+const TEXT_LOADING = '질문을 불러오는 중...';
+const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 
 const PracticeResultKeyword = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const [isAnalyzing, setIsAnalyzing] = useState(true);
     const [progress, setProgress] = useState(0);
+    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
-    const question = QUESTIONS.find((q) => q.id === questionId);
     const myAnswer = '프로세스는 실행 중인 프로그램의 인스턴스로, 독립적인 메모리 공간을 가지고 있습니다. 반면 스레드는 프로세스 내에서 실행되는 작업의 단위로, 같은 프로세스의 다른 스레드와 메모리를 공유합니다.';
 
     useEffect(() => {
@@ -33,7 +36,9 @@ const PracticeResultKeyword = () => {
         return () => clearInterval(interval);
     }, []);
 
-    if (!question) return <div>질문을 찾을 수 없습니다</div>;
+    if (isLoading) return <div>{TEXT_LOADING}</div>;
+    if (errorMessage) return <div>{errorMessage}</div>;
+    if (!question) return <div>{TEXT_NOT_FOUND}</div>;
 
     return (
         <div className="min-h-screen bg-background">


### PR DESCRIPTION
## 요약

  연습 모드에서 “선택한 질문”을 단일 소스로 유지하기 위해 전역 Context를 도입하고, 페이지마다 반복되던 질문 로딩/복구/예외처리 로직을
  usePracticeQuestionLoader 훅으로 통합했습니다.
  이제 질문 데이터는 Context를 우선 사용하고, 없거나 불일치하면 API로 복구, API가 실패하면 더미(QUESTIONS)로 fallback 하며 PracticeResultAI까지 흐름이 끊
  기지 않습니다.

  ———

  ## 변경사항 (무엇을 왜 바꿨는지)

  ### 1) 질문 상태를 Context로 승격 (공유 상태 보장)

  - 문제: 페이지 이동마다 질문을 다시 찾거나 다시 조회해야 했고, 새로고침/직접 진입 시 끊길 위험이 있었음
  - 해결:
      - PracticeQuestionContext를 추가해 “선택한 질문”을 전역으로 보관
      - sessionStorage 동기화로 새로고침에도 최대한 유지
  - 효과:
      - PracticeMain → PracticeAnswer → … → PracticeResultAI까지 동일 질문 공유
      - 불필요한 재조회 감소

  핵심 포인트

  - 선택 시 저장: PracticeMain에서 카드 클릭 시 setSelectedQuestion(question)
  - 전역 적용: App 루트에서 Provider로 감쌈

  ———

  ### 2) 중복된 질문 로딩을 커스텀 훅으로 통합

  - 문제: 여러 페이지에서 거의 동일한 loadQuestion 로직이 반복됨
      - Context 확인
      - API 조회
      - 에러/비정상 응답 처리
      - 더미 fallback
  - 해결:
      - usePracticeQuestionLoader(questionId) 훅 추가
  - 훅의 로딩 우선순위(정책):
      1. Context에 있고 questionId가 일치하면 즉시 사용
      2. 아니면 fetchQuestionById(questionId)로 복구
      3. API 실패/비정상이면 QUESTIONS 더미로 fallback
  - 효과:
      - 로직 중복 제거
      - 예외처리 일관성 확보
      - API 응답 필드 매핑을 한 곳에서 관리

  ———

  ### 3) API 응답 필드 content 기준으로 매핑 일원화

  - 문제: 화면은 title/description을 기대하지만 API는 content 중심
  - 해결:
      - 훅에서 content → title/description으로 매핑
  - 효과:
      - 페이지별 매핑 실수 방지
      - 스키마 변경 대응 용이

  ———

  ### 4) 더미 데이터 유지 (API 미연동/불안정 대비)

  - 목표: “API가 안 될 때도 화면이 돌아가야 함”
  - 조치:
      - QUESTIONS를 제거하지 않고 fallback으로 유지
      - API 실패 시 에러 화면 대신 가능한 한 더미로 진행

  ———

  ## 동작 흐름 (현재 정책 요약)

  - 정상 플로우
      - PracticeMain에서 선택 → Context 저장
      - 이후 페이지는 Context 사용 (재조회 없음)
  - 복구 플로우 (새로고침/직접 진입 등)

  ———

  ## 수정/추가 파일 (정확 목록)

  ### 추가

  - src/api/questionApi.js
  - src/app/contexts/practiceQuestionContext.jsx
  - src/app/hooks/usePracticeQuestionLoader.js

  ### 수정

  - src/app/App.jsx
  - src/app/pages/Home.jsx
  - src/app/pages/PracticeMain.jsx
  - src/app/pages/PracticeAnswer.jsx
  - src/app/pages/PracticeAnswerVoice.jsx
  - src/app/pages/PracticeAnswerText.jsx
  - src/app/pages/PracticeAnswerEdit.jsx
  - src/app/pages/PracticeResultKeyword.jsx
  - src/app/pages/PracticeResultAI.jsx

  ———

  ## 리뷰 포인트 (보면 좋은 것들)

  1. PracticeMain에서 선택 → PracticeResultAI까지 질문이 유지되는지
  2. 새로고침/직접 URL 진입 시에도 깨지지 않는지
  3. API 실패 시에도 더미로 계속 진행되는지
  4. API 응답이 content일 때 화면이 정상 표기되는지

  ———

  ## 관련 Commit, Issue

  - #29 