### PR TITLE
feat:[#31]음성답변 제출 S3 연동

### DIFF
--- a/src/api/fileApi.js
+++ b/src/api/fileApi.js
@@ -4,15 +4,28 @@ import { api, handleResponse } from '@/utils/apiUtils'
  * S3 presigned URL 요청
  * @param {Object} params
  * @param {string} params.fileName - 파일명
- * @param {string} params.contentType - MIME 타입 (예: audio/webm)
+ * @param {number} params.fileSize - 파일 크기 (bytes)
+ * @param {string} params.mimeType - MIME 타입 (예: audio/webm)
+ * @param {string} params.category - 파일 카테고리 (예: AUDIO)
  * @returns {Promise<{data: {fileId: string, presignedUrl: string}}>}
  */
-export async function getPresignedUrl({ fileName, contentType }) {
+export async function getPresignedUrl({ fileName, fileSize, mimeType, category }) {
   const response = await api.post('/api/files/presigned-url', {
-    fileName,
-    contentType,
+    file_name: fileName,
+    file_size: fileSize,
+    mime_type: mimeType,
+    category,
   })
-  return handleResponse(response)
+  const result = await handleResponse(response)
+  const data = result?.data ?? result ?? {}
+  return {
+    ...result,
+    data: {
+      ...data,
+      fileId: data.fileId ?? data.file_id,
+      presignedUrl: data.presignedUrl ?? data.presigned_url,
+    },
+  }
 }
 
 /**

--- a/src/api/sttApi.js
+++ b/src/api/sttApi.js
@@ -3,14 +3,16 @@ import { api, handleResponse } from '@/utils/apiUtils'
 /**
  * STT 요청 - 음성 파일을 텍스트로 변환
  * @param {Object} params
- * @param {string} params.audioUrl - S3 음성 파일 URL
- * @param {string} params.questionId - 질문 ID
+ * @param {number} params.userId - 사용자 ID
+ * @param {number} params.sessionId - 세션 ID
+ * @param {string} params.audioUrl - S3 음성 파일 URL (.mp3 또는 .m4a)
  * @returns {Promise<{data: {text: string}}>}
  */
-export async function requestSTT({ audioUrl, questionId }) {
-  const response = await api.post('/api/stt', {
-    audioUrl,
-    questionId,
+export async function requestSTT({ userId, sessionId, audioUrl }) {
+  const response = await api.post('/ai/stt', {
+    user_id: userId,
+    session_id: sessionId,
+    audio_url: audioUrl,
   })
   return handleResponse(response)
 }

--- a/src/app/pages/PracticeSTT.jsx
+++ b/src/app/pages/PracticeSTT.jsx
@@ -6,6 +6,9 @@ import { AppHeader } from '@/app/components/AppHeader';
 import { requestSTT } from '@/api/sttApi';
 import { toast } from 'sonner';
 
+// TODO: 인증 연동 후 실제 사용자 ID로 교체
+const DEFAULT_USER_ID = 1;
+
 const PracticeSTT = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
@@ -25,7 +28,14 @@ const PracticeSTT = () => {
             try {
                 setStatusMessage('답변을 텍스트로 변환 중입니다...');
 
-                const result = await requestSTT({ audioUrl, questionId });
+                const sessionId = Number(questionId);
+                console.log(audioUrl);
+                // 백엔드 스키마(user_id, session_id, audio_url)에 맞춰 전달
+                const result = await requestSTT({
+                    userId: DEFAULT_USER_ID,
+                    sessionId: Number.isNaN(sessionId) ? questionId : sessionId,
+                    audioUrl,
+                });
                 const { text } = result.data;
 
                 navigate(`/practice/answer-edit/${questionId}`, {


### PR DESCRIPTION
## 요약

  음성 답변을 S3 업로드 → 업로드 확정 URL 확보 → STT 변환까지 실제 백엔드 명세에 맞춰 연결했습니다. presigned-url 요청 스키마,
  STT 요청 스키마, 오디오 확장자/MIME 처리까지 정리해 “실제 동작”을 목표로 수정했습니다. 또한 인증 연동 전 임시 사용자 ID를 사
  용하고 있어, 추후 실제 사용자 ID로 교체해야 함을 명시했습니다.

  ———

  ## 변경 목적 (무엇을 해결하려고 했는지)

  - presigned-url 생성 요청이 file_name / file_size / mime_type / category 스키마를 요구
  - STT API가 /ai/stt + user_id / session_id / audio_url 스키마를 요구
  - 업로드용 presigned URL이 아니라 업로드 확정된 fileUrl을 STT에 넘겨야 함
  - 인증 연동 전에도 STT가 동작하도록 임시 사용자 ID가 필요

  ———

  ## 변경사항 상세

  ### 1) presigned-url 요청을 백엔드 스키마에 맞춤

  - 파일: src/api/fileApi.js
  - 변경 내용:
      - 요청 바디를 아래 스키마로 전송
          - file_name, file_size, mime_type, category
      - 응답 키를 프론트에서 쓰기 쉽게 정규화
          - file_id/presigned_url 또는 fileId/presignedUrl 모두 대응

  ———

  ### 2) 음성 업로드 플로우를 실제 명세에 맞춰 연결

  - 파일: src/app/pages/PracticeAnswerVoice.jsx
  - 변경 내용:
      - presigned-url 요청에 필수 필드 전달
          - fileSize: audioBlob.size
          - mimeType: ...
          - category: 'AUDIO'
      - 업로드 후 confirmFileUpload(fileId)로 받은 fileUrl을 STT 단계로 전달
          - state: { audioUrl: fileUrl }
      - 확장자/MIME 결정 로직 정리
          - 기본: mp3 / audio/mpeg
          - wav 감지 시: wav / audio/wav
          - mp4/m4a 감지 시: m4a / audio/mp4

  ———

  ### 3) STT 요청을 최신 명세에 맞춤

  - 파일: src/api/sttApi.js
  - 변경 내용:
      - 경로: /ai/stt
      - 바디 키:
          - user_id, session_id, audio_url

  ———

  ### 4) STT 호출부를 새 스키마에 맞춤 + TODO 명시

  - 파일: src/app/pages/PracticeSTT.jsx
  - 변경 내용:
      - requestSTT({ userId, sessionId, audioUrl }) 형태로 호출
      - DEFAULT_USER_ID = 1 임시 상수 추가
      - 주석 추가:
          - // TODO: 인증 연동 후 실제 사용자 ID로 교체

  의도:

  - 인증 연동 전 임시로 동작시키되, 교체 포인트를 명확히 남김

  ———

  ### 5) fetch 공통 유틸에서 signal 지원 + 디버그 로그 추가

  - 파일: src/utils/apiUtils.js
  - 변경 내용:
      - authFetch에서 signal 전달 지원
      - 디버그 로그(console.log) 추가

  ———

  ## 변경/추가/삭제 파일

  현재 워킹트리 기준 변경 파일:

  - 수정
      - src/api/fileApi.js
      - src/api/sttApi.js
      - src/app/pages/PracticeAnswerVoice.jsx
      - src/app/pages/PracticeSTT.jsx
      - src/utils/apiUtils.js
      - package-lock.json

  ———

  ## 확인 포인트

  - presigned-url 요청 400(C001) 해결 여부
  - 업로드 후 STT에 전달되는 값이 presigned URL이 아닌 fileUrl인지
  - STT 요청 바디가 user_id / session_id / audio_url인지
  - S3 버킷 CORS 설정 완료 여부

  ## 관련 Commit, Issue
  - #31 