### PR TITLE
feat:[#33]연습모드 - 나의 텍스트 답변과 답변 분석 페이지 연동

### DIFF
--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -35,7 +35,9 @@ const PracticeAnswerText = () => {
 
     const confirmSubmit = () => {
         setShowConfirm(false);
-        navigate(`/practice/result-keyword/${questionId}`);
+        navigate(`/practice/result-keyword/${questionId}`, {
+            state: { answerText: answer.trim() },
+        });
     };
 
     if (isLoading) return <div>{TEXT_LOADING}</div>;

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
 import { Badge } from '@/app/components/ui/badge';
@@ -14,11 +14,12 @@ const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 const PracticeResultKeyword = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
+    const { state } = useLocation();
     const [isAnalyzing, setIsAnalyzing] = useState(true);
     const [progress, setProgress] = useState(0);
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
-    const myAnswer = '프로세스는 실행 중인 프로그램의 인스턴스로, 독립적인 메모리 공간을 가지고 있습니다. 반면 스레드는 프로세스 내에서 실행되는 작업의 단위로, 같은 프로세스의 다른 스레드와 메모리를 공유합니다.';
+    const myAnswer = state?.answerText || '';
 
     useEffect(() => {
         // Simulate analysis


### PR DESCRIPTION
 ## 요약

  텍스트 답변 작성 후 키워드 분석 페이지로 이동할 때, 작성한 답변이 “나의 답변” 영역에 그대로 표시되도록 라우트 state로 전달/표
  시를 연결했습니다.

  ## 변경사항

  - 텍스트 답변 전달 추가
      - PracticeAnswerText → PracticeResultKeyword 이동 시 answerText를 route state로 전달
  - 키워드 분석 페이지 표시 연동
      - useLocation()으로 answerText를 받아 “나의 답변”에 렌더링

  수정 파일

  - src/app/pages/PracticeAnswerText.jsx
  - src/app/pages/PracticeResultKeyword.jsx

  ## 관련 Commit, Issue

  - #33 