### PR TITLE
feat:[#35] 연습모드 - 텍스트 답변 제출 API, 결과분석 화면 연동

### DIFF
--- a/src/api/aiFeedbackApi.js
+++ b/src/api/aiFeedbackApi.js
@@ -1,0 +1,37 @@
+import { api } from '@/utils/apiUtils'
+
+// AI 서버는 백엔드(8080)를 통해 호출한다.
+/**
+ * AI 피드백 요청 (백엔드 프록시)
+ * @param {Object} params
+ * @param {number} params.userId - 사용자 ID
+ * @param {number} params.questionId - 질문 ID
+ * @param {string} params.interviewType - PRACTICE_INTERVIEW | REAL_INTERVIEW
+ * @param {string} params.questionType - CS | SYSTEM_DESIGN | PORTFOLIO
+ * @param {string} [params.category] - 질문 카테고리 코드
+ * @param {string} params.question - 질문 내용
+ * @param {string} params.answerText - 답변 내용
+ */
+export async function requestInterviewFeedback({
+  userId,
+  questionId,
+  interviewType,
+  questionType,
+  category,
+  question,
+  answerText,
+}) {
+  return api.post(
+    '/ai/interview/feedback',
+    {
+      user_id: userId,
+      question_id: questionId,
+      interview_type: interviewType,
+      question_type: questionType,
+      category,
+      question,
+      answer_text: answerText,
+    },
+    { parseResponse: true }
+  )
+}

--- a/src/app/hooks/usePracticeQuestionLoader.js
+++ b/src/app/hooks/usePracticeQuestionLoader.js
@@ -11,10 +11,12 @@ export function usePracticeQuestionLoader(questionId) {
     const [isLoading, setIsLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState('');
 
+    // Context에 동일 질문이 있는지 먼저 확인한다.
     const hasMatchedContextQuestion = useMemo(() => {
         return selectedQuestion && String(selectedQuestion.id) === String(questionId);
     }, [selectedQuestion, questionId]);
 
+    // API 실패 대비 더미 데이터 fallback을 준비한다.
     const fallbackQuestion = useMemo(() => {
         const matched = QUESTIONS.find((q) => String(q.id) === String(questionId));
         if (matched) return matched;
@@ -46,6 +48,7 @@ export function usePracticeQuestionLoader(questionId) {
                     id: data.questionId ?? data.id ?? questionId,
                     title: data.content ?? data.title ?? '',
                     description: data.content ?? '',
+                    type: data.type ?? '',
                     category: data.category ?? '',
                     keywords: Array.isArray(data.keywords) ? data.keywords : [],
                 };

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Textarea } from '@/app/components/ui/textarea';
@@ -15,16 +15,43 @@ import {
 } from '@/app/components/ui/alert-dialog';
 import { AppHeader } from '@/app/components/AppHeader';
 import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+import { requestInterviewFeedback } from '@/api/aiFeedbackApi';
+import { toast } from 'sonner';
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
+// TODO: 인증 연동 후 실제 사용자 ID로 교체
+const DEFAULT_USER_ID = 1;
+const INTERVIEW_TYPE = 'PRACTICE_INTERVIEW';
+const FEEDBACK_STORAGE_PREFIX = 'qfeed_ai_feedback_';
+const CATEGORY_CODE_MAP = {
+    운영체제: 'OS',
+    네트워크: 'NETWORK',
+    데이터베이스: 'DB',
+    '컴퓨터 구조': 'COMPUTER_ARCHITECTURE',
+    자료구조: 'DATA_STRUCTURE',
+    알고리즘: 'ALGORITHM',
+};
 
 const PracticeAnswerText = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const [answer, setAnswer] = useState('');
     const [showConfirm, setShowConfirm] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
+
+    const questionType = useMemo(() => {
+        if (question?.type) return question.type;
+        if (question?.category === '시스템디자인') return 'SYSTEM_DESIGN';
+        return 'CS';
+    }, [question]);
+
+    const categoryCode = useMemo(() => {
+        if (!question?.category) return '';
+        if (CATEGORY_CODE_MAP[question.category]) return CATEGORY_CODE_MAP[question.category];
+        return question.category;
+    }, [question]);
 
     const handleSubmit = () => {
         if (!answer.trim()) {
@@ -33,8 +60,42 @@ const PracticeAnswerText = () => {
         setShowConfirm(true);
     };
 
-    const confirmSubmit = () => {
+    const confirmSubmit = async () => {
         setShowConfirm(false);
+        setIsSubmitting(true);
+
+        const numericQuestionId = Number(question?.id ?? questionId);
+        const storageKey = `${FEEDBACK_STORAGE_PREFIX}${questionId}`;
+
+        // 분석 화면에서 폴링할 수 있도록 상태를 세션에 저장한다.
+        sessionStorage.setItem(storageKey, JSON.stringify({ status: 'pending' }));
+
+        requestInterviewFeedback({
+            userId: DEFAULT_USER_ID,
+            questionId: Number.isNaN(numericQuestionId) ? questionId : numericQuestionId,
+            interviewType: INTERVIEW_TYPE,
+            questionType,
+            category: categoryCode,
+            question: question?.title || '',
+            answerText: answer.trim(),
+        })
+            .then((response) => {
+                sessionStorage.setItem(
+                    storageKey,
+                    JSON.stringify({ status: 'done', response })
+                );
+            })
+            .catch((err) => {
+                sessionStorage.setItem(
+                    storageKey,
+                    JSON.stringify({ status: 'error', message: err?.message || '피드백 요청 실패' })
+                );
+                toast.error(err?.message || '피드백 요청에 실패했습니다');
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+            });
+
         navigate(`/practice/result-keyword/${questionId}`, {
             state: { answerText: answer.trim() },
         });
@@ -73,10 +134,10 @@ const PracticeAnswerText = () => {
 
                 <Button
                     onClick={handleSubmit}
-                    disabled={!answer.trim()}
+                    disabled={!answer.trim() || isSubmitting}
                     className="w-full rounded-xl h-12"
                 >
-                    답변 제출
+                    {isSubmitting ? '제출 중...' : '답변 제출'}
                 </Button>
             </div>
 

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -1,4 +1,5 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
 import { ThumbsUp, AlertCircle, Home } from 'lucide-react';
@@ -8,20 +9,59 @@ import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
+const TEXT_BAD_CASE_TITLE = '답변에 문제가 있어요';
 
 const PracticeResultAI = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
+    const { state } = useLocation();
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
-    const radarData = [
-        { subject: '논리성', value: 85 },
-        { subject: '완성도', value: 78 },
-        { subject: '키워드', value: 90 },
-        { subject: '명확성', value: 82 },
-        { subject: '구조', value: 75 },
-        { subject: '전달력', value: 88 },
-    ];
+    const feedbackResponse = state?.feedbackResponse;
+    const feedbackData = feedbackResponse?.data;
+    const badCaseFeedback = feedbackData?.bad_case_feedback;
+    // score(1~5)을 0~100 범위로 변환해 레이더 차트에 사용한다.
+    const radarData = Array.isArray(feedbackData?.metrics)
+        ? feedbackData.metrics.map((metric) => ({
+            subject: metric.name,
+            value: Math.min(100, Math.max(0, Math.round((metric.score / 5) * 100))),
+        }))
+        : [];
+    // bad case일 때는 100%로 채워 긍정적 UI를 유지한다.
+    const filledRadarData = radarData.length
+        ? radarData.map((metric) => ({ ...metric, value: 100 }))
+        : [];
+    const strengthsText = badCaseFeedback
+        ? '더 잘 할 수 있어요. 지금의 시도가 충분히 의미 있습니다.'
+        : (feedbackData?.feedback?.strengths || '');
+    const improvementsText = badCaseFeedback
+        ? '조금만 더 자세히 설명해도 충분히 좋아질 수 있어요.'
+        : (feedbackData?.feedback?.improvements || '');
+
+    const renderFeedbackText = (text, className) => {
+        const lines = text.split('\n').map((line) => line.trim()).filter(Boolean);
+        return (
+            <div className={`space-y-2 ${className}`}>
+                {lines.map((line, idx) => {
+                    const isBullet = line.startsWith('-');
+                    const content = isBullet ? line.slice(1).trim() : line;
+                    return (
+                        <p
+                            key={idx}
+                            className={`leading-relaxed ${isBullet ? 'pl-4 relative' : ''}`}
+                        >
+                            {isBullet && <span className="absolute left-0">•</span>}
+                            {content}
+                        </p>
+                    );
+                })}
+            </div>
+        );
+    };
+
+    useEffect(() => {
+        if (!badCaseFeedback) return;
+    }, [badCaseFeedback]);
 
     if (isLoading) return <div>{TEXT_LOADING}</div>;
     if (errorMessage) return <div>{errorMessage}</div>;
@@ -32,7 +72,7 @@ const PracticeResultAI = () => {
             <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
                 <AppHeader
                     title="AI 피드백"
-                    onBack={() => navigate(-1)}
+                    onBack={() => navigate('/practice')}
                     showNotifications={false}
                     tone="dark"
                 />
@@ -45,50 +85,56 @@ const PracticeResultAI = () => {
             </div>
 
             <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-                <Card className="p-6 bg-white shadow-lg">
-                    <h3 className="mb-4 text-center">6각형 평가 지표</h3>
+                <>
+                    <Card className="p-6 bg-white shadow-lg">
+                        {!badCaseFeedback && (
+                            <h3 className="mb-4 text-center">5각형 평가 지표</h3>
+                        )}
+                        {badCaseFeedback && (
+                            <div className="text-center mb-4 space-y-2">
+                                <p className="text-sm text-rose-900 font-medium">
+                                    {badCaseFeedback.message}
+                                </p>
+                                <p className="text-xs text-rose-700">
+                                    {badCaseFeedback.guidance}
+                                </p>
+                            </div>
+                        )}
 
-                    <ResponsiveContainer width="100%" height={250}>
-                    <RadarChart data={radarData}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="subject" />
-                            <PolarRadiusAxis angle={90} domain={[0, 100]} />
-                        <Radar name="평가" dataKey="value" stroke="#ec4899" fill="#ec4899" fillOpacity={0.6} />
-                        </RadarChart>
-                    </ResponsiveContainer>
-                </Card>
+                        <ResponsiveContainer width="100%" height={250}>
+                            <RadarChart data={badCaseFeedback ? filledRadarData : radarData}>
+                                <PolarGrid />
+                                <PolarAngleAxis dataKey="subject" />
+                                <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} axisLine={false} />
+                                <Radar name="평가" dataKey="value" stroke="#ec4899" fill="#ec4899" fillOpacity={0.6} />
+                            </RadarChart>
+                        </ResponsiveContainer>
+                    </Card>
 
-                <Card className="p-5 border-2 border-rose-200 bg-rose-50">
-                    <div className="flex items-start gap-3">
-                        <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                            <ThumbsUp className="w-5 h-5 text-pink-600" />
+                    <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+                        <div className="flex items-start gap-3">
+                            <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+                                <ThumbsUp className="w-5 h-5 text-pink-600" />
+                            </div>
+                            <div className="flex-1">
+                                <h3 className="mb-2 text-rose-900">잘한 점</h3>
+                                {renderFeedbackText(strengthsText, 'text-sm text-rose-800')}
+                            </div>
                         </div>
-                        <div className="flex-1">
-                            <h3 className="mb-2 text-rose-900">잘한 점</h3>
-                            <ul className="text-sm text-rose-800 space-y-1 list-disc list-inside">
-                                <li>프로세스와 스레드의 핵심 개념을 명확히 설명했습니다</li>
-                                <li>메모리 공유라는 중요한 차이점을 잘 짚어냈습니다</li>
-                                <li>구조화된 답변으로 이해하기 쉽게 설명했습니다</li>
-                            </ul>
-                        </div>
-                    </div>
-                </Card>
+                    </Card>
 
-                <Card className="p-5 border-2 border-pink-200 bg-pink-50">
-                    <div className="flex items-start gap-3">
-                        <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
-                            <AlertCircle className="w-5 h-5 text-pink-600" />
+                    <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+                        <div className="flex items-start gap-3">
+                            <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
+                                <AlertCircle className="w-5 h-5 text-pink-600" />
+                            </div>
+                            <div className="flex-1">
+                                <h3 className="mb-2 text-pink-900">개선하면 좋은 점</h3>
+                                {renderFeedbackText(improvementsText, 'text-sm text-pink-800')}
+                            </div>
                         </div>
-                        <div className="flex-1">
-                            <h3 className="mb-2 text-pink-900">개선하면 좋은 점</h3>
-                            <ul className="text-sm text-pink-800 space-y-1 list-disc list-inside">
-                                <li>컨텍스트 스위칭에 대한 구체적인 설명을 추가하면 좋습니다</li>
-                                <li>멀티프로세싱과 멀티스레딩의 실제 사용 사례를 언급해보세요</li>
-                                <li>각 방식의 장단점을 좀 더 상세히 비교하면 완벽합니다</li>
-                            </ul>
-                        </div>
-                    </div>
-                </Card>
+                    </Card>
+                </>
 
                 <div className="bg-gradient-to-r from-rose-100 to-pink-100 rounded-xl p-4">
                     <p className="text-sm text-rose-900 text-center">


### PR DESCRIPTION
• ## 요약

  텍스트 답변 제출 시 AI 피드백을 백엔드(8080)로 요청하고, 결과를 분석 대기 화면 → 결과 화면 흐름으로 연결했습니다.
  분석 중에는 진행률이 95%에서 대기하다가 응답이 오면 100%까지 부드럽게 채우고 결과 보기 버튼을 활성화합니다.
  또한 bad_case 응답은 부정적 경험을 줄이도록 격려 메시지 + 5각형(100%) 표시로 처리했습니다.

  ———

  ## 변경 목적 및 구현 상세

  ### 1) AI 피드백 요청 연결 (텍스트 답변 제출 시)

  - 목적: PracticeAnswerText에서 작성한 답변을 AI 피드백 서버에 전달
  - 내용
      - 백엔드 프록시 /ai/interview/feedback로 요청
      - user_id는 인증 도입 전 임시 1 사용 (TODO 주석)
      - question_type, category, question, answer_text를 Context 데이터 기반으로 구성
      - 응답은 sessionStorage에 저장 → 분석 화면에서 폴링

  관련 파일

  - src/api/aiFeedbackApi.js (신규)
  - src/app/pages/PracticeAnswerText.jsx

  ———

  ### 2) 분석 화면 진행률 UX 개선

  - 목적: 응답 대기 중 사용자가 기다리고 있음을 체감
  - 내용
      - 진행률 0→95%까지 천천히 상승
      - 응답 도착 시 95→100%를 부드럽게 애니메이션
      - 응답 도착 전까지 결과 버튼 비활성
      - 분석 중 뒤로가기 시 모달 안내 + 목록 이동 옵션 제공

  관련 파일

  - src/app/pages/PracticeResultKeyword.jsx

  ———

  ### 3) 결과 화면 표시 로직 개선 (success / bad_case)

  - 목적: bad_case일 때 부정적 경험 최소화
  - 내용
      - metrics → 레이더 차트 데이터로 변환 (1~5 → 0~100)
      - bad_case 시:
          - 레이더 차트 100%로 채움
          - “잘한 점/개선하면 좋은 점”은 격려 메시지 표시
          - 차트 상단에 message/guidance 중앙 정렬 표시
          - “5각형 평가 지표” 제목 숨김
      - 일반 성공 시:
          - strengths / improvements 텍스트 렌더링
          - - 로 시작하는 줄은 들여쓰기 불릿 처리

  관련 파일

  - src/app/pages/PracticeResultAI.jsx

  ———

  ### 4) 질문 데이터 확장

  - 목적: 피드백 요청 시 question_type 확보
  - 내용
      - 질문 로더에서 type 필드 매핑 추가

  관련 파일

  - src/app/hooks/usePracticeQuestionLoader.js

  ———

  ### 추가

  - src/api/aiFeedbackApi.js
  - src/app/pages/PracticeAnswerText.jsx
  - src/app/pages/PracticeResultKeyword.jsx
  - src/app/pages/PracticeResultAI.jsx

  ———

  ## 관련 Commit, Issue

  -  #35 