### PR TITLE
feat:[#45] 카카오 로그인 연동 및 인증 컨텍스트 도입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# QFeed Frontend Environment Variables
+# Copy this file to .env.local or .env.development.local and fill in the values
+
+# Backend API Base URL
+# Development: http://localhost:8080
+# Production: https://api.qfeed.com
+VITE_API_BASE_URL=http://localhost:8080

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,0 +1,70 @@
+import { authFetch, extractErrorMessage, API_BASE_URL } from '@/utils/apiUtils.js'
+
+export function getOAuthAuthorizationUrl(provider = 'kakao') {
+  return `${API_BASE_URL}/api/auth/oauth/authorization-url?provider=${provider}`
+}
+
+export async function exchangeOAuthCode(exchangeCode) {
+  const response = await fetch(`${API_BASE_URL}/api/auth/oauth/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ exchangeCode }),
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, '로그인에 실패했습니다.'))
+  }
+
+  const authHeader = response.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw new Error('로그인에 실패했습니다.')
+  }
+
+  const data = await response.json().catch(() => null)
+  const user = data?.data?.user ?? null
+
+  return { accessToken: authHeader.slice(7), user }
+}
+
+export async function refreshTokens() {
+  const response = await fetch(`${API_BASE_URL}/api/auth/tokens`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, '토큰 갱신에 실패했습니다.'))
+  }
+
+  const authHeader = response.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw new Error('토큰 갱신에 실패했습니다.')
+  }
+
+  return authHeader.slice(7)
+}
+
+export async function logout() {
+  const response = await authFetch('/api/auth/logout', {
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, '로그아웃에 실패했습니다.'))
+  }
+
+  return true
+}
+
+export async function logoutAll() {
+  const response = await authFetch('/api/auth/logout/all', {
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, '전체 로그아웃에 실패했습니다.'))
+  }
+
+  return true
+}

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Toaster } from '@/app/components/ui/sonner';
-import { storage } from '@/utils/storage';
+import { AuthProvider, useAuth } from '@/context/AuthContext';
 
 // Pages
 import Splash from '@/app/pages/Splash';
@@ -17,10 +17,12 @@ import PracticeResultAI from '@/app/pages/PracticeResultAI';
 import ProfileMain from '@/app/pages/ProfileMain';
 import SettingMain from '@/app/pages/SettingMain';
 import RealInterview from '@/app/pages/RealInterview';
-import { PracticeQuestionProvider } from '@/app/contexts/practiceQuestionContext.jsx';
+import OAuthCallback from '@/app/pages/OAuthCallback';
 
 function AppRoutes() {
-    const isLoggedIn = storage.isLoggedIn();
+    const { isAuthenticated, isLoading } = useAuth()
+
+    if (isLoading) return null
 
     return (
         <>
@@ -28,9 +30,10 @@ function AppRoutes() {
                 {/* Auth */}
                 <Route path="/splash" element={<Splash />} />
                 <Route path="/login" element={<AuthLogin />} />
+                <Route path="/oauth/redirect" element={<OAuthCallback />} />
 
                 {/* Protected Routes */}
-                {isLoggedIn ? (
+                {isAuthenticated ? (
                     <>
                         <Route path="/" element={<Home />} />
 
@@ -65,9 +68,9 @@ function AppRoutes() {
 function App() {
     return (
         <BrowserRouter>
-            <PracticeQuestionProvider>
+            <AuthProvider>
                 <AppRoutes />
-            </PracticeQuestionProvider>
+            </AuthProvider>
         </BrowserRouter>
     );
 }

--- a/src/app/pages/AuthLogin.jsx
+++ b/src/app/pages/AuthLogin.jsx
@@ -1,28 +1,28 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { motion as Motion } from 'motion/react';
 import { Button } from '@/app/components/ui/button';
 import { Checkbox } from '@/app/components/ui/checkbox';
-import { storage } from '@/utils/storage';
+import { getOAuthAuthorizationUrl } from '@/api/authApi';
 import { toast } from 'sonner';
 import { AppHeader } from '@/app/components/AppHeader';
+import { useAuth } from '@/context/AuthContext';
 
 const AuthLogin = () => {
-    const navigate = useNavigate();
+    const { isAuthenticated } = useAuth();
     const [agreedToTerms, setAgreedToTerms] = useState(false);
 
+    if (isAuthenticated) {
+        return <Navigate to="/" replace />;
+    }
+
     const handleKakaoLogin = () => {
-        // Auto-agree to terms and log in
-        setAgreedToTerms(true);
+        if (!agreedToTerms) {
+            toast.error('서비스 이용약관에 동의해주세요.');
+            return;
+        }
 
-        // Mock Kakao login
-        storage.setLoggedIn(true);
-        storage.setNickname('면접 준비생');
-        toast.success('로그인 성공!');
-
-        setTimeout(() => {
-            navigate('/', { replace: true });
-        }, 500);
+        window.location.href = getOAuthAuthorizationUrl('kakao');
     };
 
     return (
@@ -61,7 +61,11 @@ const AuthLogin = () => {
                             onClick={handleKakaoLogin}
                             className="w-full bg-[#FEE500] hover:bg-[#FDD835] text-black rounded-xl h-12"
                         >
-                            <span className="mr-2">💬</span>
+                            <span className="mr-2">
+                                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path fillRule="evenodd" clipRule="evenodd" d="M9 0.5C4.02944 0.5 0 3.69 0 7.62C0 10.06 1.558 12.22 3.931 13.48L2.933 17.04C2.845 17.36 3.213 17.61 3.491 17.42L7.873 14.55C8.243 14.59 8.619 14.61 9 14.61C13.9706 14.61 18 11.42 18 7.49C18 3.56 13.9706 0.5 9 0.5Z" fill="black"/>
+                                </svg>
+                            </span>
                             카카오로 시작하기
                         </Button>
 

--- a/src/app/pages/OAuthCallback.jsx
+++ b/src/app/pages/OAuthCallback.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/context/AuthContext'
+import { exchangeOAuthCode, refreshTokens } from '@/api/authApi'
+import { toast } from 'sonner'
+
+const OAuthCallback = () => {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { login } = useAuth()
+  const [error, setError] = useState(null)
+  const processed = useRef(false)
+
+  useEffect(() => {
+    if (processed.current) return
+    processed.current = true
+
+    const handleCallback = async () => {
+      const exchangeCode = searchParams.get('exchange_code')
+      const errorParam = searchParams.get('error')
+      const errorMessage = searchParams.get('error_message')
+
+      if (errorParam) {
+        const msg = errorMessage || '로그인에 실패했습니다.'
+        setError(msg)
+        toast.error(msg)
+        setTimeout(() => navigate('/login', { replace: true }), 2000)
+        return
+      }
+
+      if (exchangeCode) {
+        try {
+          const result = await exchangeOAuthCode(exchangeCode)
+          login(result.accessToken, result.user)
+          toast.success('로그인 성공!')
+          navigate('/', { replace: true })
+        } catch {
+          setError('인증 처리에 실패했습니다.')
+          toast.error('인증 처리에 실패했습니다.')
+          setTimeout(() => navigate('/login', { replace: true }), 2000)
+        }
+        return
+      }
+
+      // exchange_code 없이 도달한 경우, HttpOnly 쿠키의 refresh token으로 시도
+      try {
+        const newToken = await refreshTokens()
+        login(newToken)
+        toast.success('로그인 성공!')
+        navigate('/', { replace: true })
+      } catch {
+        setError('인증 정보를 찾을 수 없습니다.')
+        toast.error('인증 정보를 찾을 수 없습니다.')
+        setTimeout(() => navigate('/login', { replace: true }), 2000)
+      }
+    }
+
+    handleCallback()
+  }, [searchParams, login, navigate])
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-rose-50 via-white to-pink-50 flex items-center justify-center">
+      <div className="text-center">
+        {error ? (
+          <>
+            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-100 flex items-center justify-center">
+              <span className="text-2xl">!</span>
+            </div>
+            <p className="text-red-600">{error}</p>
+            <p className="text-muted-foreground text-sm mt-2">로그인 페이지로 이동합니다...</p>
+          </>
+        ) : (
+          <>
+            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-pink-100 flex items-center justify-center animate-pulse">
+              <span className="text-2xl">Q</span>
+            </div>
+            <p className="text-muted-foreground">로그인 처리 중...</p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OAuthCallback

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,106 @@
+import { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react'
+import { setAccessTokenGetter } from '@/utils/apiUtils'
+import { refreshTokens, logout as apiLogout } from '@/api/authApi'
+import { storage } from '@/utils/storage'
+
+const AuthContext = createContext(null)
+
+const TOKEN_REFRESH_INTERVAL = 9 * 60 * 1000 // 9 minutes (before 10min expiry)
+
+export function AuthProvider({ children }) {
+  const [accessToken, setAccessToken] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [user, setUser] = useState(null)
+  const accessTokenRef = useRef(null)
+
+  const isAuthenticated = !!accessToken
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    accessTokenRef.current = accessToken
+  }, [accessToken])
+
+  // Provide access token getter to apiUtils
+  useEffect(() => {
+    setAccessTokenGetter(() => accessTokenRef.current)
+  }, [])
+
+  // Try to refresh token on initial load
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        const newToken = await refreshTokens()
+        setAccessToken(newToken)
+        storage.setLoggedIn(true)
+      } catch {
+        if (!accessTokenRef.current) {
+          setAccessToken(null)
+          storage.setLoggedIn(false)
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    initAuth()
+  }, [])
+
+  // Stable token refresh interval (does not re-create on token change)
+  useEffect(() => {
+    const refreshInterval = setInterval(async () => {
+      if (!accessTokenRef.current) return
+
+      try {
+        const newToken = await refreshTokens()
+        setAccessToken(newToken)
+      } catch {
+        setAccessToken(null)
+        storage.setLoggedIn(false)
+      }
+    }, TOKEN_REFRESH_INTERVAL)
+
+    return () => clearInterval(refreshInterval)
+  }, [])
+
+  const login = useCallback((token, userData = null) => {
+    accessTokenRef.current = token
+    setAccessToken(token)
+    if (userData) {
+      setUser(userData)
+      storage.setNickname(userData.nickname || userData.name || '사용자')
+    }
+    storage.setLoggedIn(true)
+  }, [])
+
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout()
+    } catch {
+      // Ignore logout API errors
+    } finally {
+      setAccessToken(null)
+      setUser(null)
+      storage.clear()
+    }
+  }, [])
+
+  const value = {
+    accessToken,
+    isAuthenticated,
+    isLoading,
+    user,
+    login,
+    logout,
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}


### PR DESCRIPTION
### 요약
카카오 OAuth 로그인/콜백 처리와 인증 상태 관리, API 연동을 추가했습니다.

## 변경사항
- OAuth 인가 URL/코드 교환/토큰 갱신 API 추가
- AuthContext로 토큰 관리 및 자동 갱신
- OAuth 콜백 페이지와 로그인 화면 로직 보강
- 라우팅에 OAuth 콜백 경로 추가
- .env.example로 API_BASE_URL 안내