### PR TITLE
feat:[#53]API 호출방식 통일(AT 세팅)

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -5,7 +5,7 @@ export function getOAuthAuthorizationUrl(provider = 'kakao') {
 }
 
 export async function exchangeOAuthCode(exchangeCode) {
-  const response = await fetch(`${API_BASE_URL}/api/auth/oauth/exchange`, {
+  const response = await authFetch('/api/auth/oauth/exchange', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
@@ -28,7 +28,7 @@ export async function exchangeOAuthCode(exchangeCode) {
 }
 
 export async function refreshTokens() {
-  const response = await fetch(`${API_BASE_URL}/api/auth/tokens`, {
+  const response = await authFetch('/api/auth/tokens', {
     method: 'POST',
     credentials: 'include',
   })

--- a/src/api/fileApi.js
+++ b/src/api/fileApi.js
@@ -1,5 +1,8 @@
 import { api, handleResponse } from '@/utils/apiUtils'
 
+// NOTE: 앱 서버로 가는 요청은 api(authFetch)를 사용한다.
+// presigned URL 업로드는 외부(S3)로 직접 요청해야 하므로 fetch를 유지한다.
+
 /**
  * S3 presigned URL 요청
  * @param {Object} params
@@ -35,6 +38,7 @@ export async function getPresignedUrl({ fileName, fileSize, mimeType, category }
  * @param {string} contentType - MIME 타입
  */
 export async function uploadToS3(presignedUrl, file, contentType) {
+  // presigned URL은 서명된 요청이므로 Authorization 헤더를 추가하면 실패한다.
   const response = await fetch(presignedUrl, {
     method: 'PUT',
     body: file,

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/app/components/ui/sonner';
 import { AuthProvider, useAuth } from '@/context/AuthContext';
+import { PracticeQuestionProvider } from '@/context/practiceQuestionContext.jsx';
 import { queryClient } from '@/lib/queryClient';
 
 // Pages
@@ -72,7 +73,9 @@ function App() {
         <QueryClientProvider client={queryClient}>
             <BrowserRouter>
                 <AuthProvider>
-                    <AppRoutes />
+                    <PracticeQuestionProvider>
+                        <AppRoutes />
+                    </PracticeQuestionProvider>
                 </AuthProvider>
             </BrowserRouter>
         </QueryClientProvider>


### PR DESCRIPTION
## 요약

  authApi 요청을 authFetch로 통일해 인증/헤더 처리 일관성을 확보했고, 연습모드 화면 전환이 실패하던 원인을 해결하기 위해 PracticeQuestionProvider를 앱 루트에 연결했습니다. 또한 presigned URL 업로드는 예외임을 명시

  ## 변경사항

  - 인증 API 요청 경로 통일
      - exchangeOAuthCode, refreshTokens를 authFetch 사용으로 변경
      - API Base URL/credentials/headers 처리 로직을 공통화하여 누락 가능성 감소
  - 연습모드 진입 오류 해결
      - PracticeQuestionProvider를 AppRoutes 상위에 배치
      - /practice 이동 시 컨텍스트 미설정으로 인한 렌더 에러 방지
  - presigned 업로드 예외 처리 명시
      - S3 업로드는 Authorization 헤더가 붙으면 실패하므로 직접 fetch 유지
      - 관련 주석 추가로 향후 실수 예방

  ## 수정/추가/삭제 파일

  - 수정
      - src/api/authApi.js
          - fetch → authFetch로 전환 (OAuth 교환, 토큰 갱신)
      - src/app/App.jsx
          - PracticeQuestionProvider로 앱 라우트 감싸기
      - src/api/fileApi.js
          - presigned URL 업로드 예외 주석/설명 추가
      - src/utils/apiUtils.js
          - accessToken 디버그 로그 추가

  ## 구현 의도 / 목적

  - 인증 관련 API가 authFetch를 우회하면 Authorization 헤더가 누락될 수 있어, 공통 처리로 통일해 인증 흐름을 안정화
  - /practice 경로에서 컨텍스트 미설정으로 앱이 깨지는 문제를 해결해 연습모드 진입 안정성을 확보
  - S3 presigned URL 업로드는 인증 헤더가 붙으면 실패하므로 예외 처리를 명시

  ## 장점

  - 인증/헤더 처리 일관성 확보 → API 인증 실패 가능성 감소
  - 연습모드 진입 안정성 개선 → 화면 전환 실패 문제 해결
  - presigned 업로드 예외 명시 → 향후 기능 추가 시 실수 방지

  ## 리스크 / 주의사항

  - authFetch로 전환된 exchangeOAuthCode, refreshTokens는
    accessToken이 없을 때도 호출되므로 서버가 Bearer 헤더 유무에 민감한지 확인 필요

  ## 관련 Commit, Issue

  - Issue: #53 