### PR TITLE
fix:[#55] 홈 화면 로딩 안됨 문제 해결

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -50,37 +50,14 @@ export function AuthProvider({ children }) {
 
   const nickname = user?.nickname || user?.name || DEFAULT_NICKNAME
 
-  // Keep ref in sync with state
   useEffect(() => {
     accessTokenRef.current = accessToken
   }, [accessToken])
 
-  // Provide access token getter to apiUtils
   useEffect(() => {
     setAccessTokenGetter(() => accessTokenRef.current)
   }, [])
 
-  // Try to refresh token on initial load
-  useEffect(() => {
-    const initAuth = async () => {
-      try {
-        const newToken = await refreshTokens()
-        setAccessToken(newToken)
-        setUser(getUserFromToken(newToken))
-        scheduleRefresh(newToken)
-      } catch {
-        if (!accessTokenRef.current) {
-          setAccessToken(null)
-        }
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    initAuth()
-  }, [scheduleRefresh])
-
-  // Schedule token refresh based on JWT exp claim
   const refreshTimerRef = useRef(null)
 
   const scheduleRefresh = useCallback((token) => {
@@ -105,6 +82,26 @@ export function AuthProvider({ children }) {
         setUser(null)
       }
     }, delay)
+  }, [])
+
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        const newToken = await refreshTokens()
+        setAccessToken(newToken)
+        setUser(getUserFromToken(newToken))
+        scheduleRefresh(newToken)
+      } catch {
+        if (!accessTokenRef.current) {
+          setAccessToken(null)
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    initAuth()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## 요약
"/" 진입 시 빈 화면으로 남는 문제를 해결했습니다.

## 원인
- AuthContext에서 initAuth useEffect가 scheduleRefresh를 참조했으나 scheduleRefresh 선언이 이후에 있어 undefined 참조가 발생
- initAuth effect가 scheduleRefresh 의존성으로 인해 불안정하게 재실행될 가능성 존재

## 해결
- scheduleRefresh / refreshTimerRef 선언을 initAuth보다 위로 이동
- initAuth useEffect dependency를 []로 변경하여 mount 시 1회만 실행

## 관련 이슈
- #55