### PR TITLE
feat:[#41]STT 편집 답변 제출 연동 및 분석 화면 답변 반영

### DIFF
--- a/src/app/hooks/usePracticeAnswerSubmit.js
+++ b/src/app/hooks/usePracticeAnswerSubmit.js
@@ -1,0 +1,64 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { submitPracticeAnswer } from '@/api/answerApi';
+
+const TEXT_SUBMIT_ERROR = '피드백 요청에 실패했습니다';
+const TEXT_FEEDBACK_REQUEST_FAILED = '피드백 요청 실패';
+const INTERVIEW_TYPE = 'PRACTICE_INTERVIEW';
+const FEEDBACK_STORAGE_PREFIX = 'qfeed_ai_feedback_';
+const STORAGE_STATUS_PENDING = 'pending';
+const STORAGE_STATUS_ERROR = 'error';
+
+export const usePracticeAnswerSubmit = () => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const submitAnswer = useCallback(
+        ({ questionId, question, answerText, onAfterSubmit }) => {
+            const trimmedAnswer = answerText.trim();
+            if (!trimmedAnswer || isSubmitting) return;
+
+            setIsSubmitting(true);
+
+            const numericQuestionId = Number(question?.id ?? questionId);
+            const storageKey = `${FEEDBACK_STORAGE_PREFIX}${questionId}`;
+
+            sessionStorage.setItem(
+                storageKey,
+                JSON.stringify({ status: STORAGE_STATUS_PENDING })
+            );
+
+            submitPracticeAnswer({
+                questionId: Number.isNaN(numericQuestionId) ? questionId : numericQuestionId,
+                answerText: trimmedAnswer,
+                answerType: INTERVIEW_TYPE,
+            })
+                .then((response) => {
+                    const answerId = response?.data?.answerId;
+                    sessionStorage.setItem(
+                        storageKey,
+                        JSON.stringify({ status: STORAGE_STATUS_PENDING, answerId })
+                    );
+                })
+                .catch((err) => {
+                    sessionStorage.setItem(
+                        storageKey,
+                        JSON.stringify({
+                            status: STORAGE_STATUS_ERROR,
+                            message: err?.message || TEXT_FEEDBACK_REQUEST_FAILED,
+                        })
+                    );
+                    toast.error(err?.message || TEXT_SUBMIT_ERROR);
+                })
+                .finally(() => {
+                    setIsSubmitting(false);
+                });
+
+            if (onAfterSubmit) {
+                onAfterSubmit(trimmedAnswer);
+            }
+        },
+        [isSubmitting]
+    );
+
+    return { submitAnswer, isSubmitting };
+};

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -17,10 +17,11 @@ import { Edit3, Eye } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { toast } from 'sonner';
 import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+import { usePracticeAnswerSubmit } from '@/app/hooks/usePracticeAnswerSubmit';
 
-const DEFAULT_ANSWER = '프로세스는 실행 중인 프로그램의 인스턴스로, 독립적인 메모리 공간을 가지고 있습니다. 반면 스레드는 프로세스 내에서 실행되는 작업의 단위로, 같은 프로세스의 다른 스레드와 메모리를 공유합니다. 멀티프로세싱은 여러 프로세스를 동시에 실행하는 것이고, 멀티스레딩은 하나의 프로세스 내에서 여러 스레드를 실행하는 것입니다. 스레드는 메모리를 공유하기 때문에 컨스트 스위칭 비용이 적고 통신이 빠르지만, 동기화 문제에 주의해야 합니다.';
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
+const TEXT_SUBMITTING = '제출 중...';
 
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
@@ -29,6 +30,7 @@ const PracticeAnswerEdit = () => {
 
     const [isEditing, setIsEditing] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
+    const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();
     const [answer, setAnswer] = useState(state?.transcribedText || DEFAULT_ANSWER);
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
@@ -42,12 +44,22 @@ const PracticeAnswerEdit = () => {
     };
 
     const handleSubmit = () => {
+        if (!answer.trim()) return;
         setShowConfirm(true);
     };
 
     const confirmSubmit = () => {
         setShowConfirm(false);
-        navigate(`/practice/result-keyword/${questionId}`);
+        submitAnswer({
+            questionId,
+            question,
+            answerText: answer,
+            onAfterSubmit: (trimmedAnswer) => {
+                navigate(`/practice/result-keyword/${questionId}`, {
+                    state: { answerText: trimmedAnswer },
+                });
+            },
+        });
     };
 
     if (isLoading) return <div>{TEXT_LOADING}</div>;
@@ -105,8 +117,12 @@ const PracticeAnswerEdit = () => {
                     )}
                 </Card>
 
-                <Button onClick={handleSubmit} className="w-full rounded-xl h-12">
-                    답변 제출
+                <Button
+                    onClick={handleSubmit}
+                    disabled={!answer.trim() || isSubmitting}
+                    className="w-full rounded-xl h-12"
+                >
+                    {isSubmitting ? TEXT_SUBMITTING : '답변 제출'}
                 </Button>
             </div>
 

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -6,6 +6,7 @@ import { ThumbsUp, AlertCircle, Home } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, ResponsiveContainer } from 'recharts';
 import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
+import { usePracticeQuestion } from '@/context/practiceQuestionContext.jsx';
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
@@ -31,6 +32,7 @@ const PracticeResultAI = () => {
     const { questionId } = useParams();
     const { state } = useLocation();
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
+    const { clearSelectedQuestion } = usePracticeQuestion();
 
     const feedbackResponse = state?.feedbackResponse;
     const feedbackData = feedbackResponse?.data;
@@ -78,6 +80,12 @@ const PracticeResultAI = () => {
     useEffect(() => {
         if (!badCaseFeedback) return;
     }, [badCaseFeedback]);
+
+    useEffect(() => {
+        return () => {
+            clearSelectedQuestion();
+        };
+    }, [clearSelectedQuestion]);
 
     if (isLoading) return <div>{TEXT_LOADING}</div>;
     if (errorMessage) return <div>{errorMessage}</div>;
@@ -166,7 +174,10 @@ const PracticeResultAI = () => {
                 </div>
 
                 <Button
-                    onClick={() => navigate('/')}
+                    onClick={() => {
+                        clearSelectedQuestion();
+                        navigate('/');
+                    }}
                     className="w-full rounded-xl h-12 gap-2"
                     variant="default"
                 >


### PR DESCRIPTION
 ## 요약

  연습모드 텍스트/음성(편집) 답변 제출 흐름을 공통 훅으로 통합해 중복을 제거했고, 제출된 답변이 결과 화면에 표시되도록 상태 전달을 정리했습니다.
  또한 AI 결과 화면 이탈 시 선택 질문을 세션 스토리지에서 정리하도록 처리했습니다.

  ## 변경사항

  - 답변 제출/피드백 요청 공통화
      - PracticeAnswerText, PracticeAnswerEdit의 제출 로직을 훅으로 통합
      - 제출 시 세션 스토리지에 상태 저장 + 분석 화면 폴링을 위한 answerId 기록
  - 답변 텍스트 전달 정리
      - 편집 화면 제출 시 PracticeResultKeyword로 answerText 전달 (myAnswer 표시)
  - 세션 스토리지 정리
      - PracticeResultAI 이탈 시 selectedQuestion 제거
      - “홈으로 이동” 버튼 클릭 시 즉시 제거

  ## 수정/추가/삭제 파일

  - 추가
      - src/app/hooks/usePracticeAnswerSubmit.js
  - 수정
      - src/app/pages/PracticeAnswerText.jsx
      - src/app/pages/PracticeAnswerEdit.jsx
      - src/app/pages/PracticeResultAI.jsx

  ## 구현 의도 / 목적

  - 제출/피드백 요청 로직 중복 제거 → 유지보수성 향상
  - 편집 답변이 결과 화면에 올바르게 표시되도록 흐름 정리
  - 연습 완료 후 세션 스토리지에 남는 선택 질문 정리

  ## 관련 Commit, Issue

  - #41 