### PR TITLE
feat:[#19] 실전 모드 노출 제어 플래그 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@
 # Development: http://localhost:8080
 # Production: https://api.qfeed.com
 VITE_API_BASE_URL=http://localhost:8080
+
+# Feature flags
+# Show "Real Interview" entry point (true/false)
+VITE_SHOW_REAL_INTERVIEW=false

--- a/src/app/components/BottomNav.jsx
+++ b/src/app/components/BottomNav.jsx
@@ -1,6 +1,8 @@
 import { Home, BookOpen, Target, User } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
+const SHOW_REAL_INTERVIEW = import.meta.env.VITE_SHOW_REAL_INTERVIEW === 'true';
+
 const BottomNav = () => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -8,7 +10,7 @@ const BottomNav = () => {
     const navItems = [
         { path: '/', icon: Home, label: '홈' },
         { path: '/practice', icon: BookOpen, label: '연습' },
-        { path: '/real-interview', icon: Target, label: '실전' },
+        ...(SHOW_REAL_INTERVIEW ? [{ path: '/real-interview', icon: Target, label: '실전' }] : []),
         { path: '/profile', icon: User, label: '프로필' },
     ];
 

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -31,6 +31,7 @@ const CATEGORY_LABEL_MAP = {
 const TEXT_RECOMMENDATION_LOADING = '추천 질문을 불러오는 중...';
 const TEXT_RECOMMENDATION_ERROR = '추천 질문을 불러오지 못했습니다.';
 const TEXT_RECOMMENDATION_EMPTY = '오늘의 추천 질문이 없습니다';
+const SHOW_REAL_INTERVIEW = import.meta.env.VITE_SHOW_REAL_INTERVIEW === 'true';
 
 const Home = () => {
     const navigate = useNavigate();
@@ -156,6 +157,7 @@ const Home = () => {
                             <span className="text-sm">연습 모드</span>
                         </Button>
 
+                        {SHOW_REAL_INTERVIEW && (
                         <Button
                             variant="outline"
                             className="h-20 flex-col gap-2 rounded-xl"
@@ -164,6 +166,7 @@ const Home = () => {
                             <span className="text-2xl">🎯</span>
                             <span className="text-sm">실전 모드</span>
                         </Button>
+                        )}
                     </div>
                 </section>
             </div>

--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -12,10 +12,15 @@ import { useQuestionsInfinite } from '@/app/hooks/useQuestionsInfinite';
 
 import { AppHeader } from '@/app/components/AppHeader';
 
+const SHOW_REAL_INTERVIEW = import.meta.env.VITE_SHOW_REAL_INTERVIEW === 'true';
 const INITIAL_SEARCH_QUERY = '';
 const INITIAL_CATEGORY = '전체';
 const INITIAL_SUB_CATEGORY = '전체';
-const CATEGORY_OPTIONS = ['전체', 'CS기초', '시스템디자인'];
+const CATEGORY_OPTIONS = [
+    '전체',
+    'CS기초',
+    ...(SHOW_REAL_INTERVIEW ? ['시스템디자인'] : []),
+];
 const CS_SUB_CATEGORY_OPTIONS = ['전체', '운영체제', '네트워크', '데이터베이스', '컴퓨터 구조', '자료구조&알고리즘'];
 const CS_CATEGORY_MAP = {
     운영체제: 'OS',


### PR DESCRIPTION
## 요약
환경변수(VITE_SHOW_REAL_INTERVIEW)로 실전 모드 노출을 제어할 수 있게 했습니다.

## 변경사항
- 실전 모드 버튼/탭/카테고리 노출을 플래그로 토글
- Vite 환경변수 사용 가이드 추가(.env)

## 관련 이슈
closes #19