### PR TITLE
feat:[#19] 실전 모드 URI 및 포트폴리오 노출 제어 플래그 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ VITE_API_BASE_URL=http://localhost:8080
 # Feature flags
 # Show "Real Interview" entry point (true/false)
 VITE_SHOW_REAL_INTERVIEW=false
+
+# Show "Portfolio Interview" entry point (true/false)
+VITE_SHOW_PORTFOLIO_INTERVIEW=false

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -27,6 +27,8 @@ function AppRoutes() {
 
     if (isLoading) return null
 
+    const SHOW_REAL_INTERVIEW = import.meta.env.VITE_SHOW_REAL_INTERVIEW === 'true';
+
     return (
         <>
             <Routes>
@@ -51,7 +53,9 @@ function AppRoutes() {
                         <Route path="/practice/result-ai/:questionId" element={<PracticeResultAI />} />
 
                         {/* Real Interview */}
-                        <Route path="/real-interview" element={<RealInterview />} />
+                        {(SHOW_REAL_INTERVIEW &&
+                            <Route path="/real-interview" element={<RealInterview />} />
+                        )}
 
                         {/* Profile */}
                         <Route path="/profile" element={<ProfileMain />} />

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -10,6 +10,8 @@ import { useAuth } from '@/context/AuthContext';
 import { AppHeader } from '@/app/components/AppHeader';
 import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 
+const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
+
 const ANSWER_TYPE_LABELS = {
     PRACTICE_INTERVIEW: '연습',
     REAL_INTERVIEW: '실전',
@@ -120,17 +122,19 @@ const ProfileMain = () => {
                 </section>
 
                 {/* Portfolio Management */}
-                <Card className="p-5">
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <h3 className="mb-1">포트폴리오 관리</h3>
-                            <p className="text-sm text-muted-foreground">개인화된 질문을 받아보세요</p>
+                {SHOW_PORTFOLIO_INTERVIEW && (
+                    <Card className="p-5">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <h3 className="mb-1">포트폴리오 관리</h3>
+                                <p className="text-sm text-muted-foreground">개인화된 질문을 받아보세요</p>
+                            </div>
+                            <Button variant="ghost" size="icon" className="rounded-full">
+                                <ChevronRight className="w-5 h-5" />
+                            </Button>
                         </div>
-                        <Button variant="ghost" size="icon" className="rounded-full">
-                            <ChevronRight className="w-5 h-5" />
-                        </Button>
-                    </div>
-                </Card>
+                    </Card>
+                )}
 
                 {/* Recent Activities */}
                 <section>

--- a/src/app/pages/RealInterview.jsx
+++ b/src/app/pages/RealInterview.jsx
@@ -6,6 +6,8 @@ import { toast } from 'sonner';
 
 import { AppHeader } from '@/app/components/AppHeader';
 
+const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
+
 const RealInterview = () => {
     const navigate = useNavigate();
 
@@ -26,11 +28,13 @@ const RealInterview = () => {
             description: '대규모 아키텍처 및 분산 시스템 설계 연습',
             gradient: 'from-rose-500 to-pink-600',
         },
-        {
-            title: '개별 포트폴리오',
-            description: '내 프로젝트 기반의 1:1 맞춤형 기술 면접',
-            gradient: 'from-pink-600 to-rose-600',
-        },
+        ...(SHOW_PORTFOLIO_INTERVIEW
+            ? [{
+                title: '개별 포트폴리오',
+                description: '내 프로젝트 기반의 1:1 맞춤형 기술 면접',
+                gradient: 'from-pink-600 to-rose-600',
+            }]
+            : []),
     ];
 
     return (


### PR DESCRIPTION
## 요약
 - 환경변수(VITE_SHOW_REAL_INTERVIEW)로 실전 모드 URI(`/real-interview`)을 제어할 수 있게 했습니다.
 - 환경변수(VITE_SHOW_PORTFOLIO_INTERVIEW)로 포트폴리오 노출을 제어할 수 있게 했습니다.

## 변경사항
- 실전 모드 URI(`/real-interview`) 노출을 플래그로 퍼블리싱
- 포트폴리오 프로필 페이지 카드 노출을 플래그로 토글
- Vite 환경변수 사용 가이드 추가(.env)

## 관련 이슈
closes https://github.com/100-hours-a-week/17-JinyUs-Q-Feed-FE/issues/19