### PR TITLE
feat:[#64]나의 학습 기록 목록 API 연동

### DIFF
--- a/src/api/answerApi.js
+++ b/src/api/answerApi.js
@@ -3,35 +3,35 @@ import { api, handleResponse } from '@/utils/apiUtils'
 /**
  * 답변 목록 조회 API
  * @param {Object} params
- * @param {string} [params.type] - 답변 타입 (PRACTICE_INTERVIEW, REAL_INTERVIEW, PORTFOLIO_INTERVIEW)
- * @param {string} [params.category] - 질문 카테고리
+ * @param {string} [params.type] - 답변 타입 (PRACTICE_INTERVIEW, REAL_INTERVIEW, PORTFOLIO)
+ * @param {string} [params.category] - 질문 카테고리(OS, NETWORK, DB)
+ * @param {string} [params.questionType] - 질문 타입(CS, SYSTEM_DESIGN)
  * @param {string} [params.dateFrom] - 시작 날짜
  * @param {string} [params.dateTo] - 종료 날짜
  * @param {number} [params.limit=10] - 페이지 크기 (1-50)
  * @param {string} [params.cursor] - Base64 인코딩된 커서
- * @param {string} [params.expand] - 확장 필드 (question, feedback)
  * @param {AbortSignal} [params.signal] - AbortController signal
  * @returns {Promise<Object>} 답변 목록 및 페이지네이션 정보
  */
 export async function fetchAnswers({
   type,
   category,
+  questionType,
   dateFrom,
   dateTo,
   limit = 10,
   cursor,
-  expand,
   signal,
 } = {}) {
   const queryParams = new URLSearchParams()
 
   if (type) queryParams.append('type', type)
   if (category) queryParams.append('category', category)
+  if (questionType) queryParams.append('questionType', questionType)
   if (dateFrom) queryParams.append('dateFrom', dateFrom)
   if (dateTo) queryParams.append('dateTo', dateTo)
   if (limit) queryParams.append('limit', limit.toString())
   if (cursor) queryParams.append('cursor', cursor)
-  if (expand) queryParams.append('expand', expand)
 
   const queryString = queryParams.toString()
   const url = `/api/answers${queryString ? `?${queryString}` : ''}`

--- a/src/app/hooks/useAnswersInfinite.js
+++ b/src/app/hooks/useAnswersInfinite.js
@@ -3,13 +3,15 @@ import { fetchAnswers } from '@/api/answerApi'
 
 const PAGE_SIZE = 10
 
-export function useAnswersInfinite({ type, expand } = {}) {
+export function useAnswersInfinite({ type, category, dateFrom, dateTo } = {}) {
   return useInfiniteQuery({
-    queryKey: ['answers', { type, expand }],
+    queryKey: ['answers', { type, category, dateFrom, dateTo }],
     queryFn: async ({ pageParam = null }) => {
       const response = await fetchAnswers({
         type,
-        expand,
+        category,
+        dateFrom,
+        dateTo,
         cursor: pageParam,
         limit: PAGE_SIZE,
       })


### PR DESCRIPTION
 ## 목적
  - 프론트에서 학습 기록 목록 조회 API 파라미터 정합성을 맞추고,
  - 프로필 화면에서 필터링 UX/가독성을 개선해 실제 사용 흐름에 맞는 목록 탐색을 가능하게 함.
  - 날짜 필터 선택 시 과도한 API 호출 및 스크롤 점프 문제를 해소.

  ## 주요 변경 사항
  - 학습 기록 API 파라미터 정합성 개선
    - `/api/answers` 쿼리 파라미터에 `questionType` 지원(문서 정합성)
    - `expand` 파라미터 제거 및 type 설명 정리
  - 목록 훅 연동 보강
    - `useAnswersInfinite`에 `category`, `dateFrom`, `dateTo` 반영
    - 필터 변경 시 queryKey에 반영하여 캐시/요청 분리
  - 프로필 화면 UI/UX 개선
    - 필터 UI 추가: 모드(연습 고정), 카테고리(드롭다운), 기간(시작/종료일)
    - 기간 필터는 전체 너비로 하단 배치
    - 날짜 입력: 표시 텍스트(YYYY.MM.DD) + 숨김 date input 구조로 네이티브 아이콘 제거
    - 날짜 선택 시 API 호출 디바운스(700ms) 적용
    - 필터 변경 시 스크롤 위치 복원(맨 위로 튀는 문제 방지)
    - 카드 레이아웃 압축 및 질문 텍스트 세로 중앙 정렬
    - 긴 질문은 한 줄 말줄임(`…`) 처리 + 우측 여백 확보
    - 카드 내 피드백 진행바/점수 UI 제거
    - 카드에 카테고리 뱃지 추가(연한 핑크 톤)
  - 기타
    - date input 전용 CSS 제거(텍스트 표시 + 숨김 date input 방식으로 대체)

  ## 구현 의도 / UX 포인트
  - 필터 영역을 상단에 집중 배치해 “탐색 → 결과 확인” 흐름을 명확하게 함.
  - 날짜는 캘린더 터치로만 선택하도록 하여 모바일 UX 일관성 확보.
  - 필터 변경 시 스크롤 유지로 맥락 보존(목록 중간에서 필터를 바꾸는 상황 고려).
  - 카드 높이를 줄이고 질문을 시각적 중심에 배치해 스캔 효율 개선.

  ## 영향 범위
  - API: `src/api/answerApi.js`
  - Hooks: `src/app/hooks/useAnswersInfinite.js`
  - UI: `src/app/pages/ProfileMain.jsx`
  - Styles: `src/index.css`

 # UI
 
<img width="426" height="599" alt="image" src="https://github.com/user-attachments/assets/27081fa0-d860-4910-881f-53b26b52141a" />

## 관련 커밋, 링크
 - #65 