### PR TITLE
feat:[#67] 프로필 학습 통계 API 연동

### DIFF
--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -1,13 +1,12 @@
-import { authFetch, extractErrorMessage } from '@/utils/apiUtils.js'
+import {api, handleResponse} from '@/utils/apiUtils.js'
 
 export async function deleteAccount() {
-  const response = await authFetch('/api/users/me', {
-    method: 'DELETE',
-  })
+  const response = await api.delete('/api/users/me')
 
-  if (!response.ok) {
-    throw new Error(await extractErrorMessage(response, '계정 삭제에 실패했습니다.'))
-  }
+  return handleResponse(response, '/profile', '계정 삭제에 실패했습니다.')
+}
 
-  return true
+export async function fetchUserStats() {
+    const response = await api.get('/api/users/me/stats')
+    return handleResponse(response, '/profile')
 }

--- a/src/app/hooks/useUserStats.js
+++ b/src/app/hooks/useUserStats.js
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchUserStats } from '@/api/userApi'
+
+export function useUserStats() {
+  return useQuery({
+    queryKey: ['userStats'],
+    queryFn: fetchUserStats,
+  })
+}

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -10,6 +10,7 @@ import { ChevronDown, ChevronRight, Calendar, Target, Award, Loader2 } from 'luc
 import { useAuth } from '@/context/AuthContext';
 import { AppHeader } from '@/app/components/AppHeader';
 import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
+import { useUserStats } from "@/app/hooks/useUserStats.js";
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
 
@@ -196,10 +197,13 @@ const ProfileMain = () => {
         return () => observer.disconnect();
     }, [observerCallback]);
 
+    const { data: statsData } = useUserStats();
+    const userStats = statsData?.data;
+
     const stats = [
-        { icon: Calendar, label: '총 학습일', value: '12일' },
-        { icon: Target, label: '연습 횟수', value: '24회' },
-        { icon: Award, label: '평균 점수', value: '85점' },
+        { icon: Calendar, label: '총 학습일', value: `${userStats?.distinct_days ?? '-'}일` },
+        { icon: Target, label: '연습 횟수', value: `${userStats?.practice_mode_count ?? '-'}회` },
+        { icon: Award, label: '총 답변 수', value: `${userStats?.total_questions_answered ?? '-'}개` },
     ];
 
     return (


### PR DESCRIPTION
## 요약
  - 프로필 화면 학습 통계를 `GET /api/users/me/stats` API로 연동
  - `useUserStats` React Query 훅 추가
  - 하드코딩 stats → 총 학습일 / 연습 횟수 / 총 답변 수 실데이터 반영

## Issue
  - Closes #67

## 화면
<img width="440" height="940" alt="image" src="https://github.com/user-attachments/assets/a660168d-9df4-4ce1-acd6-e2e4d8f65f49" />
