### PR TITLE
fix:[#78]질문 목록, 답변 준비 UI내 키워드 제거

### DIFF
--- a/src/app/pages/PracticeAnswer.jsx
+++ b/src/app/pages/PracticeAnswer.jsx
@@ -50,16 +50,6 @@ const PracticeAnswer = () => {
                     <p className="text-sm text-muted-foreground mb-4">
                         {question.description}
                     </p>
-                    <div className="flex flex-wrap gap-2">
-                        {question.keywords.map((keyword, idx) => (
-                            <span
-                                key={idx}
-                                className="text-xs px-3 py-1 bg-white text-rose-700 rounded-full border border-rose-200"
-                            >
-                                {keyword}
-                            </span>
-                        ))}
-                    </div>
                 </Card>
 
                 <Card className="p-6">

--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -53,6 +53,10 @@ const PracticeMain = () => {
     const observerRef = useRef(null);
 
     useEffect(() => {
+        setSelectedQuestion(null);
+    }, [setSelectedQuestion]);
+
+    useEffect(() => {
         if (prevCategoryRef.current !== selectedCategory) {
             prevCategoryRef.current = selectedCategory;
             // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -216,22 +220,6 @@ const PracticeMain = () => {
                                 <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
                                     {question.description}
                                 </p>
-
-                                <div className="flex flex-wrap gap-1">
-                                    {question.keywords.slice(0, 3).map((keyword, idx) => (
-                                        <span
-                                            key={idx}
-                                            className="text-xs px-2 py-1 bg-rose-50 text-rose-700 rounded-full"
-                                        >
-                                            #{keyword}
-                                        </span>
-                                    ))}
-                                    {question.keywords.length > 3 && (
-                                        <span className="text-xs px-2 py-1 text-gray-500">
-                                            +{question.keywords.length - 3}
-                                        </span>
-                                    )}
-                                </div>
                             </Card>
                         ))}
                         {isFetchingNextPage && (


### PR DESCRIPTION
## 요약

  질문 목록(PracticeMain)과 답변 준비(PracticeAnswer) 화면에서 질문 키워드 렌더링을 제거했습니다.

  ## 변경사항

  - 질문 목록 카드에서 키워드 배지/카운트 제거
  - 답변 준비 카드에서 키워드 리스트 제거

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/pages/PracticeMain.jsx
      - src/app/pages/PracticeAnswer.jsx

  ## 구현 의도 / 목적

  - 질문 노출 UI를 단순화하고 키워드 노출을 제한

 ## 변경 내용
| 화면 | 전 | 후 |
|---|---|---|
| 질문목록 페이지 | <img width="489" height="272" alt="image" src="https://github.com/user-attachments/assets/0c7bcee0-5626-431e-9677-b084b16ab590" /> | <img width="484" height="183" alt="image" src="https://github.com/user-attachments/assets/f39849c3-1fcb-44ae-9a7f-bb507fe8e3d8" /> |
| 답변준비 페이지 | <img width="481" height="303" alt="image" src="https://github.com/user-attachments/assets/b5003c20-678e-4923-877b-b19e1d0ea369" /> |  <img width="477" height="169" alt="image" src="https://github.com/user-attachments/assets/05888014-3dc6-42b0-83ff-ccddf53b46ce" /> |
