### PR TITLE
fix:[#79]질문 목록 화면 로드 간 세션 스토리지 초기화

### DIFF
--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -52,6 +52,7 @@ const PracticeMain = () => {
     const prevCategoryRef = useRef(selectedCategory);
     const observerRef = useRef(null);
 
+    // 선택된 질문 Session-Storage-clear
     useEffect(() => {
         setSelectedQuestion(null);
     }, [setSelectedQuestion]);


### PR DESCRIPTION
## 요약

  PracticeMain 렌더 시 세션 스토리지에 남아 있던 SelectedQuestion을 초기화해,
  이전 질문이 의도치 않게 재사용되는 문제를 방지했습니다.

  ## 변경사항

  - PracticeMain 진입 시 selectedQuestion 초기화
      - setSelectedQuestion(null) 호출로 sessionStorage 정리

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/pages/PracticeMain.jsx

  ## 구현 의도 / 목적

  - 연습 목록 재진입 시 이전 선택 질문이 남아있는 혼선을 방지
  - 항상 “새로 질문을 선택하는 흐름”을 보장해 UX 일관성 확보

  ## 관련 Commit, Issue

  - #79 

 ## 수정 내용
| 화면 | 전 | 후 |
| -- | -- | -- |
| 질문 목록 화면 | <img width="1664" height="464" alt="image" src="https://github.com/user-attachments/assets/d510fc8b-920b-4a12-aa31-b28566e96d06" /> |  <img width="1663" height="424" alt="image" src="https://github.com/user-attachments/assets/8b11febd-0c61-469b-8081-55259f5f0fd6" /> |