### PR TITLE
fix:[#81]날짜 필터링 선택 시 화면 깜빡거림

### DIFF
--- a/src/app/hooks/useAnswersInfinite.js
+++ b/src/app/hooks/useAnswersInfinite.js
@@ -19,6 +19,7 @@ export function useAnswersInfinite({ type, category, dateFrom, dateTo } = {}) {
       const { records = [], pagination = {} } = response?.data ?? response ?? {}
       return { records, pagination }
     },
+    placeholderData: (prev) => prev,
     initialPageParam: null,
     getNextPageParam: (lastPage) =>
       lastPage.pagination.hasNext ? lastPage.pagination.nextCursor : undefined,


### PR DESCRIPTION
  ## 요약

  필터 변경 시 목록 데이터가 비워지며 스크롤이 위로 튀는 현상을 줄이기 위해,
  답변 목록 쿼리에서 이전 데이터를 유지하도록 처리했습니다.

  ## 변경사항

  - 답변 목록 조회 시 이전 데이터 유지
      - useAnswersInfinite에 placeholderData 적용

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/hooks/useAnswersInfinite.js

  ## 구현 의도 / 목적

  - 필터 변경 순간 리스트가 비워지며 발생하는 화면 깜빡임/스크롤 점프를 방지
  - 사용자가 보고 있던 목록 위치와 컨텍스트를 최대한 유지

  ## 관련 Commit, Issue


  - #81 

  ## 변경 내용
### 전
https://github.com/user-attachments/assets/37c435af-d47b-40e3-91ba-75bce83be378

### 후
https://github.com/user-attachments/assets/f642ac15-edf5-430a-9fb8-e196ea3d5458

