### PR TITLE
fix:[#76]질문 타입,카테고리 하드코딩 내용 삭제

### DIFF
--- a/src/api/questionApi.js
+++ b/src/api/questionApi.js
@@ -76,3 +76,13 @@ export async function fetchTags() {
 export async function fetchQuestionTags(questionId) {
     return api.get(`/api/questions/${questionId}/tags`, { parseResponse: true });
 }
+
+// 질문 카테고리 목록 조회
+export async function fetchQuestionCategories() {
+    return api.get('/api/questions/categories', { parseResponse: true });
+}
+
+// 질문 타입 목록 조회
+export async function fetchQuestionTypes() {
+    return api.get('/api/questions/types', { parseResponse: true });
+}

--- a/src/app/hooks/useQuestionCategories.js
+++ b/src/app/hooks/useQuestionCategories.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchQuestionCategories } from '@/api/questionApi'
+
+function mapCategories(response) {
+  const data = response?.data ?? response ?? {}
+  const categories = data.categories ?? {}
+  return categories && typeof categories === 'object' ? categories : {}
+}
+
+export function useQuestionCategories() {
+  return useQuery({
+    queryKey: ['questions', 'categories'],
+    queryFn: async () => {
+      const response = await fetchQuestionCategories()
+      return mapCategories(response)
+    },
+  })
+}

--- a/src/app/hooks/useQuestionTypes.js
+++ b/src/app/hooks/useQuestionTypes.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchQuestionTypes } from '@/api/questionApi'
+
+function mapTypes(response) {
+  const data = response?.data ?? response ?? {}
+  const types = data.types ?? {}
+  return types && typeof types === 'object' ? types : {}
+}
+
+export function useQuestionTypes() {
+  return useQuery({
+    queryKey: ['questions', 'types'],
+    queryFn: async () => {
+      const response = await fetchQuestionTypes()
+      return mapTypes(response)
+    },
+  })
+}

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -7,16 +7,9 @@ import { Sparkles, TrendingUp, Calendar } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import { useRecommendedQuestion } from '@/app/hooks/useRecommendedQuestion';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
+import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 
 import { AppHeader } from '@/app/components/AppHeader';
-
-const CATEGORY_LABEL_MAP = {
-    OS: '운영체제',
-    NETWORK: '네트워크',
-    DB: '데이터베이스',
-    COMPUTER_ARCHITECTURE: '컴퓨터 구조',
-    DATA_STRUCTURE_ALGORITHM: '자료구조&알고리즘',
-};
 
 const TEXT_RECOMMENDATION_LOADING = '추천 질문을 불러오는 중...';
 const TEXT_RECOMMENDATION_ERROR = '추천 질문을 불러오지 못했습니다.';
@@ -28,6 +21,7 @@ const Home = () => {
     const { nickname } = useAuth();
 
     const { data: weeklyStatsData } = useWeeklyStats();
+    const { data: categoryMap = {} } = useQuestionCategories();
 
     const today = new Date().toISOString().slice(0, 10);
     const DAYS = ['월', '화', '수', '목', '금', '토', '일'];
@@ -92,7 +86,7 @@ const Home = () => {
                             <>
                                 <div className="flex items-start justify-between mb-3">
                                     <Badge variant="secondary" className="bg-rose-100 text-rose-700">
-                                        {CATEGORY_LABEL_MAP[todayQuestion?.category] || todayQuestion?.category || '추천'}
+                                        {categoryMap[todayQuestion?.category] || todayQuestion?.category || '추천'}
                                     </Badge>
                                 </div>
 

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -11,6 +11,7 @@ import { useAuth } from '@/context/AuthContext';
 import { AppHeader } from '@/app/components/AppHeader';
 import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 import { useUserStats } from '@/app/hooks/useUserStats.js';
+import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
 
@@ -21,23 +22,6 @@ const ANSWER_TYPE_LABELS = {
 };
 
 const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
-
-const CATEGORY_OPTIONS = [
-    { value: 'ALL', label: '전체' },
-    { value: 'OS', label: 'OS' },
-    { value: 'NETWORK', label: '네트워크' },
-    { value: 'DB', label: 'DB' },
-    { value: 'COMPUTER_ARCHITECTURE', label: '컴퓨터 구조' },
-    { value: 'DATA_STRUCTURE_ALGORITHM', label: '자료구조/알고리즘' },
-];
-
-const CATEGORY_LABELS = {
-    OS: 'OS',
-    NETWORK: '네트워크',
-    DB: 'DB',
-    COMPUTER_ARCHITECTURE: '컴퓨터 구조',
-    DATA_STRUCTURE_ALGORITHM: '자료구조/알고리즘',
-};
 
 const toDateInputValue = (date) => {
     const year = date.getFullYear();
@@ -78,6 +62,7 @@ const formatDateDisplay = (dateString) => {
 const ProfileMain = () => {
     const navigate = useNavigate();
     const { nickname } = useAuth();
+    const { data: categoryMap = {} } = useQuestionCategories();
 
     const observerRef = useRef(null);
     const categoryDropdownRef = useRef(null);
@@ -96,6 +81,14 @@ const ProfileMain = () => {
     const [isCategoryOpen, setIsCategoryOpen] = useState(false);
 
     const categoryValue = categoryFilter === 'ALL' ? undefined : categoryFilter;
+
+    const categoryOptions = useMemo(
+        () => [
+            { value: 'ALL', label: '전체' },
+            ...Object.entries(categoryMap).map(([value, label]) => ({ value, label })),
+        ],
+        [categoryMap]
+    );
 
     const requestScrollRestore = () => {
         scrollPositionRef.current = window.scrollY;
@@ -305,7 +298,7 @@ const ProfileMain = () => {
                                         aria-haspopup="listbox"
                                         aria-expanded={isCategoryOpen}
                                     >
-                                        {CATEGORY_OPTIONS.find((option) => option.value === categoryFilter)
+                                        {categoryOptions.find((option) => option.value === categoryFilter)
                                             ?.label ?? '전체'}
                                         <ChevronDown
                                             className={`transition-transform ${isCategoryOpen ? 'rotate-180' : ''}`}
@@ -314,7 +307,7 @@ const ProfileMain = () => {
 
                                     {isCategoryOpen && (
                                         <Card className="absolute z-30 mt-2 w-full gap-0 p-1 shadow-lg">
-                                            {CATEGORY_OPTIONS.map((option) => (
+                                            {categoryOptions.map((option) => (
                                                 <button
                                                     key={option.value}
                                                     type="button"
@@ -399,7 +392,7 @@ const ProfileMain = () => {
                                                 variant="secondary"
                                                 className="bg-rose-50 text-rose-600 w-fit text-[11px]"
                                             >
-                                                {CATEGORY_LABELS[activity.question.category] ||
+                                                {categoryMap[activity.question.category] ||
                                                     activity.question.category}
                                             </Badge>
                                         )}


### PR DESCRIPTION
  ## 요약

  BE에서 추가된 질문 카테고리/타입 조회 API를 연동하고, 기존 하드코딩된 옵션/라벨을 제거해 프론트에서 유연하게 확장되도록 수정했습니다.

  ## 변경사항

  - 질문 카테고리/타입 조회 API 추가 (/api/questions/categories, /api/questions/types)
  - 공통 훅 추가로 카테고리/타입 데이터 관리
  - PracticeMain/Home/ProfileMain의 하드코딩된 옵션/라벨 제거 및 API 결과로 대체
  - PracticeMain 타입 필터에서 PORTFOLIO 제외, SYSTEM_DESIGN은 플래그 기반 노출

  ## 수정/추가/삭제 파일

  - 추가
      - src/app/hooks/useQuestionCategories.js
      - src/app/hooks/useQuestionTypes.js
  - 수정
      - src/api/questionApi.js
      - src/app/pages/PracticeMain.jsx
      - src/app/pages/Home.jsx
      - src/app/pages/ProfileMain.jsx

 ## 관련 커밋
 - #76 
 - 100-hours-a-week/17-JinyUs-Q-Feed-BE/pull/138

  ## 구현 의도 / 목적

  - 질문 카테고리/타입 변경 시 FE 수정 없이 유연하게 확장 가능하도록 개선