### PR TITLE
fix:[#83]AI 피드백 결과 리스트 표시

### DIFF
--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -15,7 +15,6 @@ const TEXT_STRENGTHS_TITLE = '잘한 점';
 const TEXT_IMPROVEMENTS_TITLE = '개선하면 좋은 점';
 const TEXT_COMPLETE_TITLE = '분석 완료!';
 const TEXT_COMPLETE_DESC = '답변을 꼼꼼히 분석했어요';
-const TEXT_NEXT_GOAL_PREFIX = '💡 다음 목표:';
 const TEXT_NEXT_GOAL = '실제 프로젝트 경험과 연결하여 답변하면 더욱 인상적입니다!';
 const TEXT_HOME_BUTTON = '홈으로 이동';
 const TEXT_AI_FEEDBACK_TITLE = 'AI 피드백';
@@ -24,7 +23,7 @@ const TEXT_BAD_CASE_IMPROVEMENTS = '조금만 더 자세히 설명해도 충분�
 const TEXT_HEADER_EMOJI = '🎯';
 const TEXT_RADAR_LABEL = '평가';
 const FEEDBACK_SECTION_DELIMITER = '\n\n';
-const FEEDBACK_BULLET = '•';
+const FEEDBACK_DELIMITER = '●';
 const FEEDBACK_DASH = '-';
 
 const PracticeResultAI = () => {
@@ -60,15 +59,15 @@ const PracticeResultAI = () => {
     const renderFeedbackText = (text, className) => {
         const normalized = text.replace(/\n+/g, '\n').trim();
         const lines = normalized
-            ? normalized.split(FEEDBACK_BULLET).map((line) => line.trim()).filter(Boolean)
+            ? normalized.split(FEEDBACK_DELIMITER).map((line) => line.trim()).filter(Boolean)
             : [];
         return (
             <div className={`space-y-2 ${className}`}>
                 {lines.map((line, idx) => {
                     const content = line.startsWith(FEEDBACK_DASH) ? line.slice(1).trim() : line;
                     return (
-                        <p key={idx} className="leading-relaxed pl-4 relative">
-                            <span className="absolute left-0">{FEEDBACK_BULLET}</span>
+                        <p key={idx} className="leading-relaxed pl-5 relative">
+                            <span className="absolute left-0">{FEEDBACK_DELIMITER}</span>
                             {content}
                         </p>
                     );
@@ -166,13 +165,6 @@ const PracticeResultAI = () => {
                         </div>
                     </Card>
                 </>
-
-                <div className="bg-gradient-to-r from-rose-100 to-pink-100 rounded-xl p-4">
-                    <p className="text-sm text-rose-900 text-center">
-                        <span className="font-semibold">{TEXT_NEXT_GOAL_PREFIX}</span> {TEXT_NEXT_GOAL}
-                    </p>
-                </div>
-
                 <Button
                     onClick={() => {
                         clearSelectedQuestion();


### PR DESCRIPTION
## 요약

  AI 피드백 텍스트에서 ● 구분자를 기준으로 문단을 분리하고, 들여쓰기를 적용해 가독성을 개선했습니다. 구분자 상수명도 용도에 맞게 변경했습니다.

  ## 변경사항

  - ● 기준으로 피드백 문단 분리 렌더링
  - 들여쓰기 적용
  - 상수명 FEEDBACK_BULLET → FEEDBACK_DELIMITER 변경

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/pages/PracticeResultAI.jsx

  ## 관련 커밋

  - #83 

 ## 변경 내용
| 화면 | 전 | 후 |
|---|---|---|
| AI피드백 조회 페이지 | <img width="499" height="673" alt="Image" src="https://github.com/user-attachments/assets/39b70e9f-d99e-4f81-96b5-656bec86ee5a" /> | <img width="475" height="747" alt="Image" src="https://github.com/user-attachments/assets/8be142fc-fc59-4915-b6e4-690b1c5fc1ae" /> |
