### PR TITLE
refactor:[#100] 홈 차트,프로필 카운트 업, 설정 화면 정리

### DIFF
--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -64,7 +64,7 @@ const WeeklyChart = ({ data, maxValue, totalThisWeek }) => {
                 </span>
             </div>
             <div className="weekly-chart">
-                {sortedData.map((dayData, index) => {
+                {sortedData.map((dayData) => {
                     const height = dayData.count > 0 
                         ? `${Math.min((dayData.count / maxValue) * 100, 100)}%` 
                         : '6px';
@@ -74,7 +74,10 @@ const WeeklyChart = ({ data, maxValue, totalThisWeek }) => {
                             <div className="day-bar-container">
                                 <div
                                     className={`day-bar ${dayData.count > 0 ? 'filled' : 'empty'}`}
-                                    style={{ height }}
+                                    style={{
+                                        height,
+                                        background: dayData.count > 0 ? 'linear-gradient(180deg, #FF8FA3, #FF6B8A)' : '#f3f4f6'
+                                    }}
                                 >
                                     {dayData.count > 0 && (
                                         <span className="bar-count">{dayData.count}</span>

--- a/src/app/pages/SettingMain.jsx
+++ b/src/app/pages/SettingMain.jsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
 import { Switch } from '@/app/components/ui/switch';
 import {
@@ -12,7 +11,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '@/app/components/ui/alert-dialog';
-import { Bell, HelpCircle, LogOut, Trash2, ChevronRight } from 'lucide-react';
+import { Bell, HelpCircle, LogOut, Trash2 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import { toast } from 'sonner';
 import { useState } from 'react';
@@ -69,15 +68,9 @@ const SettingMain = () => {
             items: [
                 {
                     icon: HelpCircle,
-                    label: '자주 묻는 질문',
-                    action: <ChevronRight className="w-5 h-5 text-muted-foreground" />,
-                    onClick: () => toast.info('FAQ 페이지로 이동합니다'),
-                },
-                {
-                    icon: HelpCircle,
-                    label: '문의하기',
-                    action: <ChevronRight className="w-5 h-5 text-muted-foreground" />,
-                    onClick: () => toast.info('문의 페이지로 이동합니다'),
+                    label: '의견 보내기',
+                    action: <span className="text-sm text-muted-foreground">devqfeed@gmail.com</span>,
+                    onClick: () => window.open('mailto:devqfeed@gmail.com?subject=[QFeed] 의견'),
                 },
             ],
         },
@@ -89,12 +82,6 @@ const SettingMain = () => {
                     label: '로그아웃',
                     onClick: () => setShowLogoutDialog(true),
                     textColor: 'text-foreground',
-                },
-                {
-                    icon: Trash2,
-                    label: '회원 탈퇴',
-                    onClick: () => setShowDeleteDialog(true),
-                    textColor: 'text-destructive',
                 },
             ],
         },


### PR DESCRIPTION
## 요약
- 홈 주간 차트 스타일을 개선하고, 프로필 카운트업 훅을 안정화했습니다.
- 설정 화면에서 “의견 보내기” 메일 링크로 동선을 단순화하고 불필요 항목을 제거했습니다.

## 변경사항
- **Home**
  - 주간 차트 바 그라데이션 적용 및 렌더 개선
- **Profile**
  - 카운트업 훅 안정화(raf 정리)
  - 카테고리 색상 매핑 로직 정리
- **Settings**
  - “의견 보내기” 메일 링크 추가
  - FAQ/문의/회원탈퇴 항목 제거
