### PR TITLE
Fix:[#106] QA 디자인 수정

### DIFF
--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -140,11 +140,6 @@ const Home = () => {
         navigate(`/practice/answer/${todayQuestion.id}`);
     };
 
-    // 난이도 계산 (임시로 키워드 개수 기반)
-    const difficulty = todayQuestion?.keywords?.length || 0;
-    const difficultyLevel = difficulty <= 2 ? 1 : difficulty <= 4 ? 2 : 3;
-    const difficultyText = difficultyLevel === 1 ? '초급' : difficultyLevel === 2 ? '중급' : '고급';
-
     return (
         <div className="home-container">
             {/* 인사 섹션 */}
@@ -190,20 +185,10 @@ const Home = () => {
                                 </Badge>
                                 <p className="question-text">{todayQuestion?.title}</p>
                                 <div className="question-footer">
-                                    <div className="question-difficulty">
-                                        <div className="difficulty-dots">
-                                            {[1, 2, 3].map((level) => (
-                                                <span
-                                                    key={level}
-                                                    className={`difficulty-dot ${level <= difficultyLevel ? 'active' : ''}`}
-                                                />
-                                            ))}
-                                        </div>
-                                        {difficultyText}
-                                    </div>
                                     <button
                                         onClick={handleStartPractice}
                                         className="start-btn"
+                                        style={{ marginLeft: 'auto' }}
                                     >
                                         <Play size={16} />
                                         연습 시작

--- a/src/app/pages/PracticeAnswer.jsx
+++ b/src/app/pages/PracticeAnswer.jsx
@@ -9,6 +9,10 @@ import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
+const TEXT_ANSWER_TIP_LINES = [
+    '실제 면접관에게 설명한다는 생각으로 1분 이상 답변해 보세요.',
+    '답변이 자세할수록 피드백도 정확해요.',
+];
 
 const PracticeAnswer = () => {
     const navigate = useNavigate();
@@ -88,7 +92,12 @@ const PracticeAnswer = () => {
 
                 <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
                     <p className="text-sm text-amber-800">
-                        <span className="font-semibold">💡 Tip:</span> 면접관에게 설명한다는 생각으로 답변해보세요. 키워드를 모두 포함하려고 노력해주세요.
+                        <span className="font-semibold">💡 Tip:</span>
+                        {TEXT_ANSWER_TIP_LINES.map((line) => (
+                            <span key={line} className="block pl-5">
+                                {line}
+                            </span>
+                        ))}
                     </p>
                 </div>
             </div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,7 +15,7 @@
   --primary-700: #C73E5C;
 
   /* Secondary Colors (웜 베이지) */
-  --secondary-50: #FFFBF5;
+  --secondary-50: #FAFAFA;
   --secondary-100: #FFF7ED;
   --secondary-200: #FFECD9;
   --secondary-300: #FFD9B8;


### PR DESCRIPTION
## 요약

  홈 화면 난이도 요소를 제거하고, 주요 화면 배경색을 통일해 UI 일관성을 높였습니다.
  또한 답변 준비 화면 Tip 문구를 개선하고, 나의 학습기록 날짜 필터에 범위 제한 정책을 적용해 잘못된 조회 조건을 방지했습니다.

  ## 변경사항

  - 홈 화면 난이도 관련 UI 제거
  - 주요 화면 배경색 스타일 통일
  - 답변 준비 화면 Tip 문구 수정
  - 나의 학습기록 날짜 필터 제한 적용

  ## 날짜 필터링 정책 (ProfileMain)

  - 서비스 오픈일(2026-02-04) 이전 날짜는 조회 불가
  - 조회 종료일은 페이지 진입일(accessDate) 이후 선택 불가
  - 기본 조회 기간은 최근 1개월이며, 시작일이 오픈일보다 빠르면 오픈일로 보정
  - 시작일 > 종료일이 되면 종료일을 시작일로 자동 보정
  - 종료일 < 시작일이 되면 시작일을 종료일(최소 오픈일)로 자동 보정
  - 날짜 변경 시 700ms 디바운스 후 조회 API 재호출

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/pages/Home.jsx
      - src/app/pages/PracticeAnswer.jsx
      - src/app/pages/ProfileMain.jsx
      - (배경색 통일 반영 스타일 파일이 있다면 추가)

  ## 관련 커밋

  - #106 

  ## 구현 의도 / 목적

  - 화면 간 시각적 일관성 향상
  - 사용자 입력 실수(잘못된 날짜 범위) 예방
  - 답변 가이드 문구 명확화로 피드백 경험 개선