### PR TITLE
feat:[#112] 설문 링크 추가 및 이번주 학습 목표 수정

### DIFF
--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -246,6 +246,7 @@ const ProfileMain = () => {
     const { data: statsData } = useUserStats();
     const userStats = statsData?.data;
     const { data: weeklyStatsData } = useWeeklyStats();
+    const weeklyStats = weeklyStatsData?.data;
 
     const stats = [
         { icon: Calendar, label: '총 학습일', value: `${userStats?.distinct_days ?? '-'}일` },
@@ -271,7 +272,7 @@ const ProfileMain = () => {
     }, [categoryMap]);
 
     // 주간 목표 계산
-    const totalThisWeek = weeklyStatsData?.total_this_week ?? 0;
+    const totalThisWeek = weeklyStats.total_this_week ?? 0;
     const weeklyGoal = 7; // 목표값
     const weeklyProgress = Math.min((totalThisWeek / weeklyGoal) * 100, 100);
     const remainingCount = Math.max(weeklyGoal - totalThisWeek, 0);
@@ -301,6 +302,15 @@ const ProfileMain = () => {
                             면접 준비 중
                         </span>
                     </div>
+                    <a
+                        className="btn-secondary"
+                        href="https://forms.gle/nraq9VyYzQogYgFSA"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ marginLeft: 'auto' }}
+                    >
+                        피드백 남기기
+                    </a>
                 </div>
             </section>
 

--- a/src/app/pages/SettingMain.jsx
+++ b/src/app/pages/SettingMain.jsx
@@ -68,6 +68,12 @@ const SettingMain = () => {
             items: [
                 {
                     icon: HelpCircle,
+                    label: '피드백 남기기',
+                    action: <span className="text-sm text-muted-foreground"></span>,
+                    onClick: () => window.open('https://forms.gle/nraq9VyYzQogYgFSA', '_blank', 'noopener,noreferrer'),
+                },
+                {
+                    icon: HelpCircle,
                     label: '의견 보내기',
                     action: <span className="text-sm text-muted-foreground">devqfeed@gmail.com</span>,
                     onClick: () => window.open('mailto:devqfeed@gmail.com?subject=[QFeed] 의견'),


### PR DESCRIPTION
## 요약
프로필 카드와 설정 화면에 서비스 설문 링크를 추가했습니다.

## 변경사항
- ProfileMain
  - 프로필 카드 우측에 설문 링크 버튼 추가
  - 이번주 학습 목표 데이터 가져올 수 있도록 수정
- SettingMain: 고객센터 섹션에 설문 참여 항목 추가

## 변경 파일
- `frontend/src/app/pages/ProfileMain.jsx`
- `frontend/src/app/pages/SettingMain.jsx`

## 관련 이슈
- #112