### PR TITLE
feat:[#114]프로필 학습 기록 상세(질문/답변/레이더/AI 피드백) 화면 추가

### DIFF
--- a/src/api/answerApi.js
+++ b/src/api/answerApi.js
@@ -42,6 +42,30 @@ export async function fetchAnswers({
 }
 
 /**
+ * 답변 상세 조회 API
+ * @param {number|string} answerId - 답변 ID
+ * @param {Object} [params]
+ * @param {string|string[]} [params.expand] - 확장 필드
+ * @param {AbortSignal} [params.signal] - AbortController signal
+ * @returns {Promise<Object>} 답변 상세 정보
+ */
+export async function fetchAnswerDetail(
+  answerId,
+  { expand = ['question', 'feedback', 'immediate_feedback'], signal } = {}
+) {
+  const queryParams = new URLSearchParams()
+  const expandValue = Array.isArray(expand) ? expand.join(',') : expand
+
+  if (expandValue) queryParams.append('expand', expandValue)
+
+  const queryString = queryParams.toString()
+  const url = `/api/answers/${answerId}${queryString ? `?${queryString}` : ''}`
+
+  const response = await api.get(url, { signal })
+  return handleResponse(response)
+}
+
+/**
  * AI 피드백 조회
  * @param {number|string} answerId
  * @returns {Promise<Object>} 피드백 조회 결과

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -20,6 +20,7 @@ import PracticeAnswerText from '@/app/pages/PracticeAnswerText';
 import PracticeResultKeyword from '@/app/pages/PracticeResultKeyword';
 import PracticeResultAI from '@/app/pages/PracticeResultAI';
 import ProfileMain from '@/app/pages/ProfileMain';
+import LearningRecordDetail from '@/app/pages/LearningRecordDetail';
 import SettingMain from '@/app/pages/SettingMain';
 import RealInterview from '@/app/pages/RealInterview';
 import OAuthCallback from '@/app/pages/OAuthCallback';
@@ -66,6 +67,7 @@ function AppRoutes() {
 
                         {/* Profile */}
                         <Route path="/profile" element={<ProfileMain />} />
+                        <Route path="/profile/records/:answerId" element={<LearningRecordDetail />} />
                         <Route path="/settings" element={<SettingMain />} />
 
                         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/app/hooks/useAnswerDetail.js
+++ b/src/app/hooks/useAnswerDetail.js
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchAnswerDetail } from '@/api/answerApi'
+
+export function useAnswerDetail(answerId) {
+  return useQuery({
+    queryKey: ['answerDetail', answerId],
+    queryFn: () =>
+      fetchAnswerDetail(answerId, {
+        expand: ['question', 'feedback', 'immediate_feedback'],
+      }),
+    enabled: Boolean(answerId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+}

--- a/src/app/pages/LearningRecordDetail.jsx
+++ b/src/app/pages/LearningRecordDetail.jsx
@@ -1,0 +1,279 @@
+import { useMemo } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { AppHeader } from '@/app/components/AppHeader'
+import { Card } from '@/app/components/ui/card'
+import { Button } from '@/app/components/ui/button'
+import { Badge } from '@/app/components/ui/badge'
+import { AlertCircle, Home, Loader2, Sparkles, ThumbsUp } from 'lucide-react'
+import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, ResponsiveContainer } from 'recharts'
+import { useAnswerDetail } from '@/app/hooks/useAnswerDetail'
+import { useQuestionCategories } from '@/app/hooks/useQuestionCategories'
+import { useQuestionTypes } from '@/app/hooks/useQuestionTypes'
+
+const TEXT_PAGE_TITLE = '학습 기록 상세'
+const TEXT_HEADER_DESC = '제출한 답변과 AI 피드백을 확인해보세요'
+const TEXT_LOADING = '학습 기록을 불러오는 중...'
+const TEXT_NOT_FOUND = '학습 기록을 찾을 수 없습니다'
+const TEXT_QUESTION_LABEL = '질문'
+const TEXT_MY_ANSWER_LABEL = '내 답변'
+const TEXT_STRENGTHS_TITLE = '잘한 점'
+const TEXT_IMPROVEMENTS_TITLE = '개선하면 좋은 점'
+const TEXT_RADAR_TITLE = '답변 평가'
+const TEXT_FEEDBACK_EMPTY = '아직 AI 피드백이 준비되지 않았습니다.'
+const TEXT_GO_PROFILE = '학습 기록으로 돌아가기'
+const TEXT_RETRY_HELP = '잠시 후 다시 시도해 주세요.'
+const FEEDBACK_SECTION_DELIMITER = '\n\n'
+const FEEDBACK_SPLIT_DELIMITER = '●'
+const FEEDBACK_BULLET = '•'
+const FEEDBACK_DASH = '-'
+
+const formatDateTime = (dateString) => {
+  if (!dateString) return ''
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) return dateString
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const hour = String(date.getHours()).padStart(2, '0')
+  const minute = String(date.getMinutes()).padStart(2, '0')
+  return `${year}년 ${month}월 ${day}일 ${hour}:${minute} 답변했어요`
+}
+
+const normalizeRadarValue = (metric) => {
+  const score = Number(metric?.score)
+  const maxScore = Number(metric?.maxScore)
+
+  if (Number.isNaN(score)) return 0
+
+  if (!Number.isNaN(maxScore) && maxScore > 0) {
+    return Math.min(100, Math.max(0, Math.round((score / maxScore) * 100)))
+  }
+
+  // maxScore가 내려오지 않을 때 1~5 스케일을 1~100으로 변환한다.
+  if (score >= 0 && score <= 5) {
+    return Math.min(100, Math.max(0, Math.round((score / 5) * 100)))
+  }
+
+  return Math.min(100, Math.max(0, Math.round(score)))
+}
+
+const renderFeedbackText = (text, className) => {
+  const normalized = (text || '').replace(/\n+/g, '\n').trim()
+  const lines = normalized
+    ? normalized.split(FEEDBACK_SPLIT_DELIMITER).map((line) => line.trim()).filter(Boolean)
+    : []
+
+  if (lines.length === 0) {
+    return <p className={className}>{TEXT_FEEDBACK_EMPTY}</p>
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {lines.map((line, idx) => {
+        const content = line.startsWith(FEEDBACK_DASH) ? line.slice(1).trim() : line
+        return (
+          <p key={idx} className="leading-relaxed pl-5 relative">
+            <span className="absolute left-0">{FEEDBACK_BULLET}</span>
+            {content}
+          </p>
+        )
+      })}
+    </div>
+  )
+}
+
+const LearningRecordDetail = () => {
+  const navigate = useNavigate()
+  const { answerId } = useParams()
+  const { data, isLoading, error } = useAnswerDetail(answerId)
+  const { data: CATEGORY_LABELS = {} } = useQuestionCategories()
+  const { data: QUESTION_TYPE_LABELS = {} } = useQuestionTypes()
+
+  const answerDetail = data?.data ?? data ?? {}
+  const hasAnswerDetail = Boolean(answerDetail?.answerId)
+  const detail = answerDetail
+  const question = detail?.question
+  const aiFeedback = detail?.aiFeedback
+  const metrics = Array.isArray(aiFeedback?.metrics) ? aiFeedback.metrics : []
+  const radarData = useMemo(
+    () =>
+      metrics.map((metric) => ({
+        subject: metric?.metricName ?? '평가 항목',
+        value: normalizeRadarValue(metric),
+      })),
+    [metrics]
+  )
+  const hasRadarChart = radarData.length > 0
+
+  const feedbackText = (aiFeedback?.feedback ?? '').trim()
+  const [strengthsText, improvementsText] = feedbackText
+    ? [
+        feedbackText.split(FEEDBACK_SECTION_DELIMITER)[0] || '',
+        feedbackText.split(FEEDBACK_SECTION_DELIMITER)[1] || '',
+      ]
+    : ['', '']
+  const mergedImprovementsText = hasRadarChart
+    ? improvementsText
+    : [strengthsText, improvementsText].filter(Boolean).join('\n')
+  const questionTypeLabel = question?.type ? QUESTION_TYPE_LABELS[question.type] || question.type : null
+  const questionCategory = question?.category ? (
+    <Badge variant="secondary" className="bg-rose-100 text-rose-700">
+      {CATEGORY_LABELS[question.category] || question.category}
+    </Badge>
+  ) : null
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <AppHeader title={TEXT_PAGE_TITLE} onBack={() => navigate('/profile')} showNotifications={false} />
+        <div className="p-6 max-w-lg mx-auto">
+          <Card className="p-6 flex items-center gap-3">
+            <Loader2 className="w-5 h-5 animate-spin text-pink-600" />
+            <p className="text-sm text-muted-foreground">{TEXT_LOADING}</p>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !hasAnswerDetail) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+          <AppHeader
+            title={TEXT_PAGE_TITLE}
+            onBack={() => navigate('/profile')}
+            showNotifications={false}
+            tone="dark"
+            className="!static"
+          />
+          <div className="text-center pb-6 pt-1 px-6">
+            <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+          </div>
+        </div>
+
+        <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
+          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-5 h-5 text-rose-600" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm text-rose-800">{error?.message || TEXT_NOT_FOUND}</p>
+                <p className="text-xs text-rose-700 mt-1">{TEXT_RETRY_HELP}</p>
+              </div>
+            </div>
+          </Card>
+
+          <Button
+            onClick={() => navigate('/profile')}
+            className="w-full rounded-xl h-12 gap-2"
+            variant="default"
+          >
+            <Home className="w-5 h-5" />
+            {TEXT_GO_PROFILE}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+        <AppHeader
+          title={TEXT_PAGE_TITLE}
+          onBack={() => navigate('/profile')}
+          showNotifications={false}
+          tone="dark"
+          className="!static"
+        />
+
+        <div className="text-center pb-6 pt-1 px-6">
+          <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+        </div>
+      </div>
+
+      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
+        <Card className="p-5 bg-white shadow-lg">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-sm text-muted-foreground">{TEXT_QUESTION_LABEL}</p>
+            <div className="flex items-center gap-2">
+              {questionTypeLabel && (
+                <Badge variant="outline" className="text-pink-700 border-pink-200">
+                  {questionTypeLabel}
+                </Badge>
+              )}
+              {questionCategory}
+            </div>
+          </div>
+          <p className="leading-relaxed">{question?.content || TEXT_NOT_FOUND}</p>
+          <p className="text-xs text-muted-foreground text-right mt-3">{formatDateTime(detail?.createdAt)}</p>
+        </Card>
+
+        <Card className="p-5">
+          <p className="text-sm text-muted-foreground mb-2">{TEXT_MY_ANSWER_LABEL}</p>
+          <div className="h-44 overflow-y-auto overscroll-contain pr-1">
+            <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">
+              {detail?.content || '제출한 답변 내용이 없습니다.'}
+            </p>
+          </div>
+        </Card>
+
+        {hasRadarChart && (
+          <Card className="p-5 bg-white shadow-lg">
+            <div className="flex items-center gap-2 mb-4">
+              <Sparkles className="w-5 h-5 text-pink-600" />
+              <h3>{TEXT_RADAR_TITLE}</h3>
+            </div>
+            <ResponsiveContainer width="100%" height={250}>
+              <RadarChart data={radarData}>
+                <PolarGrid />
+                <PolarAngleAxis dataKey="subject" />
+                <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} axisLine={false} />
+                <Radar name="평가" dataKey="value" stroke="#ec4899" fill="#ec4899" fillOpacity={0.6} />
+              </RadarChart>
+            </ResponsiveContainer>
+          </Card>
+        )}
+
+        {hasRadarChart && (
+          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+                <ThumbsUp className="w-5 h-5 text-pink-600" />
+              </div>
+              <div className="flex-1">
+                <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
+                {renderFeedbackText(strengthsText, 'text-sm text-rose-800')}
+              </div>
+            </div>
+          </Card>
+        )}
+
+        <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
+              <AlertCircle className="w-5 h-5 text-pink-600" />
+            </div>
+            <div className="flex-1">
+              <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+              {renderFeedbackText(mergedImprovementsText, 'text-sm text-pink-800')}
+            </div>
+          </div>
+        </Card>
+
+        <Button
+          onClick={() => navigate('/profile')}
+          className="w-full rounded-xl h-12 gap-2"
+          variant="default"
+        >
+          <Home className="w-5 h-5" />
+          {TEXT_GO_PROFILE}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default LearningRecordDetail

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -83,8 +83,27 @@ const StatCard = ({ icon, label, value, unit }) => {
 };
 
 // 학습 기록 아이템 컴포넌트
-const HistoryItem = ({ mode, category, categoryColor, title, date, feedbackAvailable }) => (
-    <div className="history-item">
+const HistoryItem = ({
+    mode,
+    category,
+    categoryColor,
+    title,
+    date,
+    feedbackAvailable,
+    onClick,
+}) => (
+    <div
+        className="history-item"
+        onClick={onClick}
+        onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onClick?.();
+            }
+        }}
+        role="button"
+        tabIndex={0}
+    >
         <div className="history-header">
             <span className="history-mode">{mode}</span>
             <div className="history-meta">
@@ -521,6 +540,7 @@ const ProfileMain = () => {
                                 title={activity.question?.content || '질문 정보 없음'}
                                 date={formatDate(activity.createdAt)}
                                 feedbackAvailable={activity.feedback?.feedbackAvailable}
+                                onClick={() => navigate(`/profile/records/${activity.answerId}`)}
                             />
                         );
                     })}


### PR DESCRIPTION
 ## 요약

  프로필의 학습 기록 리스트에서 개별 기록을 클릭하면 이동하는 **학습 기록 상세 조회 화면**을 추가했습니다.
  상세 화면은 기존 `PracticeResultAI`의 톤/구성을 유지하면서, 실제 답변 상세 API를 기반으로 다음 정보를 순서대로 보여줍니다.

  - 질문
  - 내 답변
  - 레이더 차트
  - AI 피드백(잘한 점 / 개선하면 좋은 점)

  또한 피드백 문자열 포맷(`● ... \n\n ● ...`) 파싱, 레이더 점수 정규화(1~5 → 1~100), 예외 처리(로딩/에러/데이터 없음), 네트워크
  효율(캐시/재요청 최소화)까지 함께 반영했습니다.

  ## 변경사항

  - 답변 상세 조회 API 추가
    - `fetchAnswerDetail(answerId, { expand })` 추가
    - 요청: `GET /api/answers/{answerId}?expand=question,feedback,immediate_feedback`
  - 상세 조회 훅 추가
    - `useAnswerDetail` 추가
    - React Query 설정
      - `staleTime: 5min`
      - `gcTime: 10min`
      - `refetchOnWindowFocus: false`
      - `refetchOnReconnect: false`
  - 학습 기록 상세 페이지 신규 구현
    - `LearningRecordDetail` 페이지 추가
    - UI 구성: 질문 → 내 답변 → 레이더 차트 → AI 피드백
    - 질문 타입/카테고리 라벨은 카테고리/타입 API 훅 기반으로 표시
    - 내 답변 영역은 고정 높이 + 내부 스크롤 처리(`h-44`, `overflow-y-auto`)
  - 피드백 렌더링 로직 반영
    - `\n\n` 기준으로 잘한 점/개선점 분리
    - `●` 기준 항목 분리 후 작은 불릿(`•`)로 렌더링
    - `-` 접두 문장 정리
  - 레이더 차트 예외 분기 개선
    - 레이더 데이터 없을 때:
      - 레이더 카드 숨김
      - 잘한 점 카드 숨김
      - 잘한 점 + 개선점 내용을 개선점 카드로 합쳐 노출
  - 레이더 점수 정규화
    - `maxScore`가 있으면 `(score/maxScore)*100`
    - `maxScore`가 없고 `score`가 1~5 범위면 `1~100`으로 변환
  - 프로필 목록 → 상세 이동 연결
    - `ProfileMain`의 학습 기록 카드 클릭 시 `/profile/records/:answerId` 이동
    - Enter/Space 키보드 접근성 처리
  - 라우팅 추가
    - `/profile/records/:answerId` 등록
  - 예외 처리
    - 로딩 상태 UI
    - 에러/데이터 없음 상태에서 안내 카드 + 복귀 버튼 제공

  ## 수정/추가/삭제 파일

  - 추가
    - `src/app/hooks/useAnswerDetail.js`
    - `src/app/pages/LearningRecordDetail.jsx`
  - 수정
    - `src/api/answerApi.js`
    - `src/app/App.jsx`
    - `src/app/pages/ProfileMain.jsx`
  - 삭제
    - 없음

  ## 구현 의도 / 목적

  - 프로필의 학습 기록을 단순 목록에서 끝내지 않고, **기록별 상세 분석 확인 흐름**으로 확장
  - 기존 `PracticeResultAI`와 시각적/정보 구조를 맞춰 사용자 학습 비용 최소화
  - 피드백 텍스트 포맷의 변동성을 프론트에서 흡수해 안정적인 가독성 제공
  - 단일 상세 API 호출 + 캐시 전략으로 네트워크/서버 부하 최소화

  ## 관련 Commit, Issue
  - #114 

 ## 변경 화면
<img width="508" height="592" alt="image" src="https://github.com/user-attachments/assets/2f0e88ee-6c6a-4de8-a3ab-1304591fba01" />
<img width="496" height="783" alt="image" src="https://github.com/user-attachments/assets/93ff6b2b-120b-48f3-8dc9-56142673fa20" />
<img width="506" height="725" alt="image" src="https://github.com/user-attachments/assets/c49467d1-49b3-40fc-b596-265bde5158f3" />
