### PR TITLE
fix:[#120] 레이더 데이터 메모이제이션 제거

### DIFF
--- a/src/app/pages/LearningRecordDetail.jsx
+++ b/src/app/pages/LearningRecordDetail.jsx
@@ -95,14 +95,11 @@ const LearningRecordDetail = () => {
   const question = detail?.question
   const aiFeedback = detail?.aiFeedback
   const metrics = Array.isArray(aiFeedback?.metrics) ? aiFeedback.metrics : []
-  const radarData = useMemo(
-    () =>
-      metrics.map((metric) => ({
-        subject: metric?.metricName ?? '평가 항목',
-        value: normalizeRadarValue(metric),
-      })),
-    [metrics]
-  )
+  const radarData = (metrics ?? []).map(metric => ({
+    ...metric,
+    value: normalizeRadarValue(metric),
+  }));
+
   const hasRadarChart = radarData.length > 0
 
   const feedbackText = (aiFeedback?.feedback ?? '').trim()


### PR DESCRIPTION
## 요약
React Compiler 경고를 제거하기 위해 레이더 차트 데이터 계산의 useMemo를 제거했습니다.

## 변경사항
- 레이더 차트 데이터 계산을 단순 map으로 변경

## 변경 파일
- `src/app/pages/LearningRecordDetail.jsx`

## 관련 이슈
 - closes #120