### PR TITLE
fix:[#125]LearningRecordDetail 레이더 차트 미표시

### DIFF
--- a/src/app/pages/LearningRecordDetail.jsx
+++ b/src/app/pages/LearningRecordDetail.jsx
@@ -39,8 +39,13 @@ const formatDateTime = (dateString) => {
 }
 
 const normalizeRadarValue = (metric) => {
+  const rawValue = Number(metric?.value)
   const score = Number(metric?.score)
   const maxScore = Number(metric?.maxScore)
+
+  if (!Number.isNaN(rawValue)) {
+    return Math.min(100, Math.max(0, Math.round(rawValue)))
+  }
 
   if (Number.isNaN(score)) return 0
 
@@ -92,12 +97,21 @@ const LearningRecordDetail = () => {
   const hasAnswerDetail = Boolean(answerDetail?.answerId)
   const detail = answerDetail
   const question = detail?.question
-  const aiFeedback = detail?.aiFeedback
-  const metrics = Array.isArray(aiFeedback?.metrics) ? aiFeedback.metrics : []
-  const radarData = (metrics ?? []).map(metric => ({
+  const aiFeedback =
+    detail?.aiFeedback ??
+    detail?.feedback ??
+    detail?.immediateFeedback ??
+    detail?.immediate_feedback
+  const metrics = Array.isArray(aiFeedback?.metrics)
+    ? aiFeedback.metrics
+    : Array.isArray(aiFeedback?.radarChart)
+      ? aiFeedback.radarChart
+      : []
+  const radarData = metrics.map((metric) => ({
     ...metric,
+    subject: metric?.subject ?? metric?.metricName ?? metric?.name ?? metric?.label ?? '평가',
     value: normalizeRadarValue(metric),
-  }));
+  }))
 
   const hasRadarChart = radarData.length > 0
 


### PR DESCRIPTION
  ## 요약

  학습 기록 상세에서 레이더 차트가 보이지 않던 문제를 해결했습니다.
  API 응답 구조 차이(metrics vs radarChart, aiFeedback vs feedback/immediate_feedback)를 고려해 fallback 경로와 라벨 매핑을 보강했습니다.

  ## 변경사항

  - 레이더 차트 데이터 소스 fallback 적용 (aiFeedback → feedback → immediate_feedback)
  - metrics 없을 때 radarChart 데이터 사용
  - subject 키가 없을 경우 metricName/name/label로 매핑
  - value가 이미 있는 경우 기존 값을 그대로 사용

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/pages/LearningRecordDetail.jsx

  ## 관련 커밋

  - #125 

  ## 구현 의도 / 목적

  - 학습 기록 상세 화면에서 레이더 차트 미표시 버그 해결
  - 다양한 응답 스키마를 안전하게 처리해 UI 안정성 확보
<img width="469" height="369" alt="image" src="https://github.com/user-attachments/assets/e23a5d6e-b911-4aa0-ba77-630d9e4f768b" />
