### PR TITLE
Fix/#116 QA 디자인 수정

### DIFF
--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -23,6 +23,10 @@ const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 const TEXT_SUBMITTING = '제출 중...';
 const TEXT_CHARACTER_SUFFIX = '자';
+const TEXT_LIMIT_TITLE = '답변 길이 초과';
+const TEXT_LIMIT_DESC = '답변은 1500자 이내로 작성해주세요.';
+const TEXT_LIMIT_OK = '확인';
+const MAX_ANSWER_LENGTH = 1500;
 
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
@@ -31,11 +35,16 @@ const PracticeAnswerEdit = () => {
 
     const [isEditing, setIsEditing] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
+    const [showLengthWarning, setShowLengthWarning] = useState(false);
     const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();
     const [answer, setAnswer] = useState(state?.transcribedText);
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleToggleEdit = () => {
+        if (isEditing && (answer || '').length > MAX_ANSWER_LENGTH) {
+            setShowLengthWarning(true);
+            return;
+        }
         if (isEditing) {
             toast.success('편집이 완료되었습니다');
         } else {
@@ -111,7 +120,13 @@ const PracticeAnswerEdit = () => {
                         <>
                             <Textarea
                                 value={answer}
-                                onChange={(e) => setAnswer(e.target.value)}
+                                onChange={(e) => {
+                                    const nextValue = e.target.value;
+                                    if (nextValue.length > MAX_ANSWER_LENGTH && (answer || '').length <= MAX_ANSWER_LENGTH) {
+                                        setShowLengthWarning(true);
+                                    }
+                                    setAnswer(nextValue);
+                                }}
                                 className="h-[300px] overflow-y-auto text-base leading-relaxed"
                                 placeholder="답변을 입력하세요..."
                             />
@@ -133,7 +148,7 @@ const PracticeAnswerEdit = () => {
 
                 <Button
                     onClick={handleSubmit}
-                    disabled={!answer.trim() || isSubmitting}
+                    disabled={!answer.trim() || isSubmitting || (answer || '').length > MAX_ANSWER_LENGTH}
                     className="w-full rounded-xl h-12"
                 >
                     {isSubmitting ? TEXT_SUBMITTING : '답변 제출'}
@@ -151,6 +166,22 @@ const PracticeAnswerEdit = () => {
                     <AlertDialogFooter>
                         <AlertDialogCancel>취소</AlertDialogCancel>
                         <AlertDialogAction onClick={confirmSubmit}>제출</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog open={showLengthWarning} onOpenChange={setShowLengthWarning}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{TEXT_LIMIT_TITLE}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {TEXT_LIMIT_DESC}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogAction onClick={() => setShowLengthWarning(false)}>
+                            {TEXT_LIMIT_OK}
+                        </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -22,6 +22,7 @@ import { usePracticeAnswerSubmit } from '@/app/hooks/usePracticeAnswerSubmit';
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 const TEXT_SUBMITTING = '제출 중...';
+const TEXT_CHARACTER_SUFFIX = '자';
 
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
@@ -104,14 +105,19 @@ const PracticeAnswerEdit = () => {
                     <p className="text-sm text-muted-foreground mb-3">나의 답변</p>
 
                     {isEditing ? (
-                        <Textarea
-                            value={answer}
-                            onChange={(e) => setAnswer(e.target.value)}
-                            className="h-[300px] overflow-y-auto text-base leading-relaxed"
-                            placeholder="답변을 입력하세요..."
-                        />
+                        <>
+                            <Textarea
+                                value={answer}
+                                onChange={(e) => setAnswer(e.target.value)}
+                                className="h-[300px] overflow-y-auto text-base leading-relaxed"
+                                placeholder="답변을 입력하세요..."
+                            />
+                            <p className="text-xs text-muted-foreground mt-2">
+                                {(answer || '').length}{TEXT_CHARACTER_SUFFIX}
+                            </p>
+                        </>
                     ) : (
-                        <div className="text-base leading-relaxed whitespace-pre-wrap">
+                        <div className="h-[300px] overflow-y-auto text-base leading-relaxed whitespace-pre-wrap">
                             {answer}
                         </div>
                     )}

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -107,7 +107,7 @@ const PracticeAnswerEdit = () => {
                         <Textarea
                             value={answer}
                             onChange={(e) => setAnswer(e.target.value)}
-                            className="min-h-[300px] text-base leading-relaxed"
+                            className="h-[300px] overflow-y-auto text-base leading-relaxed"
                             placeholder="답변을 입력하세요..."
                         />
                     ) : (

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -57,7 +57,10 @@ const PracticeAnswerEdit = () => {
             answerText: answer,
             onAfterSubmit: (trimmedAnswer) => {
                 navigate(`/practice/result-keyword/${questionId}`, {
-                    state: { answerText: trimmedAnswer },
+                    state: {
+                        answerText: trimmedAnswer,
+                        retryPath: `/practice/answer-voice/${questionId}`,
+                    },
                 });
             },
         });
@@ -117,9 +120,14 @@ const PracticeAnswerEdit = () => {
                             </p>
                         </>
                     ) : (
-                        <div className="h-[300px] overflow-y-auto text-base leading-relaxed whitespace-pre-wrap">
-                            {answer}
-                        </div>
+                        <>
+                            <div className="h-[300px] overflow-y-auto text-base leading-relaxed whitespace-pre-wrap">
+                                {answer}
+                            </div>
+                            <p className="text-xs text-muted-foreground mt-2">
+                                {(answer || '').length}{TEXT_CHARACTER_SUFFIX}
+                            </p>
+                        </>
                     )}
                 </Card>
 

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -53,7 +53,10 @@ const PracticeAnswerText = () => {
             answerText: answer,
             onAfterSubmit: (trimmedAnswer) => {
                 navigate(`/practice/result-keyword/${questionId}`, {
-                    state: { answerText: trimmedAnswer },
+                    state: {
+                        answerText: trimmedAnswer,
+                        retryPath: `/practice/answer-text/${questionId}`,
+                    },
                 });
             },
         });

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -82,7 +82,7 @@ const PracticeAnswerText = () => {
                     <Textarea
                         value={answer}
                         onChange={(e) => setAnswer(e.target.value)}
-                        className="min-h-[300px] text-base leading-relaxed"
+                        className="h-[300px] overflow-y-auto text-base leading-relaxed"
                         placeholder={TEXT_ANSWER_PLACEHOLDER}
                     />
                     <p className="text-xs text-muted-foreground mt-2">

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -30,16 +30,25 @@ const TEXT_ANSWER_PLACEHOLDER = '여기에 답변을 작성해주세요...';
 const TEXT_CHARACTER_SUFFIX = '자';
 const TEXT_CANCEL = '취소';
 const TEXT_SUBMIT = '제출';
+const TEXT_LIMIT_TITLE = '답변 길이 초과';
+const TEXT_LIMIT_DESC = '답변은 1500자 이내로 작성해주세요.';
+const TEXT_LIMIT_OK = '확인';
+const MAX_ANSWER_LENGTH = 1500;
 const PracticeAnswerText = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const [answer, setAnswer] = useState('');
     const [showConfirm, setShowConfirm] = useState(false);
+    const [showLengthWarning, setShowLengthWarning] = useState(false);
     const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleSubmit = () => {
         if (!answer.trim()) {
+            return;
+        }
+        if (answer.length > MAX_ANSWER_LENGTH) {
+            setShowLengthWarning(true);
             return;
         }
         setShowConfirm(true);
@@ -84,7 +93,13 @@ const PracticeAnswerText = () => {
                     <p className="text-sm text-muted-foreground mb-3">{TEXT_ANSWER_LABEL}</p>
                     <Textarea
                         value={answer}
-                        onChange={(e) => setAnswer(e.target.value)}
+                        onChange={(e) => {
+                            const nextValue = e.target.value;
+                            if (nextValue.length > MAX_ANSWER_LENGTH && answer.length <= MAX_ANSWER_LENGTH) {
+                                setShowLengthWarning(true);
+                            }
+                            setAnswer(nextValue);
+                        }}
                         className="h-[300px] overflow-y-auto text-base leading-relaxed"
                         placeholder={TEXT_ANSWER_PLACEHOLDER}
                     />
@@ -95,7 +110,7 @@ const PracticeAnswerText = () => {
 
                 <Button
                     onClick={handleSubmit}
-                    disabled={!answer.trim() || isSubmitting}
+                    disabled={!answer.trim() || isSubmitting || answer.length > MAX_ANSWER_LENGTH}
                     className="w-full rounded-xl h-12"
                 >
                     {isSubmitting ? TEXT_SUBMITTING : TEXT_SUBMIT_BUTTON}
@@ -113,6 +128,22 @@ const PracticeAnswerText = () => {
                     <AlertDialogFooter>
                         <AlertDialogCancel>{TEXT_CANCEL}</AlertDialogCancel>
                         <AlertDialogAction onClick={confirmSubmit}>{TEXT_SUBMIT}</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog open={showLengthWarning} onOpenChange={setShowLengthWarning}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{TEXT_LIMIT_TITLE}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {TEXT_LIMIT_DESC}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogAction onClick={() => setShowLengthWarning(false)}>
+                            {TEXT_LIMIT_OK}
+                        </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -241,7 +241,7 @@ const PracticeAnswerVoice = () => {
       <div className="flex-1 flex flex-col items-center justify-center px-6 py-12">
         <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 mb-8 w-full max-w-lg">
           <p className="text-center text-white/90 text-sm mb-2">질문</p>
-          <h2 className="text-center text-lg">{question.title}</h2>
+          <h2 className="text-center text-lg text-white">{question.title}</h2>
         </div>
 
         {/* Audio Visualizer */}

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -15,7 +15,6 @@ const TEXT_STRENGTHS_TITLE = '잘한 점';
 const TEXT_IMPROVEMENTS_TITLE = '개선하면 좋은 점';
 const TEXT_COMPLETE_TITLE = '분석 완료!';
 const TEXT_COMPLETE_DESC = '답변을 꼼꼼히 분석했어요';
-const TEXT_NEXT_GOAL = '실제 프로젝트 경험과 연결하여 답변하면 더욱 인상적입니다!';
 const TEXT_HOME_BUTTON = '홈으로 이동';
 const TEXT_AI_FEEDBACK_TITLE = 'AI 피드백';
 const TEXT_BAD_CASE_STRENGTHS = '더 잘 할 수 있어요. 지금의 시도가 충분히 의미 있습니다.';
@@ -102,7 +101,7 @@ const PracticeResultAI = () => {
 
                 <div className="text-center pb-6 px-6">
                     <div className="text-5xl mb-2">{TEXT_HEADER_EMOJI}</div>
-                    <h2 className="text-2xl mb-1">{TEXT_COMPLETE_TITLE}</h2>
+                    <h2 className="text-2xl mb-1 text-white">{TEXT_COMPLETE_TITLE}</h2>
                     <p className="text-white/80 text-sm">{TEXT_COMPLETE_DESC}</p>
                 </div>
             </div>

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -22,7 +22,8 @@ const TEXT_BAD_CASE_IMPROVEMENTS = '조금만 더 자세히 설명해도 충분�
 const TEXT_HEADER_EMOJI = '🎯';
 const TEXT_RADAR_LABEL = '평가';
 const FEEDBACK_SECTION_DELIMITER = '\n\n';
-const FEEDBACK_DELIMITER = '●';
+const FEEDBACK_SPLIT_DELIMITER = '●';
+const FEEDBACK_BULLET = '•';
 const FEEDBACK_DASH = '-';
 
 const PracticeResultAI = () => {
@@ -58,7 +59,7 @@ const PracticeResultAI = () => {
     const renderFeedbackText = (text, className) => {
         const normalized = text.replace(/\n+/g, '\n').trim();
         const lines = normalized
-            ? normalized.split(FEEDBACK_DELIMITER).map((line) => line.trim()).filter(Boolean)
+            ? normalized.split(FEEDBACK_SPLIT_DELIMITER).map((line) => line.trim()).filter(Boolean)
             : [];
         return (
             <div className={`space-y-2 ${className}`}>
@@ -66,7 +67,7 @@ const PracticeResultAI = () => {
                     const content = line.startsWith(FEEDBACK_DASH) ? line.slice(1).trim() : line;
                     return (
                         <p key={idx} className="leading-relaxed pl-5 relative">
-                            <span className="absolute left-0">{FEEDBACK_DELIMITER}</span>
+                            <span className="absolute left-0">{FEEDBACK_BULLET}</span>
                             {content}
                         </p>
                     );

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -185,7 +185,7 @@ const PracticeResultKeyword = () => {
 
                 <Card className="p-4">
                     <p className="text-sm text-muted-foreground mb-3">{TEXT_MY_ANSWER_LABEL}</p>
-                    <div className="text-sm leading-relaxed whitespace-pre-wrap">
+                    <div className="h-[300px] overflow-y-auto text-sm leading-relaxed whitespace-pre-wrap">
                         {myAnswer}
                     </div>
                 </Card>

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -29,6 +29,7 @@ const TEXT_BACK_MODAL_DESC = '연습모드로 돌아가시겠습니까?';
 const TEXT_BACK_MODAL_CONFIRM = '연습모드로 돌아가기';
 const TEXT_BACK_MODAL_CANCEL = '닫기';
 const TEXT_RESULT_BUTTON = 'AI 분석결과 보기';
+const TEXT_RETRY_BUTTON = '다시 답변하기';
 const TEXT_PAGE_TITLE = '답변 분석';
 const TEXT_QUESTION_LABEL = '질문';
 const TEXT_MY_ANSWER_LABEL = '나의 답변';
@@ -60,6 +61,7 @@ const PracticeResultKeyword = () => {
     const [feedbackError, setFeedbackError] = useState('');
 
     const myAnswer = state?.answerText || '';
+    const retryPath = state?.retryPath || `/practice/answer/${questionId}`;
 
     // 0~95%까지 천천히 올라가며 대기 상태를 표현한다.
     useEffect(() => {
@@ -227,8 +229,16 @@ const PracticeResultKeyword = () => {
                         </div>
                     </Card>
                 ) : feedbackError ? (
-                    <div className="text-center text-rose-500 text-sm py-4">
-                        {feedbackError}
+                    <div className="space-y-3">
+                        <div className="text-center text-rose-500 text-sm py-2">
+                            {feedbackError}
+                        </div>
+                        <Button
+                            onClick={() => navigate(retryPath)}
+                            className="w-full rounded-xl h-12"
+                        >
+                            {TEXT_RETRY_BUTTON}
+                        </Button>
                     </div>
                 ) : (
                     <Button

--- a/src/app/pages/PracticeSTT.jsx
+++ b/src/app/pages/PracticeSTT.jsx
@@ -73,7 +73,7 @@ const PracticeSTT = () => {
                         <Loader2 className="w-16 h-16" />
                     </Motion.div>
 
-                    <h2 className="text-2xl mb-3">{statusMessage}</h2>
+                    <h2 className="text-2xl mb-3 text-white">{statusMessage}</h2>
                     <p className="text-white/80">
                         잠시만 기다려주세요
                     </p>

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -291,7 +291,7 @@ const ProfileMain = () => {
     }, [categoryMap]);
 
     // 주간 목표 계산
-    const totalThisWeek = weeklyStats.total_this_week ?? 0;
+    const totalThisWeek = weeklyStats?.total_this_week ?? 0;
     const weeklyGoal = 7; // 목표값
     const weeklyProgress = Math.min((totalThisWeek / weeklyGoal) * 100, 100);
     const remainingCount = Math.max(weeklyGoal - totalThisWeek, 0);


### PR DESCRIPTION
## 요약

  최근 QA 수정 7건을 묶어 답변 작성/분석 흐름의 UI 안정성과 입력 검증, 오류 대응 UX를 강화했습니다. 음성·텍스트 답변 화면 컬러 통일, 답변 입력 영역 고정/스크롤, 피드백 불릿 표기 개선, 프로필 새로고
  침 크래시 방지, 제출 실패 재시도 UX, 1500자 초과 검증까지 포함됩니다.

  ## 변경사항

  - 음성 답변/분석 텍스트 컬러 통일
      - 음성 답변 질문 텍스트와 분석 완료 타이틀을 흰색으로 맞춤
  - 답변 입력 영역 높이 고정
      - 텍스트 답변/편집 textarea 고정 높이 + 내부 스크롤 적용
  - 편집/키워드 화면 답변 영역 스크롤 고정 + 글자 수 표시
      - 보기/편집에서 긴 답변이 레이아웃을 밀지 않도록 처리
  - AI 피드백 불릿 표기 개선
      - 원본 파싱(●)과 화면 표시(•) 분리
  - 프로필 새로고침 화이트스크린 방지
      - 주간 통계 undefined 접근 가드 추가
  - 제출 실패 재시도 UX 추가
      - 텍스트 답변은 텍스트 페이지, 음성 답변은 음성 녹음 페이지로 이동
  - 1500자 초과 입력 검증
      - 입력 중 경고 모달 + 제출 버튼 비활성화
      - 편집 완료 시에도 1500자 초과 차단

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/pages/PracticeAnswerVoice.jsx
      - src/app/pages/PracticeSTT.jsx
      - src/app/pages/PracticeAnswerText.jsx
      - src/app/pages/PracticeAnswerEdit.jsx
      - src/app/pages/PracticeResultKeyword.jsx
      - src/app/pages/PracticeResultAI.jsx
      - src/app/pages/ProfileMain.jsx

  ## 구현 의도 / 목적

  - 답변 작성/편집 UX 일관성 확보 및 긴 입력에 대한 레이아웃 안정성 강화
  - 제출 실패 시 사용자 이탈 방지(재시도/리다이렉트 제공)
  - 입력 길이 제한 준수(1500자)로 API 실패 가능성 사전 차단
  - 피드백 표시 가독성 개선 및 프로필 새로고침 안정화

  ## 관련 Commit, Issue

  - fix:[#117] 음성답변, 분석화면 Text 컬러 통일
  - fix:[#118] 텍스트로 답변, STT 편집화면 textarea y축 고정
  - fix:[#127] 연습 답변 편집/키워드 화면 답변 영역 스크롤 고정 및 글자 수 표시
  - fix:[#124] AI 피드백 불릿 표시 개선(파싱·표시 분리)
  - fix:[#123] 프로필 새로고침 시 주간 통계 undefined 접근으로 인한 화이트스크린 방지
  - fix:[#122] 답변 제출 실패 시 재시도 이동 버튼 추가(텍스트/음성 분기)
  - fix:[#75] 텍스트/편집 답변 1500자 초과 검증 및 제출 제한 추가