### PR TITLE
fix:[#129] QA 디자인 수정

### DIFF
--- a/src/app/hooks/useFeedbackFormDialog.jsx
+++ b/src/app/hooks/useFeedbackFormDialog.jsx
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/app/components/ui/alert-dialog';
+
+const FEEDBACK_FORM_URL = 'https://forms.gle/nraq9VyYzQogYgFSA';
+const TEXT_TITLE = 'Q-Feed v1.0.0 사용 후기 설문';
+const TEXT_DESC = [
+    'Q-Feed 사용해 주셔서 감사합니다! 🎙️',
+    '베타 단계라 의견을 빠르게 반영하고 있어요.',
+];
+const TEXT_POINTS = [
+    '👍 좋았던 점',
+    '🛠️ 불편했던 점',
+    '🌱 바라는 점',
+];
+const TEXT_FOOTER_LINES = [
+    '총 5문항 · 약 1분.',
+    '버튼을 누르면 새 창에서 구글폼이 열립니다.',
+];
+const TEXT_ACTION = '예, 피드백 남길래요';
+const TEXT_CANCEL = '나중에 할게요';
+
+export const useFeedbackFormDialog = () => {
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = useCallback(() => {
+        setOpen(true);
+    }, []);
+
+    const handleConfirm = useCallback(() => {
+        window.open(FEEDBACK_FORM_URL, '_blank', 'noopener,noreferrer');
+        setOpen(false);
+    }, []);
+
+    const dialog = useMemo(() => (
+        <AlertDialog open={open} onOpenChange={setOpen}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{TEXT_TITLE}</AlertDialogTitle>
+                    <AlertDialogDescription className="text-[13px] leading-snug">
+                        <div className="space-y-2">
+                            <div className="space-y-1">
+                                {TEXT_DESC.map((line) => (
+                                    <p key={line}>{line}</p>
+                                ))}
+                            </div>
+                            <ul className="space-y-1">
+                                {TEXT_POINTS.map((point) => (
+                                    <li key={point} className="leading-snug">
+                                        {point}
+                                    </li>
+                                ))}
+                            </ul>
+                            <div className="space-y-1 text-muted-foreground">
+                                {TEXT_FOOTER_LINES.map((line) => (
+                                    <p key={line}>{line}</p>
+                                ))}
+                            </div>
+                        </div>
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>{TEXT_CANCEL}</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleConfirm}>
+                        {TEXT_ACTION}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    ), [open, handleConfirm]);
+
+    return {
+        open: handleOpen,
+        dialog,
+    };
+};

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -173,6 +173,7 @@ const ProfileMain = () => {
 
     const observerRef = useRef(null);
     const categoryDropdownRef = useRef(null);
+    const filterModalContentRef = useRef(null);
     const scrollPositionRef = useRef(0);
     const shouldRestoreScrollRef = useRef(false);
 
@@ -226,6 +227,30 @@ const ProfileMain = () => {
             document.removeEventListener('touchstart', handleClickOutside);
         };
     }, []);
+
+    useEffect(() => {
+        if (!showFilterModal) return;
+        const originalOverflow = document.body.style.overflow;
+        const originalTouchAction = document.body.style.touchAction;
+        const originalOverscroll = document.body.style.overscrollBehavior;
+        document.body.style.overflow = 'hidden';
+        document.body.style.touchAction = 'none';
+        document.body.style.overscrollBehavior = 'none';
+
+        const preventScroll = (event) => {
+            const content = filterModalContentRef.current;
+            if (content && content.contains(event.target)) return;
+            event.preventDefault();
+        };
+
+        document.addEventListener('touchmove', preventScroll, { passive: false });
+        return () => {
+            document.body.style.overflow = originalOverflow;
+            document.body.style.touchAction = originalTouchAction;
+            document.body.style.overscrollBehavior = originalOverscroll;
+            document.removeEventListener('touchmove', preventScroll);
+        };
+    }, [showFilterModal]);
 
     const handleDateFromChange = (value) => {
         const launchClampedFrom = value < SERVICE_LAUNCH_DATE ? SERVICE_LAUNCH_DATE : value;
@@ -446,7 +471,11 @@ const ProfileMain = () => {
                             }
                         }}
                     >
-                        <div className="filter-modal-content" onClick={(e) => e.stopPropagation()}>
+                        <div
+                            className="filter-modal-content"
+                            ref={filterModalContentRef}
+                            onClick={(e) => e.stopPropagation()}
+                        >
                             <div className="space-y-3 mb-4">
                                 <div className="grid grid-cols-[0.8fr_1.2fr] gap-3">
                                     <div className="space-y-2">

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -64,17 +64,37 @@ const formatDateDisplay = (dateString) => {
     return dateString;
 };
 
+const formatCount = (value) => {
+    if (value === null || value === undefined) return '-';
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) return '-';
+    if (numericValue < 1000) return String(numericValue);
+
+    const units = ['K', 'M', 'B', 'T'];
+    let unitIndex = -1;
+    let scaled = numericValue;
+
+    while (scaled >= 1000 && unitIndex < units.length - 1) {
+        scaled /= 1000;
+        unitIndex += 1;
+    }
+
+    const precision = scaled >= 10 ? 0 : 1;
+    const display = scaled.toFixed(precision).replace(/\.0$/, '');
+    return `${display}${units[unitIndex]}`;
+};
+
 // 통계 카드 컴포넌트
 const StatCard = ({ icon, label, value, unit }) => {
-    const numericValue = value.replace(/[^0-9]/g, '');
-    const displayValue = value.includes('-') ? '-' : numericValue || '0';
+    const displayValue = formatCount(value);
+    const showUnit = displayValue !== '-' && unit;
 
     return (
         <div className="stat-card">
             <div className="stat-icon">{icon}</div>
             <div className="stat-content">
                 <span className="stat-value">
-                    {displayValue}<span className="stat-unit">{unit}</span>
+                    {displayValue}{showUnit && <span className="stat-unit">{unit}</span>}
                 </span>
                 <span className="stat-label">{label}</span>
             </div>
@@ -268,9 +288,9 @@ const ProfileMain = () => {
     const weeklyStats = weeklyStatsData?.data;
 
     const stats = [
-        { icon: Calendar, label: '총 학습일', value: `${userStats?.distinct_days ?? '-'}일` },
-        { icon: Target, label: '연습 횟수', value: `${userStats?.practice_mode_count ?? '-'}회` },
-        { icon: MessageSquare, label: '총 답변 수', value: `${userStats?.total_questions_answered ?? '-'}개` },
+        { icon: Calendar, label: '총 학습일', value: userStats?.distinct_days, unit: '일' },
+        { icon: Target, label: '연습 횟수', value: userStats?.practice_mode_count, unit: '회' },
+        { icon: MessageSquare, label: '총 답변 수', value: userStats?.total_questions_answered, unit: '개' },
     ];
 
     // 카테고리 색상 매핑
@@ -344,7 +364,7 @@ const ProfileMain = () => {
                                 icon={<Icon size={24} />}
                                 label={stat.label}
                                 value={stat.value}
-                                unit={stat.value.includes('일') ? '일' : stat.value.includes('회') ? '회' : '개'}
+                                unit={stat.unit}
                             />
                         );
                     })}

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -7,16 +7,7 @@ import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 import { useUserStats } from '@/app/hooks/useUserStats.js';
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from '@/app/components/ui/alert-dialog';
+import { useFeedbackFormDialog } from '@/app/hooks/useFeedbackFormDialog';
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
 
@@ -26,22 +17,8 @@ const ANSWER_TYPE_LABELS = {
     PORTFOLIO_INTERVIEW: '포트폴리오',
 };
 
-const FEEDBACK_FORM_URL = 'https://forms.gle/nraq9VyYzQogYgFSA';
 const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
 const SERVICE_LAUNCH_DATE = '2026-02-04';
-const TEXT_FEEDBACK_CONFIRM_TITLE = 'Q-Feed v1.0.0 사용 후기 설문';
-const TEXT_FEEDBACK_CONFIRM_DESC = [
-    'Q-Feed 사용해 주셔서 감사합니다! 🎙️',
-    '베타 단계라 의견을 빠르게 반영하고 있어요.',
-];
-const TEXT_FEEDBACK_CONFIRM_POINTS = [
-    '👍 좋았던 점',
-    '🛠️ 불편했던 점',
-    '🌱 바라는 점',
-];
-const TEXT_FEEDBACK_CONFIRM_FOOTER = '총 5문항 · 약 1분. 버튼을 누르면 새 창에서 구글폼이 열립니다.';
-const TEXT_FEEDBACK_CONFIRM_ACTION = '예, 피드백 남길래요';
-const TEXT_FEEDBACK_CONFIRM_CANCEL = '나중에 할게요';
 
 const toDateInputValue = (date) => {
     const year = date.getFullYear();
@@ -189,7 +166,7 @@ const ProfileMain = () => {
     const [categoryFilter, setCategoryFilter] = useState('ALL');
     const [isCategoryOpen, setIsCategoryOpen] = useState(false);
     const [showFilterModal, setShowFilterModal] = useState(false);
-    const [showFeedbackConfirm, setShowFeedbackConfirm] = useState(false);
+    const { open: openFeedbackDialog, dialog: feedbackDialog } = useFeedbackFormDialog();
 
     const categoryValue = categoryFilter === 'ALL' ? undefined : categoryFilter;
 
@@ -200,11 +177,6 @@ const ProfileMain = () => {
         ],
         [categoryMap]
     );
-
-    const handleOpenFeedbackForm = () => {
-        window.open(FEEDBACK_FORM_URL, '_blank', 'noopener,noreferrer');
-        setShowFeedbackConfirm(false);
-    };
 
     const requestScrollRestore = () => {
         scrollPositionRef.current = window.scrollY;
@@ -400,7 +372,7 @@ const ProfileMain = () => {
                         type="button"
                         className="btn-secondary text-xs px-3 py-2"
                         style={{ marginLeft: 'auto' }}
-                        onClick={() => setShowFeedbackConfirm(true)}
+                        onClick={openFeedbackDialog}
                     >
                         피드백 남기기
                     </button>
@@ -649,36 +621,7 @@ const ProfileMain = () => {
 
             <BottomNav />
 
-            <AlertDialog open={showFeedbackConfirm} onOpenChange={setShowFeedbackConfirm}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>{TEXT_FEEDBACK_CONFIRM_TITLE}</AlertDialogTitle>
-                        <AlertDialogDescription className="text-[13px] leading-snug">
-                            <div className="space-y-2">
-                                <div className="space-y-1">
-                                    {TEXT_FEEDBACK_CONFIRM_DESC.map((line) => (
-                                        <p key={line}>{line}</p>
-                                    ))}
-                                </div>
-                                <ul className="space-y-1">
-                                    {TEXT_FEEDBACK_CONFIRM_POINTS.map((point) => (
-                                        <li key={point} className="leading-snug">
-                                            {point}
-                                        </li>
-                                    ))}
-                                </ul>
-                                <p className="text-muted-foreground">{TEXT_FEEDBACK_CONFIRM_FOOTER}</p>
-                            </div>
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>{TEXT_FEEDBACK_CONFIRM_CANCEL}</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleOpenFeedbackForm}>
-                            {TEXT_FEEDBACK_CONFIRM_ACTION}
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            {feedbackDialog}
         </div>
     );
 };

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -7,6 +7,16 @@ import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 import { useUserStats } from '@/app/hooks/useUserStats.js';
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/app/components/ui/alert-dialog';
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
 
@@ -16,8 +26,22 @@ const ANSWER_TYPE_LABELS = {
     PORTFOLIO_INTERVIEW: '포트폴리오',
 };
 
+const FEEDBACK_FORM_URL = 'https://forms.gle/nraq9VyYzQogYgFSA';
 const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
 const SERVICE_LAUNCH_DATE = '2026-02-04';
+const TEXT_FEEDBACK_CONFIRM_TITLE = 'Q-Feed v1.0.0 사용 후기 설문';
+const TEXT_FEEDBACK_CONFIRM_DESC = [
+    'Q-Feed 사용해 주셔서 감사합니다! 🎙️',
+    '베타 단계라 의견을 빠르게 반영하고 있어요.',
+];
+const TEXT_FEEDBACK_CONFIRM_POINTS = [
+    '👍 좋았던 점',
+    '🛠️ 불편했던 점',
+    '🌱 바라는 점',
+];
+const TEXT_FEEDBACK_CONFIRM_FOOTER = '총 5문항 · 약 1분. 버튼을 누르면 새 창에서 구글폼이 열립니다.';
+const TEXT_FEEDBACK_CONFIRM_ACTION = '예, 피드백 남길래요';
+const TEXT_FEEDBACK_CONFIRM_CANCEL = '나중에 할게요';
 
 const toDateInputValue = (date) => {
     const year = date.getFullYear();
@@ -164,6 +188,7 @@ const ProfileMain = () => {
     const [categoryFilter, setCategoryFilter] = useState('ALL');
     const [isCategoryOpen, setIsCategoryOpen] = useState(false);
     const [showFilterModal, setShowFilterModal] = useState(false);
+    const [showFeedbackConfirm, setShowFeedbackConfirm] = useState(false);
 
     const categoryValue = categoryFilter === 'ALL' ? undefined : categoryFilter;
 
@@ -174,6 +199,11 @@ const ProfileMain = () => {
         ],
         [categoryMap]
     );
+
+    const handleOpenFeedbackForm = () => {
+        window.open(FEEDBACK_FORM_URL, '_blank', 'noopener,noreferrer');
+        setShowFeedbackConfirm(false);
+    };
 
     const requestScrollRestore = () => {
         scrollPositionRef.current = window.scrollY;
@@ -341,15 +371,14 @@ const ProfileMain = () => {
                             면접 준비 중
                         </span>
                     </div>
-                    <a
-                        className="btn-secondary"
-                        href="https://forms.gle/nraq9VyYzQogYgFSA"
-                        target="_blank"
-                        rel="noopener noreferrer"
+                    <button
+                        type="button"
+                        className="btn-secondary text-xs px-3 py-2"
                         style={{ marginLeft: 'auto' }}
+                        onClick={() => setShowFeedbackConfirm(true)}
                     >
                         피드백 남기기
-                    </a>
+                    </button>
                 </div>
             </section>
 
@@ -590,6 +619,37 @@ const ProfileMain = () => {
             <div className="scroll-padding" />
 
             <BottomNav />
+
+            <AlertDialog open={showFeedbackConfirm} onOpenChange={setShowFeedbackConfirm}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{TEXT_FEEDBACK_CONFIRM_TITLE}</AlertDialogTitle>
+                        <AlertDialogDescription className="text-[13px] leading-snug">
+                            <div className="space-y-2">
+                                <div className="space-y-1">
+                                    {TEXT_FEEDBACK_CONFIRM_DESC.map((line) => (
+                                        <p key={line}>{line}</p>
+                                    ))}
+                                </div>
+                                <ul className="space-y-1">
+                                    {TEXT_FEEDBACK_CONFIRM_POINTS.map((point) => (
+                                        <li key={point} className="leading-snug">
+                                            {point}
+                                        </li>
+                                    ))}
+                                </ul>
+                                <p className="text-muted-foreground">{TEXT_FEEDBACK_CONFIRM_FOOTER}</p>
+                            </div>
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>{TEXT_FEEDBACK_CONFIRM_CANCEL}</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleOpenFeedbackForm}>
+                            {TEXT_FEEDBACK_CONFIRM_ACTION}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 };

--- a/src/app/pages/SettingMain.jsx
+++ b/src/app/pages/SettingMain.jsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 
 import { AppHeader } from '@/app/components/AppHeader';
 import { deleteAccount } from '@/api/userApi';
+import { useFeedbackFormDialog } from '@/app/hooks/useFeedbackFormDialog';
 
 const SettingMain = () => {
 
@@ -28,6 +29,7 @@ const SettingMain = () => {
     const [showLogoutDialog, setShowLogoutDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [notifications, setNotifications] = useState(true);
+    const { open: openFeedbackDialog, dialog: feedbackDialog } = useFeedbackFormDialog();
 
     const handleLogout = async () => {
         await logout();
@@ -70,7 +72,7 @@ const SettingMain = () => {
                     icon: HelpCircle,
                     label: '피드백 남기기',
                     action: <span className="text-sm text-muted-foreground"></span>,
-                    onClick: () => window.open('https://forms.gle/nraq9VyYzQogYgFSA', '_blank', 'noopener,noreferrer'),
+                    onClick: openFeedbackDialog,
                 },
                 {
                     icon: HelpCircle,
@@ -102,20 +104,22 @@ const SettingMain = () => {
                     <section key={groupIndex}>
                         <h2 className="text-sm text-muted-foreground mb-3 px-2">{group.title}</h2>
 
-                        <Card className="divide-y">
+                        <Card className="p-0 gap-0 overflow-hidden">
                             {group.items.map((item, itemIndex) => {
                                 const Icon = item.icon;
                                 return (
                                     <div
                                         key={itemIndex}
-                                        className="flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 transition-colors"
+                                        className={`setting-item flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 transition-colors ${itemIndex > 0 ? 'border-t border-gray-100' : ''}`}
                                         onClick={item.onClick}
                                     >
-                                        <div className="flex items-center gap-3">
+                                        <div className="setting-main flex items-center gap-3">
                                             <Icon className={`w-5 h-5 ${item.textColor || 'text-muted-foreground'}`} />
                                             <span className={item.textColor || 'text-foreground'}>{item.label}</span>
                                         </div>
-                                        {item.action}
+                                        {item.action && (
+                                            <div className="setting-action">{item.action}</div>
+                                        )}
                                     </div>
                                 );
                             })}
@@ -144,6 +148,8 @@ const SettingMain = () => {
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
+
+            {feedbackDialog}
 
             {/* Delete Account Dialog */}
             <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1170,6 +1170,86 @@
   50% { opacity: 0.5; }
 }
 
+@media (max-width: 430px) {
+  .profile-card {
+    flex-wrap: wrap;
+  }
+
+  .profile-info {
+    min-width: 0;
+  }
+
+  .profile-status {
+    white-space: nowrap;
+  }
+
+  .stats-section {
+    padding: 20px 16px;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-grid .stat-card:last-child {
+    grid-column: span 2;
+  }
+
+  .stat-card {
+    padding: 16px 12px;
+  }
+
+  .stat-value {
+    font-size: 22px;
+    line-height: 1.1;
+  }
+
+  .stat-label {
+    font-size: 12px;
+    line-height: 1.2;
+  }
+}
+
+@media (max-width: 390px) {
+  .profile-section {
+    padding: 16px;
+  }
+
+  .profile-card {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 18px;
+    gap: 12px;
+  }
+
+  .avatar {
+    width: 56px;
+    height: 56px;
+    font-size: 22px;
+  }
+
+  .profile-info {
+    width: 100%;
+  }
+
+  .profile-name {
+    font-size: 18px;
+  }
+
+  .profile-status {
+    font-size: 11px;
+    padding: 4px 10px;
+  }
+
+  .profile-card .btn-secondary {
+    width: 100%;
+    text-align: center;
+    padding: 10px 12px;
+    margin-left: 0 !important;
+    align-self: stretch;
+  }
+}
+
 /* 통계 섹션 */
 .stats-section {
   padding: 24px 20px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1475,15 +1475,14 @@
 .filter-modal {
   position: fixed;
   top: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   right: 0;
   bottom: 0;
+  width: 100%;
   background: rgba(0, 0, 0, 0.5);
   z-index: 200;
   display: flex;
   align-items: flex-end;
-  max-width: 428px;
   animation: fadeIn 0.2s ease-out;
 }
 
@@ -1501,8 +1500,10 @@
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   padding: 24px 20px;
   width: 100%;
+  max-width: 428px;
   max-height: 80vh;
   overflow-y: auto;
+  margin: 0 auto;
   animation: slideUpModal 0.3s ease-out;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1029,7 +1029,6 @@
   background: var(--gray-50);
   padding-bottom: 90px;
   position: relative;
-  overflow-x: hidden;
 }
 
 /* 헤더 */
@@ -1038,10 +1037,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  background: transparent;
+  background: rgba(250, 250, 250, 0.9);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--gray-100);
   position: sticky;
   top: 0;
-  z-index: 100;
+  z-index: 200;
 }
 
 .header-title {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1069,6 +1069,31 @@
   color: var(--gray-800);
 }
 
+.setting-item {
+  gap: 12px;
+  position: relative;
+}
+
+.setting-main {
+  min-width: 0;
+}
+
+.setting-action {
+  margin-left: auto;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+@media (max-width: 430px) {
+  .setting-item {
+    align-items: flex-start;
+  }
+
+  .setting-action {
+    max-width: 48%;
+  }
+}
+
 /* 프로필 섹션 */
 .profile-section {
   padding: 20px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1188,24 +1188,32 @@
   }
 
   .stats-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
   }
 
   .stats-grid .stat-card:last-child {
-    grid-column: span 2;
+    grid-column: auto;
   }
 
   .stat-card {
-    padding: 16px 12px;
+    padding: 12px 8px;
+    min-height: 96px;
+  }
+
+  .stat-icon {
+    width: 32px;
+    height: 32px;
+    margin-bottom: 8px;
   }
 
   .stat-value {
-    font-size: 22px;
+    font-size: 18px;
     line-height: 1.1;
   }
 
   .stat-label {
-    font-size: 12px;
+    font-size: 11px;
     line-height: 1.2;
   }
 }
@@ -1250,6 +1258,41 @@
   }
 }
 
+@media (max-width: 380px) {
+  .stat-card {
+    padding: 8px 6px;
+    min-height: 82px;
+    min-width: 0;
+  }
+
+  .stat-icon {
+    width: 28px;
+    height: 28px;
+    margin-bottom: 6px;
+  }
+
+  .stat-value {
+    font-size: 14px;
+    gap: 1px;
+  }
+
+  .stat-unit {
+    font-size: 10px;
+  }
+
+  .stat-label {
+    font-size: 9px;
+  }
+
+  .stat-content {
+    gap: 2px;
+  }
+
+  .stats-grid {
+    gap: 6px;
+  }
+}
+
 /* 통계 섹션 */
 .stats-section {
   padding: 24px 20px;
@@ -1259,6 +1302,8 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 12px;
+  align-items: stretch;
+  grid-auto-rows: 1fr;
 }
 
 .stat-card {
@@ -1268,6 +1313,11 @@
   padding: 20px 16px;
   text-align: center;
   transition: all 0.2s ease;
+  height: 100%;
+  min-height: 118px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .stat-card:hover {
@@ -1291,6 +1341,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-height: 48px;
 }
 
 .stat-value {
@@ -1298,6 +1349,13 @@
   font-weight: var(--font-weight-bold);
   color: var(--gray-900);
   font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  min-height: 1.1em;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 2px;
+  white-space: nowrap;
 }
 
 .stat-unit {
@@ -1310,6 +1368,12 @@
 .stat-label {
   font-size: 13px;
   color: var(--gray-600);
+  line-height: 1.2;
+  min-height: 2.4em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 /* 성장 지표 */


### PR DESCRIPTION
## 요약

  프로필/설정 화면의 모바일 UX와 필터/피드백 흐름을 집중 개선했습니다. 통계 카드의 레이아웃 안정화 및 숫자 컴팩트 표기, 피드백
  모달 UI 개선 및 공통화, 필터 모달 오버레이/스크롤 이슈 해결, 헤더 sticky 적용, 상단 프로필 카드 모바일 깨짐 대응이 포함됩니다.

  ## 변경사항

  - 프로필 상단 카드 모바일 레이아웃 깨짐 대응(414px 이하)
  - 프로필 통계 카드 레이아웃 안정화 + 숫자 컴팩트 표기(K/M/B/T)
  - 피드백 모달 문구/레이아웃 개선(모바일 가독성 + 외부 이동 안내)
  - 프로필 필터 모달 오버레이 중앙만 덮이던 문제 수정 + 스크롤 잠금
  - 피드백 설문 모달 공통 훅으로 분리 + 프로필/설정에서 재사용
  - 프로필 헤더 sticky 고정 및 배경 처리(블러/보더) 추가

  ## 수정/추가/삭제 파일

  - 추가
      - src/app/hooks/useFeedbackFormDialog.jsx
  - 수정
      - src/app/pages/ProfileMain.jsx
      - src/app/pages/SettingMain.jsx
      - src/styles/theme.css

  ## 구현 의도 / 목적

  - 모바일 환경에서 핵심 정보(통계/프로필/필터)가 깨지지 않도록 레이아웃 안정화
  - 피드백 유입 UX를 명확하게 안내하고, 중복 구현을 공통 훅으로 통합
  - 필터 모달과 헤더 UX를 안정적으로 고정하여 사용성 향상

  ## 관련 Commit, Issue

  - fix:[#130] 프로필 상단 뱃지/버튼 모바일(414px 이하) 레이아웃 깨짐 대응
  - fix:[#131] 프로필 통계 카드 레이아웃 깨짐 대응 + 숫자 컴팩트 표기 추가
  - fix:[#132] 피드백 남기기 모달 문구/레이아웃 개선(모바일 가독성 + 외부 이동 안내)
  - fix:[#133] 프로필 필터 모달 오버레이가 중앙만 덮이는 문제 수정
  - fix:[#134] 피드백 설문 모달 공통화 + 프로필/설정 UX 개선(모바일 레이아웃·필터 모달·설정 리스트 구분선)
  - fix:[#135] 프로필 헤더 sticky 고정 및 배경 처리 개선