### PR TITLE
release: #120~#135 프로필/피드백 UX 개선, 답변 플로우 안정화, FE CI/CD 환경 분리

### DIFF
--- a/.github/workflows/FE-CICD.yml
+++ b/.github/workflows/FE-CICD.yml
@@ -4,9 +4,10 @@
 name: Frontend CI/CD
 
 on:
-  push:               # main 브랜치에 직접 push될 때 실행
+  push:               # main 또는 dev 브랜치에 직접 push될 때 실행
     branches:
-      - main      
+      - main
+      - dev      
   pull_request:       # main 브랜치로의 PR이 생성되거나 업데이트될 때 실행
     branches:
       - main
@@ -96,12 +97,12 @@ jobs:
               }]
             }'
             
-  deploy:
-    name: Deploy to EC2
+  deploy-prod:
+    name: Deploy to Production (EC2)
     runs-on: ubuntu-latest
     needs: build-and-test
 
-    # main 브랜치로 push된 경우에만 배포 실행 (PR에서는 실행하지 않음)
+    # main 브랜치로 push된 경우에만 배포 실행
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
@@ -160,12 +161,76 @@ jobs:
             set -e
             sudo /srv/qfeed/deploy-fe.sh /tmp/fe-v${{ steps.package-version.outputs.version }}.tar.gz
 
+  deploy-dev:
+    name: Deploy to Dev (EC2)
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    # dev 브랜치로 push된 경우에만 배포 실행
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: 패키지 버전 추출
+        id: package-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: 빌드 산출물 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: fe-v${{ steps.package-version.outputs.version }}
+
+      # 서버로 산출물을 전송한 뒤, 서버 내부 deploy.sh로 교체/백업 처리
+      - name: SSH 키 설정
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.QFEED_EC2_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.QFEED_EC2_DEV_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: 서버 연결 테스트
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=no \
+            -o ConnectTimeout=30 \
+            -o ServerAliveInterval=10 \
+            ${{ secrets.QFEED_EC2_USER }}@${{ secrets.QFEED_EC2_DEV_HOST }} \
+            "echo 'Connection successful'"
+
+      - name: 서버로 파일 업로드 (SCP)
+        timeout-minutes: 5
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=no \
+            -o ConnectTimeout=60 \
+            -o ServerAliveInterval=10 \
+            -o ServerAliveCountMax=3 \
+            fe-v${{ steps.package-version.outputs.version }}.tar.gz \
+            ${{ secrets.QFEED_EC2_USER }}@${{ secrets.QFEED_EC2_DEV_HOST }}:/tmp/
+
+      - name: 서버에서 배포 실행 (deploy-fe.sh)
+        timeout-minutes: 5
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.QFEED_EC2_DEV_HOST }}
+          username: ${{ secrets.QFEED_EC2_USER }}
+          key: ${{ secrets.QFEED_EC2_SSH_KEY }}
+          timeout: 60s
+          command_timeout: 5m
+          script: |
+            set -e
+            sudo /srv/qfeed/deploy-fe.sh /tmp/fe-v${{ steps.package-version.outputs.version }}.tar.gz
+
   # CI 실패 시 어떤 과정에서 실패했는지 Discord 알림
   discord-notify-failure:
     name: Discord 알림 (CI 실패)
     runs-on: ubuntu-latest
-    needs: [build-and-test, deploy]
-    if: always() && (needs.build-and-test.result == 'failure' || needs.deploy.result == 'failure')
+    needs: [build-and-test, deploy-prod, deploy-dev]
+    if: always() && (needs.build-and-test.result == 'failure' || needs.deploy-prod.result == 'failure' || needs.deploy-dev.result == 'failure')
     steps:
       - name: 실패한 Job/Step 조회
         id: failed

--- a/src/app/hooks/useFeedbackFormDialog.jsx
+++ b/src/app/hooks/useFeedbackFormDialog.jsx
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/app/components/ui/alert-dialog';
+
+const FEEDBACK_FORM_URL = 'https://forms.gle/nraq9VyYzQogYgFSA';
+const TEXT_TITLE = 'Q-Feed v1.0.0 사용 후기 설문';
+const TEXT_DESC = [
+    'Q-Feed 사용해 주셔서 감사합니다! 🎙️',
+    '베타 단계라 의견을 빠르게 반영하고 있어요.',
+];
+const TEXT_POINTS = [
+    '👍 좋았던 점',
+    '🛠️ 불편했던 점',
+    '🌱 바라는 점',
+];
+const TEXT_FOOTER_LINES = [
+    '총 5문항 · 약 1분.',
+    '버튼을 누르면 새 창에서 구글폼이 열립니다.',
+];
+const TEXT_ACTION = '예, 피드백 남길래요';
+const TEXT_CANCEL = '나중에 할게요';
+
+export const useFeedbackFormDialog = () => {
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = useCallback(() => {
+        setOpen(true);
+    }, []);
+
+    const handleConfirm = useCallback(() => {
+        window.open(FEEDBACK_FORM_URL, '_blank', 'noopener,noreferrer');
+        setOpen(false);
+    }, []);
+
+    const dialog = useMemo(() => (
+        <AlertDialog open={open} onOpenChange={setOpen}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{TEXT_TITLE}</AlertDialogTitle>
+                    <AlertDialogDescription className="text-[13px] leading-snug">
+                        <div className="space-y-2">
+                            <div className="space-y-1">
+                                {TEXT_DESC.map((line) => (
+                                    <p key={line}>{line}</p>
+                                ))}
+                            </div>
+                            <ul className="space-y-1">
+                                {TEXT_POINTS.map((point) => (
+                                    <li key={point} className="leading-snug">
+                                        {point}
+                                    </li>
+                                ))}
+                            </ul>
+                            <div className="space-y-1 text-muted-foreground">
+                                {TEXT_FOOTER_LINES.map((line) => (
+                                    <p key={line}>{line}</p>
+                                ))}
+                            </div>
+                        </div>
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>{TEXT_CANCEL}</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleConfirm}>
+                        {TEXT_ACTION}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    ), [open, handleConfirm]);
+
+    return {
+        open: handleOpen,
+        dialog,
+    };
+};

--- a/src/app/pages/LearningRecordDetail.jsx
+++ b/src/app/pages/LearningRecordDetail.jsx
@@ -39,8 +39,13 @@ const formatDateTime = (dateString) => {
 }
 
 const normalizeRadarValue = (metric) => {
+  const rawValue = Number(metric?.value)
   const score = Number(metric?.score)
   const maxScore = Number(metric?.maxScore)
+
+  if (!Number.isNaN(rawValue)) {
+    return Math.min(100, Math.max(0, Math.round(rawValue)))
+  }
 
   if (Number.isNaN(score)) return 0
 
@@ -92,12 +97,21 @@ const LearningRecordDetail = () => {
   const hasAnswerDetail = Boolean(answerDetail?.answerId)
   const detail = answerDetail
   const question = detail?.question
-  const aiFeedback = detail?.aiFeedback
-  const metrics = Array.isArray(aiFeedback?.metrics) ? aiFeedback.metrics : []
-  const radarData = (metrics ?? []).map(metric => ({
+  const aiFeedback =
+    detail?.aiFeedback ??
+    detail?.feedback ??
+    detail?.immediateFeedback ??
+    detail?.immediate_feedback
+  const metrics = Array.isArray(aiFeedback?.metrics)
+    ? aiFeedback.metrics
+    : Array.isArray(aiFeedback?.radarChart)
+      ? aiFeedback.radarChart
+      : []
+  const radarData = metrics.map((metric) => ({
     ...metric,
+    subject: metric?.subject ?? metric?.metricName ?? metric?.name ?? metric?.label ?? '평가',
     value: normalizeRadarValue(metric),
-  }));
+  }))
 
   const hasRadarChart = radarData.length > 0
 

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -23,6 +23,10 @@ const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 const TEXT_SUBMITTING = '제출 중...';
 const TEXT_CHARACTER_SUFFIX = '자';
+const TEXT_LIMIT_TITLE = '답변 길이 초과';
+const TEXT_LIMIT_DESC = '답변은 1500자 이내로 작성해주세요.';
+const TEXT_LIMIT_OK = '확인';
+const MAX_ANSWER_LENGTH = 1500;
 
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
@@ -31,11 +35,16 @@ const PracticeAnswerEdit = () => {
 
     const [isEditing, setIsEditing] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
+    const [showLengthWarning, setShowLengthWarning] = useState(false);
     const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();
     const [answer, setAnswer] = useState(state?.transcribedText);
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleToggleEdit = () => {
+        if (isEditing && (answer || '').length > MAX_ANSWER_LENGTH) {
+            setShowLengthWarning(true);
+            return;
+        }
         if (isEditing) {
             toast.success('편집이 완료되었습니다');
         } else {
@@ -111,7 +120,13 @@ const PracticeAnswerEdit = () => {
                         <>
                             <Textarea
                                 value={answer}
-                                onChange={(e) => setAnswer(e.target.value)}
+                                onChange={(e) => {
+                                    const nextValue = e.target.value;
+                                    if (nextValue.length > MAX_ANSWER_LENGTH && (answer || '').length <= MAX_ANSWER_LENGTH) {
+                                        setShowLengthWarning(true);
+                                    }
+                                    setAnswer(nextValue);
+                                }}
                                 className="h-[300px] overflow-y-auto text-base leading-relaxed"
                                 placeholder="답변을 입력하세요..."
                             />
@@ -133,7 +148,7 @@ const PracticeAnswerEdit = () => {
 
                 <Button
                     onClick={handleSubmit}
-                    disabled={!answer.trim() || isSubmitting}
+                    disabled={!answer.trim() || isSubmitting || (answer || '').length > MAX_ANSWER_LENGTH}
                     className="w-full rounded-xl h-12"
                 >
                     {isSubmitting ? TEXT_SUBMITTING : '답변 제출'}
@@ -151,6 +166,22 @@ const PracticeAnswerEdit = () => {
                     <AlertDialogFooter>
                         <AlertDialogCancel>취소</AlertDialogCancel>
                         <AlertDialogAction onClick={confirmSubmit}>제출</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog open={showLengthWarning} onOpenChange={setShowLengthWarning}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{TEXT_LIMIT_TITLE}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {TEXT_LIMIT_DESC}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogAction onClick={() => setShowLengthWarning(false)}>
+                            {TEXT_LIMIT_OK}
+                        </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -22,6 +22,7 @@ import { usePracticeAnswerSubmit } from '@/app/hooks/usePracticeAnswerSubmit';
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 const TEXT_SUBMITTING = '제출 중...';
+const TEXT_CHARACTER_SUFFIX = '자';
 
 const PracticeAnswerEdit = () => {
     const navigate = useNavigate();
@@ -104,14 +105,19 @@ const PracticeAnswerEdit = () => {
                     <p className="text-sm text-muted-foreground mb-3">나의 답변</p>
 
                     {isEditing ? (
-                        <Textarea
-                            value={answer}
-                            onChange={(e) => setAnswer(e.target.value)}
-                            className="h-[300px] overflow-y-auto text-base leading-relaxed"
-                            placeholder="답변을 입력하세요..."
-                        />
+                        <>
+                            <Textarea
+                                value={answer}
+                                onChange={(e) => setAnswer(e.target.value)}
+                                className="h-[300px] overflow-y-auto text-base leading-relaxed"
+                                placeholder="답변을 입력하세요..."
+                            />
+                            <p className="text-xs text-muted-foreground mt-2">
+                                {(answer || '').length}{TEXT_CHARACTER_SUFFIX}
+                            </p>
+                        </>
                     ) : (
-                        <div className="text-base leading-relaxed whitespace-pre-wrap">
+                        <div className="h-[300px] overflow-y-auto text-base leading-relaxed whitespace-pre-wrap">
                             {answer}
                         </div>
                     )}

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -107,7 +107,7 @@ const PracticeAnswerEdit = () => {
                         <Textarea
                             value={answer}
                             onChange={(e) => setAnswer(e.target.value)}
-                            className="min-h-[300px] text-base leading-relaxed"
+                            className="h-[300px] overflow-y-auto text-base leading-relaxed"
                             placeholder="답변을 입력하세요..."
                         />
                     ) : (

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -57,7 +57,10 @@ const PracticeAnswerEdit = () => {
             answerText: answer,
             onAfterSubmit: (trimmedAnswer) => {
                 navigate(`/practice/result-keyword/${questionId}`, {
-                    state: { answerText: trimmedAnswer },
+                    state: {
+                        answerText: trimmedAnswer,
+                        retryPath: `/practice/answer-voice/${questionId}`,
+                    },
                 });
             },
         });
@@ -117,9 +120,14 @@ const PracticeAnswerEdit = () => {
                             </p>
                         </>
                     ) : (
-                        <div className="h-[300px] overflow-y-auto text-base leading-relaxed whitespace-pre-wrap">
-                            {answer}
-                        </div>
+                        <>
+                            <div className="h-[300px] overflow-y-auto text-base leading-relaxed whitespace-pre-wrap">
+                                {answer}
+                            </div>
+                            <p className="text-xs text-muted-foreground mt-2">
+                                {(answer || '').length}{TEXT_CHARACTER_SUFFIX}
+                            </p>
+                        </>
                     )}
                 </Card>
 

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -53,7 +53,10 @@ const PracticeAnswerText = () => {
             answerText: answer,
             onAfterSubmit: (trimmedAnswer) => {
                 navigate(`/practice/result-keyword/${questionId}`, {
-                    state: { answerText: trimmedAnswer },
+                    state: {
+                        answerText: trimmedAnswer,
+                        retryPath: `/practice/answer-text/${questionId}`,
+                    },
                 });
             },
         });

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -82,7 +82,7 @@ const PracticeAnswerText = () => {
                     <Textarea
                         value={answer}
                         onChange={(e) => setAnswer(e.target.value)}
-                        className="min-h-[300px] text-base leading-relaxed"
+                        className="h-[300px] overflow-y-auto text-base leading-relaxed"
                         placeholder={TEXT_ANSWER_PLACEHOLDER}
                     />
                     <p className="text-xs text-muted-foreground mt-2">

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -30,16 +30,25 @@ const TEXT_ANSWER_PLACEHOLDER = '여기에 답변을 작성해주세요...';
 const TEXT_CHARACTER_SUFFIX = '자';
 const TEXT_CANCEL = '취소';
 const TEXT_SUBMIT = '제출';
+const TEXT_LIMIT_TITLE = '답변 길이 초과';
+const TEXT_LIMIT_DESC = '답변은 1500자 이내로 작성해주세요.';
+const TEXT_LIMIT_OK = '확인';
+const MAX_ANSWER_LENGTH = 1500;
 const PracticeAnswerText = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const [answer, setAnswer] = useState('');
     const [showConfirm, setShowConfirm] = useState(false);
+    const [showLengthWarning, setShowLengthWarning] = useState(false);
     const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleSubmit = () => {
         if (!answer.trim()) {
+            return;
+        }
+        if (answer.length > MAX_ANSWER_LENGTH) {
+            setShowLengthWarning(true);
             return;
         }
         setShowConfirm(true);
@@ -84,7 +93,13 @@ const PracticeAnswerText = () => {
                     <p className="text-sm text-muted-foreground mb-3">{TEXT_ANSWER_LABEL}</p>
                     <Textarea
                         value={answer}
-                        onChange={(e) => setAnswer(e.target.value)}
+                        onChange={(e) => {
+                            const nextValue = e.target.value;
+                            if (nextValue.length > MAX_ANSWER_LENGTH && answer.length <= MAX_ANSWER_LENGTH) {
+                                setShowLengthWarning(true);
+                            }
+                            setAnswer(nextValue);
+                        }}
                         className="h-[300px] overflow-y-auto text-base leading-relaxed"
                         placeholder={TEXT_ANSWER_PLACEHOLDER}
                     />
@@ -95,7 +110,7 @@ const PracticeAnswerText = () => {
 
                 <Button
                     onClick={handleSubmit}
-                    disabled={!answer.trim() || isSubmitting}
+                    disabled={!answer.trim() || isSubmitting || answer.length > MAX_ANSWER_LENGTH}
                     className="w-full rounded-xl h-12"
                 >
                     {isSubmitting ? TEXT_SUBMITTING : TEXT_SUBMIT_BUTTON}
@@ -113,6 +128,22 @@ const PracticeAnswerText = () => {
                     <AlertDialogFooter>
                         <AlertDialogCancel>{TEXT_CANCEL}</AlertDialogCancel>
                         <AlertDialogAction onClick={confirmSubmit}>{TEXT_SUBMIT}</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog open={showLengthWarning} onOpenChange={setShowLengthWarning}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{TEXT_LIMIT_TITLE}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {TEXT_LIMIT_DESC}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogAction onClick={() => setShowLengthWarning(false)}>
+                            {TEXT_LIMIT_OK}
+                        </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -241,7 +241,7 @@ const PracticeAnswerVoice = () => {
       <div className="flex-1 flex flex-col items-center justify-center px-6 py-12">
         <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 mb-8 w-full max-w-lg">
           <p className="text-center text-white/90 text-sm mb-2">질문</p>
-          <h2 className="text-center text-lg">{question.title}</h2>
+          <h2 className="text-center text-lg text-white">{question.title}</h2>
         </div>
 
         {/* Audio Visualizer */}

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -15,7 +15,6 @@ const TEXT_STRENGTHS_TITLE = '잘한 점';
 const TEXT_IMPROVEMENTS_TITLE = '개선하면 좋은 점';
 const TEXT_COMPLETE_TITLE = '분석 완료!';
 const TEXT_COMPLETE_DESC = '답변을 꼼꼼히 분석했어요';
-const TEXT_NEXT_GOAL = '실제 프로젝트 경험과 연결하여 답변하면 더욱 인상적입니다!';
 const TEXT_HOME_BUTTON = '홈으로 이동';
 const TEXT_AI_FEEDBACK_TITLE = 'AI 피드백';
 const TEXT_BAD_CASE_STRENGTHS = '더 잘 할 수 있어요. 지금의 시도가 충분히 의미 있습니다.';
@@ -102,7 +101,7 @@ const PracticeResultAI = () => {
 
                 <div className="text-center pb-6 px-6">
                     <div className="text-5xl mb-2">{TEXT_HEADER_EMOJI}</div>
-                    <h2 className="text-2xl mb-1">{TEXT_COMPLETE_TITLE}</h2>
+                    <h2 className="text-2xl mb-1 text-white">{TEXT_COMPLETE_TITLE}</h2>
                     <p className="text-white/80 text-sm">{TEXT_COMPLETE_DESC}</p>
                 </div>
             </div>

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -22,7 +22,8 @@ const TEXT_BAD_CASE_IMPROVEMENTS = '조금만 더 자세히 설명해도 충분�
 const TEXT_HEADER_EMOJI = '🎯';
 const TEXT_RADAR_LABEL = '평가';
 const FEEDBACK_SECTION_DELIMITER = '\n\n';
-const FEEDBACK_DELIMITER = '●';
+const FEEDBACK_SPLIT_DELIMITER = '●';
+const FEEDBACK_BULLET = '•';
 const FEEDBACK_DASH = '-';
 
 const PracticeResultAI = () => {
@@ -58,7 +59,7 @@ const PracticeResultAI = () => {
     const renderFeedbackText = (text, className) => {
         const normalized = text.replace(/\n+/g, '\n').trim();
         const lines = normalized
-            ? normalized.split(FEEDBACK_DELIMITER).map((line) => line.trim()).filter(Boolean)
+            ? normalized.split(FEEDBACK_SPLIT_DELIMITER).map((line) => line.trim()).filter(Boolean)
             : [];
         return (
             <div className={`space-y-2 ${className}`}>
@@ -66,7 +67,7 @@ const PracticeResultAI = () => {
                     const content = line.startsWith(FEEDBACK_DASH) ? line.slice(1).trim() : line;
                     return (
                         <p key={idx} className="leading-relaxed pl-5 relative">
-                            <span className="absolute left-0">{FEEDBACK_DELIMITER}</span>
+                            <span className="absolute left-0">{FEEDBACK_BULLET}</span>
                             {content}
                         </p>
                     );

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -185,7 +185,7 @@ const PracticeResultKeyword = () => {
 
                 <Card className="p-4">
                     <p className="text-sm text-muted-foreground mb-3">{TEXT_MY_ANSWER_LABEL}</p>
-                    <div className="text-sm leading-relaxed whitespace-pre-wrap">
+                    <div className="h-[300px] overflow-y-auto text-sm leading-relaxed whitespace-pre-wrap">
                         {myAnswer}
                     </div>
                 </Card>

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -29,6 +29,7 @@ const TEXT_BACK_MODAL_DESC = '연습모드로 돌아가시겠습니까?';
 const TEXT_BACK_MODAL_CONFIRM = '연습모드로 돌아가기';
 const TEXT_BACK_MODAL_CANCEL = '닫기';
 const TEXT_RESULT_BUTTON = 'AI 분석결과 보기';
+const TEXT_RETRY_BUTTON = '다시 답변하기';
 const TEXT_PAGE_TITLE = '답변 분석';
 const TEXT_QUESTION_LABEL = '질문';
 const TEXT_MY_ANSWER_LABEL = '나의 답변';
@@ -60,6 +61,7 @@ const PracticeResultKeyword = () => {
     const [feedbackError, setFeedbackError] = useState('');
 
     const myAnswer = state?.answerText || '';
+    const retryPath = state?.retryPath || `/practice/answer/${questionId}`;
 
     // 0~95%까지 천천히 올라가며 대기 상태를 표현한다.
     useEffect(() => {
@@ -227,8 +229,16 @@ const PracticeResultKeyword = () => {
                         </div>
                     </Card>
                 ) : feedbackError ? (
-                    <div className="text-center text-rose-500 text-sm py-4">
-                        {feedbackError}
+                    <div className="space-y-3">
+                        <div className="text-center text-rose-500 text-sm py-2">
+                            {feedbackError}
+                        </div>
+                        <Button
+                            onClick={() => navigate(retryPath)}
+                            className="w-full rounded-xl h-12"
+                        >
+                            {TEXT_RETRY_BUTTON}
+                        </Button>
                     </div>
                 ) : (
                     <Button

--- a/src/app/pages/PracticeSTT.jsx
+++ b/src/app/pages/PracticeSTT.jsx
@@ -73,7 +73,7 @@ const PracticeSTT = () => {
                         <Loader2 className="w-16 h-16" />
                     </Motion.div>
 
-                    <h2 className="text-2xl mb-3">{statusMessage}</h2>
+                    <h2 className="text-2xl mb-3 text-white">{statusMessage}</h2>
                     <p className="text-white/80">
                         잠시만 기다려주세요
                     </p>

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -173,6 +173,7 @@ const ProfileMain = () => {
 
     const observerRef = useRef(null);
     const categoryDropdownRef = useRef(null);
+    const filterModalContentRef = useRef(null);
     const scrollPositionRef = useRef(0);
     const shouldRestoreScrollRef = useRef(false);
 
@@ -226,6 +227,30 @@ const ProfileMain = () => {
             document.removeEventListener('touchstart', handleClickOutside);
         };
     }, []);
+
+    useEffect(() => {
+        if (!showFilterModal) return;
+        const originalOverflow = document.body.style.overflow;
+        const originalTouchAction = document.body.style.touchAction;
+        const originalOverscroll = document.body.style.overscrollBehavior;
+        document.body.style.overflow = 'hidden';
+        document.body.style.touchAction = 'none';
+        document.body.style.overscrollBehavior = 'none';
+
+        const preventScroll = (event) => {
+            const content = filterModalContentRef.current;
+            if (content && content.contains(event.target)) return;
+            event.preventDefault();
+        };
+
+        document.addEventListener('touchmove', preventScroll, { passive: false });
+        return () => {
+            document.body.style.overflow = originalOverflow;
+            document.body.style.touchAction = originalTouchAction;
+            document.body.style.overscrollBehavior = originalOverscroll;
+            document.removeEventListener('touchmove', preventScroll);
+        };
+    }, [showFilterModal]);
 
     const handleDateFromChange = (value) => {
         const launchClampedFrom = value < SERVICE_LAUNCH_DATE ? SERVICE_LAUNCH_DATE : value;
@@ -446,7 +471,11 @@ const ProfileMain = () => {
                             }
                         }}
                     >
-                        <div className="filter-modal-content" onClick={(e) => e.stopPropagation()}>
+                        <div
+                            className="filter-modal-content"
+                            ref={filterModalContentRef}
+                            onClick={(e) => e.stopPropagation()}
+                        >
                             <div className="space-y-3 mb-4">
                                 <div className="grid grid-cols-[0.8fr_1.2fr] gap-3">
                                     <div className="space-y-2">

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -64,17 +64,37 @@ const formatDateDisplay = (dateString) => {
     return dateString;
 };
 
+const formatCount = (value) => {
+    if (value === null || value === undefined) return '-';
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) return '-';
+    if (numericValue < 1000) return String(numericValue);
+
+    const units = ['K', 'M', 'B', 'T'];
+    let unitIndex = -1;
+    let scaled = numericValue;
+
+    while (scaled >= 1000 && unitIndex < units.length - 1) {
+        scaled /= 1000;
+        unitIndex += 1;
+    }
+
+    const precision = scaled >= 10 ? 0 : 1;
+    const display = scaled.toFixed(precision).replace(/\.0$/, '');
+    return `${display}${units[unitIndex]}`;
+};
+
 // 통계 카드 컴포넌트
 const StatCard = ({ icon, label, value, unit }) => {
-    const numericValue = value.replace(/[^0-9]/g, '');
-    const displayValue = value.includes('-') ? '-' : numericValue || '0';
+    const displayValue = formatCount(value);
+    const showUnit = displayValue !== '-' && unit;
 
     return (
         <div className="stat-card">
             <div className="stat-icon">{icon}</div>
             <div className="stat-content">
                 <span className="stat-value">
-                    {displayValue}<span className="stat-unit">{unit}</span>
+                    {displayValue}{showUnit && <span className="stat-unit">{unit}</span>}
                 </span>
                 <span className="stat-label">{label}</span>
             </div>
@@ -268,9 +288,9 @@ const ProfileMain = () => {
     const weeklyStats = weeklyStatsData?.data;
 
     const stats = [
-        { icon: Calendar, label: '총 학습일', value: `${userStats?.distinct_days ?? '-'}일` },
-        { icon: Target, label: '연습 횟수', value: `${userStats?.practice_mode_count ?? '-'}회` },
-        { icon: MessageSquare, label: '총 답변 수', value: `${userStats?.total_questions_answered ?? '-'}개` },
+        { icon: Calendar, label: '총 학습일', value: userStats?.distinct_days, unit: '일' },
+        { icon: Target, label: '연습 횟수', value: userStats?.practice_mode_count, unit: '회' },
+        { icon: MessageSquare, label: '총 답변 수', value: userStats?.total_questions_answered, unit: '개' },
     ];
 
     // 카테고리 색상 매핑
@@ -344,7 +364,7 @@ const ProfileMain = () => {
                                 icon={<Icon size={24} />}
                                 label={stat.label}
                                 value={stat.value}
-                                unit={stat.value.includes('일') ? '일' : stat.value.includes('회') ? '회' : '개'}
+                                unit={stat.unit}
                             />
                         );
                     })}

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -7,16 +7,7 @@ import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 import { useUserStats } from '@/app/hooks/useUserStats.js';
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from '@/app/components/ui/alert-dialog';
+import { useFeedbackFormDialog } from '@/app/hooks/useFeedbackFormDialog';
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
 
@@ -26,22 +17,8 @@ const ANSWER_TYPE_LABELS = {
     PORTFOLIO_INTERVIEW: '포트폴리오',
 };
 
-const FEEDBACK_FORM_URL = 'https://forms.gle/nraq9VyYzQogYgFSA';
 const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
 const SERVICE_LAUNCH_DATE = '2026-02-04';
-const TEXT_FEEDBACK_CONFIRM_TITLE = 'Q-Feed v1.0.0 사용 후기 설문';
-const TEXT_FEEDBACK_CONFIRM_DESC = [
-    'Q-Feed 사용해 주셔서 감사합니다! 🎙️',
-    '베타 단계라 의견을 빠르게 반영하고 있어요.',
-];
-const TEXT_FEEDBACK_CONFIRM_POINTS = [
-    '👍 좋았던 점',
-    '🛠️ 불편했던 점',
-    '🌱 바라는 점',
-];
-const TEXT_FEEDBACK_CONFIRM_FOOTER = '총 5문항 · 약 1분. 버튼을 누르면 새 창에서 구글폼이 열립니다.';
-const TEXT_FEEDBACK_CONFIRM_ACTION = '예, 피드백 남길래요';
-const TEXT_FEEDBACK_CONFIRM_CANCEL = '나중에 할게요';
 
 const toDateInputValue = (date) => {
     const year = date.getFullYear();
@@ -189,7 +166,7 @@ const ProfileMain = () => {
     const [categoryFilter, setCategoryFilter] = useState('ALL');
     const [isCategoryOpen, setIsCategoryOpen] = useState(false);
     const [showFilterModal, setShowFilterModal] = useState(false);
-    const [showFeedbackConfirm, setShowFeedbackConfirm] = useState(false);
+    const { open: openFeedbackDialog, dialog: feedbackDialog } = useFeedbackFormDialog();
 
     const categoryValue = categoryFilter === 'ALL' ? undefined : categoryFilter;
 
@@ -200,11 +177,6 @@ const ProfileMain = () => {
         ],
         [categoryMap]
     );
-
-    const handleOpenFeedbackForm = () => {
-        window.open(FEEDBACK_FORM_URL, '_blank', 'noopener,noreferrer');
-        setShowFeedbackConfirm(false);
-    };
 
     const requestScrollRestore = () => {
         scrollPositionRef.current = window.scrollY;
@@ -400,7 +372,7 @@ const ProfileMain = () => {
                         type="button"
                         className="btn-secondary text-xs px-3 py-2"
                         style={{ marginLeft: 'auto' }}
-                        onClick={() => setShowFeedbackConfirm(true)}
+                        onClick={openFeedbackDialog}
                     >
                         피드백 남기기
                     </button>
@@ -649,36 +621,7 @@ const ProfileMain = () => {
 
             <BottomNav />
 
-            <AlertDialog open={showFeedbackConfirm} onOpenChange={setShowFeedbackConfirm}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>{TEXT_FEEDBACK_CONFIRM_TITLE}</AlertDialogTitle>
-                        <AlertDialogDescription className="text-[13px] leading-snug">
-                            <div className="space-y-2">
-                                <div className="space-y-1">
-                                    {TEXT_FEEDBACK_CONFIRM_DESC.map((line) => (
-                                        <p key={line}>{line}</p>
-                                    ))}
-                                </div>
-                                <ul className="space-y-1">
-                                    {TEXT_FEEDBACK_CONFIRM_POINTS.map((point) => (
-                                        <li key={point} className="leading-snug">
-                                            {point}
-                                        </li>
-                                    ))}
-                                </ul>
-                                <p className="text-muted-foreground">{TEXT_FEEDBACK_CONFIRM_FOOTER}</p>
-                            </div>
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>{TEXT_FEEDBACK_CONFIRM_CANCEL}</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleOpenFeedbackForm}>
-                            {TEXT_FEEDBACK_CONFIRM_ACTION}
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            {feedbackDialog}
         </div>
     );
 };

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -7,6 +7,16 @@ import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 import { useUserStats } from '@/app/hooks/useUserStats.js';
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/app/components/ui/alert-dialog';
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
 
@@ -16,8 +26,22 @@ const ANSWER_TYPE_LABELS = {
     PORTFOLIO_INTERVIEW: '포트폴리오',
 };
 
+const FEEDBACK_FORM_URL = 'https://forms.gle/nraq9VyYzQogYgFSA';
 const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
 const SERVICE_LAUNCH_DATE = '2026-02-04';
+const TEXT_FEEDBACK_CONFIRM_TITLE = 'Q-Feed v1.0.0 사용 후기 설문';
+const TEXT_FEEDBACK_CONFIRM_DESC = [
+    'Q-Feed 사용해 주셔서 감사합니다! 🎙️',
+    '베타 단계라 의견을 빠르게 반영하고 있어요.',
+];
+const TEXT_FEEDBACK_CONFIRM_POINTS = [
+    '👍 좋았던 점',
+    '🛠️ 불편했던 점',
+    '🌱 바라는 점',
+];
+const TEXT_FEEDBACK_CONFIRM_FOOTER = '총 5문항 · 약 1분. 버튼을 누르면 새 창에서 구글폼이 열립니다.';
+const TEXT_FEEDBACK_CONFIRM_ACTION = '예, 피드백 남길래요';
+const TEXT_FEEDBACK_CONFIRM_CANCEL = '나중에 할게요';
 
 const toDateInputValue = (date) => {
     const year = date.getFullYear();
@@ -164,6 +188,7 @@ const ProfileMain = () => {
     const [categoryFilter, setCategoryFilter] = useState('ALL');
     const [isCategoryOpen, setIsCategoryOpen] = useState(false);
     const [showFilterModal, setShowFilterModal] = useState(false);
+    const [showFeedbackConfirm, setShowFeedbackConfirm] = useState(false);
 
     const categoryValue = categoryFilter === 'ALL' ? undefined : categoryFilter;
 
@@ -174,6 +199,11 @@ const ProfileMain = () => {
         ],
         [categoryMap]
     );
+
+    const handleOpenFeedbackForm = () => {
+        window.open(FEEDBACK_FORM_URL, '_blank', 'noopener,noreferrer');
+        setShowFeedbackConfirm(false);
+    };
 
     const requestScrollRestore = () => {
         scrollPositionRef.current = window.scrollY;
@@ -341,15 +371,14 @@ const ProfileMain = () => {
                             면접 준비 중
                         </span>
                     </div>
-                    <a
-                        className="btn-secondary"
-                        href="https://forms.gle/nraq9VyYzQogYgFSA"
-                        target="_blank"
-                        rel="noopener noreferrer"
+                    <button
+                        type="button"
+                        className="btn-secondary text-xs px-3 py-2"
                         style={{ marginLeft: 'auto' }}
+                        onClick={() => setShowFeedbackConfirm(true)}
                     >
                         피드백 남기기
-                    </a>
+                    </button>
                 </div>
             </section>
 
@@ -590,6 +619,37 @@ const ProfileMain = () => {
             <div className="scroll-padding" />
 
             <BottomNav />
+
+            <AlertDialog open={showFeedbackConfirm} onOpenChange={setShowFeedbackConfirm}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{TEXT_FEEDBACK_CONFIRM_TITLE}</AlertDialogTitle>
+                        <AlertDialogDescription className="text-[13px] leading-snug">
+                            <div className="space-y-2">
+                                <div className="space-y-1">
+                                    {TEXT_FEEDBACK_CONFIRM_DESC.map((line) => (
+                                        <p key={line}>{line}</p>
+                                    ))}
+                                </div>
+                                <ul className="space-y-1">
+                                    {TEXT_FEEDBACK_CONFIRM_POINTS.map((point) => (
+                                        <li key={point} className="leading-snug">
+                                            {point}
+                                        </li>
+                                    ))}
+                                </ul>
+                                <p className="text-muted-foreground">{TEXT_FEEDBACK_CONFIRM_FOOTER}</p>
+                            </div>
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>{TEXT_FEEDBACK_CONFIRM_CANCEL}</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleOpenFeedbackForm}>
+                            {TEXT_FEEDBACK_CONFIRM_ACTION}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 };

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -291,7 +291,7 @@ const ProfileMain = () => {
     }, [categoryMap]);
 
     // 주간 목표 계산
-    const totalThisWeek = weeklyStats.total_this_week ?? 0;
+    const totalThisWeek = weeklyStats?.total_this_week ?? 0;
     const weeklyGoal = 7; // 목표값
     const weeklyProgress = Math.min((totalThisWeek / weeklyGoal) * 100, 100);
     const remainingCount = Math.max(weeklyGoal - totalThisWeek, 0);

--- a/src/app/pages/SettingMain.jsx
+++ b/src/app/pages/SettingMain.jsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 
 import { AppHeader } from '@/app/components/AppHeader';
 import { deleteAccount } from '@/api/userApi';
+import { useFeedbackFormDialog } from '@/app/hooks/useFeedbackFormDialog';
 
 const SettingMain = () => {
 
@@ -28,6 +29,7 @@ const SettingMain = () => {
     const [showLogoutDialog, setShowLogoutDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [notifications, setNotifications] = useState(true);
+    const { open: openFeedbackDialog, dialog: feedbackDialog } = useFeedbackFormDialog();
 
     const handleLogout = async () => {
         await logout();
@@ -70,7 +72,7 @@ const SettingMain = () => {
                     icon: HelpCircle,
                     label: '피드백 남기기',
                     action: <span className="text-sm text-muted-foreground"></span>,
-                    onClick: () => window.open('https://forms.gle/nraq9VyYzQogYgFSA', '_blank', 'noopener,noreferrer'),
+                    onClick: openFeedbackDialog,
                 },
                 {
                     icon: HelpCircle,
@@ -102,20 +104,22 @@ const SettingMain = () => {
                     <section key={groupIndex}>
                         <h2 className="text-sm text-muted-foreground mb-3 px-2">{group.title}</h2>
 
-                        <Card className="divide-y">
+                        <Card className="p-0 gap-0 overflow-hidden">
                             {group.items.map((item, itemIndex) => {
                                 const Icon = item.icon;
                                 return (
                                     <div
                                         key={itemIndex}
-                                        className="flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 transition-colors"
+                                        className={`setting-item flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 transition-colors ${itemIndex > 0 ? 'border-t border-gray-100' : ''}`}
                                         onClick={item.onClick}
                                     >
-                                        <div className="flex items-center gap-3">
+                                        <div className="setting-main flex items-center gap-3">
                                             <Icon className={`w-5 h-5 ${item.textColor || 'text-muted-foreground'}`} />
                                             <span className={item.textColor || 'text-foreground'}>{item.label}</span>
                                         </div>
-                                        {item.action}
+                                        {item.action && (
+                                            <div className="setting-action">{item.action}</div>
+                                        )}
                                     </div>
                                 );
                             })}
@@ -144,6 +148,8 @@ const SettingMain = () => {
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
+
+            {feedbackDialog}
 
             {/* Delete Account Dialog */}
             <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1170,6 +1170,86 @@
   50% { opacity: 0.5; }
 }
 
+@media (max-width: 430px) {
+  .profile-card {
+    flex-wrap: wrap;
+  }
+
+  .profile-info {
+    min-width: 0;
+  }
+
+  .profile-status {
+    white-space: nowrap;
+  }
+
+  .stats-section {
+    padding: 20px 16px;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-grid .stat-card:last-child {
+    grid-column: span 2;
+  }
+
+  .stat-card {
+    padding: 16px 12px;
+  }
+
+  .stat-value {
+    font-size: 22px;
+    line-height: 1.1;
+  }
+
+  .stat-label {
+    font-size: 12px;
+    line-height: 1.2;
+  }
+}
+
+@media (max-width: 390px) {
+  .profile-section {
+    padding: 16px;
+  }
+
+  .profile-card {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 18px;
+    gap: 12px;
+  }
+
+  .avatar {
+    width: 56px;
+    height: 56px;
+    font-size: 22px;
+  }
+
+  .profile-info {
+    width: 100%;
+  }
+
+  .profile-name {
+    font-size: 18px;
+  }
+
+  .profile-status {
+    font-size: 11px;
+    padding: 4px 10px;
+  }
+
+  .profile-card .btn-secondary {
+    width: 100%;
+    text-align: center;
+    padding: 10px 12px;
+    margin-left: 0 !important;
+    align-self: stretch;
+  }
+}
+
 /* 통계 섹션 */
 .stats-section {
   padding: 24px 20px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1475,15 +1475,14 @@
 .filter-modal {
   position: fixed;
   top: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   right: 0;
   bottom: 0;
+  width: 100%;
   background: rgba(0, 0, 0, 0.5);
   z-index: 200;
   display: flex;
   align-items: flex-end;
-  max-width: 428px;
   animation: fadeIn 0.2s ease-out;
 }
 
@@ -1501,8 +1500,10 @@
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   padding: 24px 20px;
   width: 100%;
+  max-width: 428px;
   max-height: 80vh;
   overflow-y: auto;
+  margin: 0 auto;
   animation: slideUpModal 0.3s ease-out;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1029,7 +1029,6 @@
   background: var(--gray-50);
   padding-bottom: 90px;
   position: relative;
-  overflow-x: hidden;
 }
 
 /* 헤더 */
@@ -1038,10 +1037,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  background: transparent;
+  background: rgba(250, 250, 250, 0.9);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--gray-100);
   position: sticky;
   top: 0;
-  z-index: 100;
+  z-index: 200;
 }
 
 .header-title {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1069,6 +1069,31 @@
   color: var(--gray-800);
 }
 
+.setting-item {
+  gap: 12px;
+  position: relative;
+}
+
+.setting-main {
+  min-width: 0;
+}
+
+.setting-action {
+  margin-left: auto;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+@media (max-width: 430px) {
+  .setting-item {
+    align-items: flex-start;
+  }
+
+  .setting-action {
+    max-width: 48%;
+  }
+}
+
 /* 프로필 섹션 */
 .profile-section {
   padding: 20px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1188,24 +1188,32 @@
   }
 
   .stats-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
   }
 
   .stats-grid .stat-card:last-child {
-    grid-column: span 2;
+    grid-column: auto;
   }
 
   .stat-card {
-    padding: 16px 12px;
+    padding: 12px 8px;
+    min-height: 96px;
+  }
+
+  .stat-icon {
+    width: 32px;
+    height: 32px;
+    margin-bottom: 8px;
   }
 
   .stat-value {
-    font-size: 22px;
+    font-size: 18px;
     line-height: 1.1;
   }
 
   .stat-label {
-    font-size: 12px;
+    font-size: 11px;
     line-height: 1.2;
   }
 }
@@ -1250,6 +1258,41 @@
   }
 }
 
+@media (max-width: 380px) {
+  .stat-card {
+    padding: 8px 6px;
+    min-height: 82px;
+    min-width: 0;
+  }
+
+  .stat-icon {
+    width: 28px;
+    height: 28px;
+    margin-bottom: 6px;
+  }
+
+  .stat-value {
+    font-size: 14px;
+    gap: 1px;
+  }
+
+  .stat-unit {
+    font-size: 10px;
+  }
+
+  .stat-label {
+    font-size: 9px;
+  }
+
+  .stat-content {
+    gap: 2px;
+  }
+
+  .stats-grid {
+    gap: 6px;
+  }
+}
+
 /* 통계 섹션 */
 .stats-section {
   padding: 24px 20px;
@@ -1259,6 +1302,8 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 12px;
+  align-items: stretch;
+  grid-auto-rows: 1fr;
 }
 
 .stat-card {
@@ -1268,6 +1313,11 @@
   padding: 20px 16px;
   text-align: center;
   transition: all 0.2s ease;
+  height: 100%;
+  min-height: 118px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .stat-card:hover {
@@ -1291,6 +1341,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-height: 48px;
 }
 
 .stat-value {
@@ -1298,6 +1349,13 @@
   font-weight: var(--font-weight-bold);
   color: var(--gray-900);
   font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  min-height: 1.1em;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 2px;
+  white-space: nowrap;
 }
 
 .stat-unit {
@@ -1310,6 +1368,12 @@
 .stat-label {
   font-size: 13px;
   color: var(--gray-600);
+  line-height: 1.2;
+  min-height: 2.4em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 /* 성장 지표 */


### PR DESCRIPTION
  ## 요약
  - 프로필/설정/모달 UX 개선과 모바일 레이아웃 안정화
  - 답변 플로우 안정성 개선(길이 제한, 재시도 이동, 편집 화면 보정)
  - 학습 기록/AI 피드백 화면 표시 버그 수정
  - FE CI/CD 환경 분리(staging/prod) 반영

  ## 변경사항
  - 프로필 헤더 sticky 고정 및 배경 처리 개선
  - 프로필/설정/필터 모달 UX 및 레이아웃 개선
  - AI 피드백 불릿 표시 개선
  - LearningRecordDetail 레이더 차트 미표시 수정
  - 텍스트/편집 답변 1500자 초과 제한 및 제출 실패 재시도 이동 추가
  - 음성/텍스트 답변 화면 UI 정리(색상/스크롤/textarea 고정)
  - FE CI/CD change (staging/prod)

  ## 관련 커밋
  - 77dbb8e feat: FE CI/CD change (staging/prod)
  - c4fb9c5 fix:[#135]프로필 헤더 sticky 고정 및 배경 처리 개선
  - 5213725 fix:[#134]피드백 설문 모달 공통화 + 프로필/설정 UX 개선(모바일 레이아웃·필터 모달·설정 리스트 구분선)
  - b880989 fix:[#133]프로필 필터 모달 오버레이가 중앙만 덮이는 문제 수정
  - 39ad482 fix:[#132]피드백 남기기 모달 문구/레이아웃 개선(모바일 가독성 + 외부 이동 안내)
  - 6cdabc2 fix:[#131]프로필 통계 카드 레이아웃 깨짐 대응 + 숫자 컴팩트 표기 추가
  - 3ab377e fix:[#130]프로필 상단 뱃지/버튼 모바일(414px 이하) 레이아웃 깨짐 대응
  - e59c556 fix:[#75]텍스트/편집 답변 1500자 초과 검증 및 제출 제한 추가
  - 6f4aea3 fix:[#122]답변 제출 실패 시 재시도 이동 버튼 추가(텍스트/음성 분기)
  - 1676474 fix:[#123]프로필 새로고침 시 주간 통계 undefined 접근으로 인한 화이트스크린 방지
  - 7d04a95 fix:[#124]AI 피드백 불릿 표시 개선(파싱·표시 분리)
  - 7866de4 fix:[#127]연습 답변 편집/키워드 화면 답변 영역 스크롤 고정 및 글자 수 표시
  - b267289 fix:[#118]텍스트로 답변, STT 편집화면 textarea y축 고정
  - 07c6744 fix:[#117]음성답변, 분석화면 Text 컬러 통일
  - 951f858 fix:[#125]LearningRecordDetail 레이더 차트 미표시