### PR TITLE
feat:[#142]프로필 필터에 questionType + 타입별 카테고리 연동

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,7 +8,7 @@ VITE_API_BASE_URL=https://q-feed.com
 
 # Feature flags
 # Show "Real Interview" entry point (true/false)
-VITE_SHOW_REAL_INTERVIEW=false
+VITE_SHOW_REAL_INTERVIEW=true
 
 # Show "Portfolio Interview" entry point (true/false)
 VITE_SHOW_PORTFOLIO_INTERVIEW=false

--- a/src/app/constants/questionCategoryMeta.js
+++ b/src/app/constants/questionCategoryMeta.js
@@ -1,0 +1,57 @@
+export const QUESTION_TYPE_FALLBACK_LABELS = Object.freeze({
+  CS: 'CS',
+  SYSTEM_DESIGN: '시스템 디자인',
+  PORTFOLIO: '포트폴리오',
+})
+
+export const QUESTION_CATEGORY_FALLBACK_LABELS = Object.freeze({
+  OS: '운영체제',
+  NETWORK: '네트워크',
+  DB: '데이터베이스',
+  COMPUTER_ARCHITECTURE: '컴퓨터 구조',
+  DATA_STRUCTURE_ALGORITHM: '자료구조&알고리즘',
+  SOCIAL: '소셜/피드 시스템',
+  NOTIFICATION: '알림 시스템',
+  REALTIME: '실시간 통신 시스템',
+  SEARCH: '검색 시스템',
+  MEDIA: '미디어/스트리밍 시스템',
+  STORAGE: '파일 저장/협업 시스템',
+  PLATFORM: '플랫폼 인프라 시스템',
+  TRANSACTION: '거래/정산 시스템',
+})
+
+export const DEFAULT_QUESTION_CATEGORY_COLOR = Object.freeze({
+  bg: '#F5F5F5',
+  text: '#616161',
+})
+
+export const QUESTION_CATEGORY_COLOR_BY_KEY = Object.freeze({
+  OS: { bg: '#F3E5F5', text: '#7B1FA2' },
+  NETWORK: { bg: '#E8F5E9', text: '#2E7D32' },
+  DB: { bg: '#FFF3E0', text: '#E65100' },
+  COMPUTER_ARCHITECTURE: { bg: '#E8EAF6', text: '#3949AB' },
+  DATA_STRUCTURE_ALGORITHM: { bg: '#E3F2FD', text: '#1565C0' },
+  SOCIAL: { bg: '#F3E5F5', text: '#7B1FA2' },
+  NOTIFICATION: { bg: '#E0F2F1', text: '#00695C' },
+  REALTIME: { bg: '#E8F0FE', text: '#1A73E8' },
+  SEARCH: { bg: '#FFF8E1', text: '#F57F17' },
+  MEDIA: { bg: '#FCE4EC', text: '#AD1457' },
+  STORAGE: { bg: '#EDE7F6', text: '#5E35B1' },
+  PLATFORM: { bg: '#E1F5FE', text: '#0277BD' },
+  TRANSACTION: { bg: '#F1F8E9', text: '#558B2F' },
+})
+
+export function getQuestionTypeLabel(typeKey, typeMap = {}) {
+  if (!typeKey) return ''
+  return typeMap[typeKey] || QUESTION_TYPE_FALLBACK_LABELS[typeKey] || typeKey
+}
+
+export function getQuestionCategoryLabel(categoryKey, categoryMap = {}) {
+  if (!categoryKey) return ''
+  return categoryMap[categoryKey] || QUESTION_CATEGORY_FALLBACK_LABELS[categoryKey] || categoryKey
+}
+
+export function getQuestionCategoryColor(categoryKey) {
+  if (!categoryKey) return DEFAULT_QUESTION_CATEGORY_COLOR
+  return QUESTION_CATEGORY_COLOR_BY_KEY[categoryKey] || DEFAULT_QUESTION_CATEGORY_COLOR
+}

--- a/src/app/hooks/useAnswersInfinite.js
+++ b/src/app/hooks/useAnswersInfinite.js
@@ -3,12 +3,13 @@ import { fetchAnswers } from '@/api/answerApi'
 
 const PAGE_SIZE = 10
 
-export function useAnswersInfinite({ type, category, dateFrom, dateTo } = {}) {
+export function useAnswersInfinite({ type, questionType, category, dateFrom, dateTo } = {}) {
   return useInfiniteQuery({
-    queryKey: ['answers', { type, category, dateFrom, dateTo }],
+    queryKey: ['answers', { type, questionType, category, dateFrom, dateTo }],
     queryFn: async ({ pageParam = null }) => {
       const response = await fetchAnswers({
         type,
+        questionType,
         category,
         dateFrom,
         dateTo,

--- a/src/app/hooks/useFeedbackFormDialog.jsx
+++ b/src/app/hooks/useFeedbackFormDialog.jsx
@@ -45,7 +45,7 @@ export const useFeedbackFormDialog = () => {
             <AlertDialogContent>
                 <AlertDialogHeader>
                     <AlertDialogTitle>{TEXT_TITLE}</AlertDialogTitle>
-                    <AlertDialogDescription className="text-[13px] leading-snug">
+                    <AlertDialogDescription asChild className="text-[13px] leading-snug">
                         <div className="space-y-2">
                             <div className="space-y-1">
                                 {TEXT_DESC.map((line) => (

--- a/src/app/hooks/useQuestionCategories.js
+++ b/src/app/hooks/useQuestionCategories.js
@@ -1,15 +1,48 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchQuestionCategories } from '@/api/questionApi'
 
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+}
+
 function mapCategories(response) {
-  const data = response?.data ?? response ?? {}
-  const categories = data.categories ?? {}
-  return categories && typeof categories === 'object' ? categories : {}
+  const categories = response?.data?.categories
+  if (!isPlainObject(categories)) {
+    return {
+      byType: {},
+      flat: {},
+    }
+  }
+
+  const byType = {}
+  const flat = {}
+
+  Object.entries(categories).forEach(([typeKey, categoryGroup]) => {
+    if (!isPlainObject(categoryGroup)) return
+
+    const normalizedGroup = {}
+    Object.entries(categoryGroup).forEach(([categoryKey, label]) => {
+      if (typeof label !== 'string') return
+      normalizedGroup[categoryKey] = label
+      flat[categoryKey] = label
+    })
+
+    if (Object.keys(normalizedGroup).length > 0) {
+      byType[typeKey] = normalizedGroup
+    }
+  })
+
+  return {
+    byType,
+    flat,
+  }
 }
 
 export function useQuestionCategories() {
   return useQuery({
     queryKey: ['questions', 'categories'],
+    staleTime: 0,
+    refetchOnMount: 'always',
     queryFn: async () => {
       const response = await fetchQuestionCategories()
       return mapCategories(response)

--- a/src/app/hooks/useRecommendedQuestion.js
+++ b/src/app/hooks/useRecommendedQuestion.js
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchRecommendedQuestion } from '@/api/questionApi'
 
+const NOT_FOUND_MESSAGE = '질문을 찾을 수 없습니다'
+
 function mapQuestion(response) {
   const data = response?.data ?? response ?? {}
   return {
@@ -16,9 +18,18 @@ export function useRecommendedQuestion() {
   return useQuery({
     queryKey: ['questions', 'recommendation'],
     queryFn: async () => {
-      const response = await fetchRecommendedQuestion()
-      const mapped = mapQuestion(response)
-      return mapped?.id ? mapped : null
+      try {
+        const response = await fetchRecommendedQuestion()
+        const mapped = mapQuestion(response)
+        return mapped?.id ? mapped : null
+      } catch (error) {
+        // 추천 질문이 없는 경우(404/Q001)는 예외가 아니라 빈 상태로 처리한다.
+        const message = String(error?.message ?? '')
+        if (message.includes(NOT_FOUND_MESSAGE) || message.includes('404')) {
+          return null
+        }
+        throw error
+      }
     },
   })
 }

--- a/src/app/pages/LearningRecordDetail.jsx
+++ b/src/app/pages/LearningRecordDetail.jsx
@@ -8,6 +8,7 @@ import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, Responsi
 import { useAnswerDetail } from '@/app/hooks/useAnswerDetail'
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories'
 import { useQuestionTypes } from '@/app/hooks/useQuestionTypes'
+import { getQuestionCategoryLabel, getQuestionTypeLabel } from '@/app/constants/questionCategoryMeta'
 
 const TEXT_PAGE_TITLE = '학습 기록 상세'
 const TEXT_HEADER_DESC = '제출한 답변과 AI 피드백을 확인해보세요'
@@ -90,7 +91,8 @@ const LearningRecordDetail = () => {
   const navigate = useNavigate()
   const { answerId } = useParams()
   const { data, isLoading, error } = useAnswerDetail(answerId)
-  const { data: CATEGORY_LABELS = {} } = useQuestionCategories()
+  const { data: categoryData } = useQuestionCategories()
+  const CATEGORY_LABELS = categoryData?.flat ?? {}
   const { data: QUESTION_TYPE_LABELS = {} } = useQuestionTypes()
 
   const answerDetail = data?.data ?? data ?? {}
@@ -125,10 +127,12 @@ const LearningRecordDetail = () => {
   const mergedImprovementsText = hasRadarChart
     ? improvementsText
     : [strengthsText, improvementsText].filter(Boolean).join('\n')
-  const questionTypeLabel = question?.type ? QUESTION_TYPE_LABELS[question.type] || question.type : null
+  const questionTypeLabel = question?.type
+    ? getQuestionTypeLabel(question.type, QUESTION_TYPE_LABELS)
+    : null
   const questionCategory = question?.category ? (
     <Badge variant="secondary" className="bg-rose-100 text-rose-700">
-      {CATEGORY_LABELS[question.category] || question.category}
+      {getQuestionCategoryLabel(question.category, CATEGORY_LABELS)}
     </Badge>
   ) : null
 

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -6,10 +6,14 @@ import { useAuth } from '@/context/AuthContext';
 import { useAnswersInfinite } from '@/app/hooks/useAnswersInfinite';
 import { useUserStats } from '@/app/hooks/useUserStats.js';
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
+import { useQuestionTypes } from '@/app/hooks/useQuestionTypes';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
 import { useFeedbackFormDialog } from '@/app/hooks/useFeedbackFormDialog';
-
-const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
+import {
+    getQuestionCategoryColor,
+    getQuestionCategoryLabel,
+    getQuestionTypeLabel,
+} from '@/app/constants/questionCategoryMeta';
 
 const ANSWER_TYPE_LABELS = {
     PRACTICE_INTERVIEW: '연습',
@@ -19,6 +23,8 @@ const ANSWER_TYPE_LABELS = {
 
 const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
 const SERVICE_LAUNCH_DATE = '2026-02-04';
+const EMPTY_CATEGORY_MAP = Object.freeze({});
+const ALL_FILTER_VALUE = 'ALL';
 
 const toDateInputValue = (date) => {
     const year = date.getFullYear();
@@ -146,9 +152,13 @@ const HistoryItem = ({
 const ProfileMain = () => {
     const navigate = useNavigate();
     const { nickname } = useAuth();
-    const { data: categoryMap = {} } = useQuestionCategories();
+    const { data: categoryData } = useQuestionCategories();
+    const { data: questionTypeMap = {} } = useQuestionTypes();
+    const categoryMap = categoryData?.flat ?? EMPTY_CATEGORY_MAP;
+    const categoriesByType = categoryData?.byType ?? EMPTY_CATEGORY_MAP;
 
     const observerRef = useRef(null);
+    const typeDropdownRef = useRef(null);
     const categoryDropdownRef = useRef(null);
     const filterModalContentRef = useRef(null);
     const scrollPositionRef = useRef(0);
@@ -163,20 +173,40 @@ const ProfileMain = () => {
         dateTo,
     });
     const modeFilter = MODE_OPTIONS[0].value;
-    const [categoryFilter, setCategoryFilter] = useState('ALL');
+    const [questionTypeFilter, setQuestionTypeFilter] = useState(ALL_FILTER_VALUE);
+    const [categoryFilter, setCategoryFilter] = useState(ALL_FILTER_VALUE);
+    const [isTypeOpen, setIsTypeOpen] = useState(false);
     const [isCategoryOpen, setIsCategoryOpen] = useState(false);
     const [showFilterModal, setShowFilterModal] = useState(false);
     const { open: openFeedbackDialog, dialog: feedbackDialog } = useFeedbackFormDialog();
 
-    const categoryValue = categoryFilter === 'ALL' ? undefined : categoryFilter;
+    const questionTypeValue =
+        questionTypeFilter === ALL_FILTER_VALUE ? undefined : questionTypeFilter;
+    const categoryValue = categoryFilter === ALL_FILTER_VALUE ? undefined : categoryFilter;
 
-    const categoryOptions = useMemo(
-        () => [
-            { value: 'ALL', label: '전체' },
-            ...Object.entries(categoryMap).map(([value, label]) => ({ value, label })),
-        ],
-        [categoryMap]
-    );
+    const questionTypeOptions = useMemo(() => {
+        const typeOptions = Object.keys(categoriesByType).map((typeKey) => ({
+            value: typeKey,
+            label: getQuestionTypeLabel(typeKey, questionTypeMap),
+        }));
+        return [{ value: ALL_FILTER_VALUE, label: '전체' }, ...typeOptions];
+    }, [categoriesByType, questionTypeMap]);
+
+    const categoryOptions = useMemo(() => {
+        if (questionTypeFilter === ALL_FILTER_VALUE) {
+            return [{ value: ALL_FILTER_VALUE, label: '전체' }];
+        }
+
+        const selectedTypeCategories = categoriesByType[questionTypeFilter];
+        if (!selectedTypeCategories || typeof selectedTypeCategories !== 'object') {
+            return [{ value: ALL_FILTER_VALUE, label: '전체' }];
+        }
+
+        return [
+            { value: ALL_FILTER_VALUE, label: '전체' },
+            ...Object.entries(selectedTypeCategories).map(([value, label]) => ({ value, label })),
+        ];
+    }, [categoriesByType, questionTypeFilter]);
 
     const requestScrollRestore = () => {
         scrollPositionRef.current = window.scrollY;
@@ -185,8 +215,10 @@ const ProfileMain = () => {
 
     useEffect(() => {
         const handleClickOutside = (event) => {
-            if (!categoryDropdownRef.current) return;
-            if (!categoryDropdownRef.current.contains(event.target)) {
+            if (typeDropdownRef.current && !typeDropdownRef.current.contains(event.target)) {
+                setIsTypeOpen(false);
+            }
+            if (categoryDropdownRef.current && !categoryDropdownRef.current.contains(event.target)) {
                 setIsCategoryOpen(false);
             }
         };
@@ -264,6 +296,7 @@ const ProfileMain = () => {
         fetchNextPage
     } = useAnswersInfinite({
         type: modeFilter,
+        questionType: questionTypeValue,
         category: categoryValue,
         dateFrom: debouncedDateRange.dateFrom,
         dateTo: debouncedDateRange.dateTo,
@@ -319,23 +352,6 @@ const ProfileMain = () => {
         { icon: Target, label: '연습 횟수', value: userStats?.practice_mode_count, unit: '회' },
         { icon: MessageSquare, label: '총 답변 수', value: userStats?.total_questions_answered, unit: '개' },
     ];
-
-    // 카테고리 색상 매핑
-    const categoryColors = useMemo(() => {
-        const colors = {
-            '네트워크': { bg: '#E8F5E9', text: '#2E7D32' },
-            '자료구조/알고리즘': { bg: '#E3F2FD', text: '#1565C0' },
-            '데이터베이스': { bg: '#FFF3E0', text: '#E65100' },
-            '운영체제': { bg: '#F3E5F5', text: '#7B1FA2' },
-        };
-        
-        // categoryMap의 값들을 색상에 매핑
-        const result = {};
-        Object.values(categoryMap).forEach((label) => {
-            result[label] = colors[label] || { bg: '#F5F5F5', text: '#616161' };
-        });
-        return result;
-    }, [categoryMap]);
 
     // 주간 목표 계산
     const totalThisWeek = weeklyStats?.total_this_week ?? 0;
@@ -464,14 +480,60 @@ const ProfileMain = () => {
                                     </div>
 
                                     <div className="space-y-2">
+                                        <p className="text-xs text-muted-foreground">질문 타입</p>
+                                        <div className="relative" ref={typeDropdownRef}>
+                                            <button
+                                                type="button"
+                                                className="filter-select-btn"
+                                                onClick={() => {
+                                                    setIsCategoryOpen(false);
+                                                    setIsTypeOpen((prev) => !prev);
+                                                }}
+                                            >
+                                                {questionTypeOptions.find((option) => option.value === questionTypeFilter)?.label ?? '전체'}
+                                                <span className={`filter-arrow ${isTypeOpen ? 'open' : ''}`}>▼</span>
+                                            </button>
+
+                                            {isTypeOpen && (
+                                                <div className="filter-dropdown">
+                                                    {questionTypeOptions.map((option) => (
+                                                        <button
+                                                            key={option.value}
+                                                            type="button"
+                                                            className={`filter-dropdown-item ${option.value === questionTypeFilter ? 'active' : ''}`}
+                                                            onClick={() => {
+                                                                requestScrollRestore();
+                                                                setQuestionTypeFilter(option.value);
+                                                                setCategoryFilter(ALL_FILTER_VALUE);
+                                                                setIsTypeOpen(false);
+                                                                setIsCategoryOpen(false);
+                                                            }}
+                                                        >
+                                                            {option.label}
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className="space-y-2">
                                         <p className="text-xs text-muted-foreground">질문 카테고리</p>
                                         <div className="relative" ref={categoryDropdownRef}>
                                             <button
                                                 type="button"
                                                 className="filter-select-btn"
-                                                onClick={() => setIsCategoryOpen((prev) => !prev)}
+                                                onClick={() => {
+                                                    if (questionTypeFilter === ALL_FILTER_VALUE) return;
+                                                    setIsTypeOpen(false);
+                                                    setIsCategoryOpen((prev) => !prev);
+                                                }}
+                                                disabled={questionTypeFilter === ALL_FILTER_VALUE}
                                             >
-                                                {categoryOptions.find((option) => option.value === categoryFilter)?.label ?? '전체'}
+                                                {questionTypeFilter === ALL_FILTER_VALUE
+                                                    ? '타입을 선택해주세요'
+                                                    : (categoryOptions.find((option) => option.value === categoryFilter)?.label ?? '전체')}
                                                 <span className={`filter-arrow ${isCategoryOpen ? 'open' : ''}`}>▼</span>
                                             </button>
 
@@ -495,7 +557,6 @@ const ProfileMain = () => {
                                             )}
                                         </div>
                                     </div>
-                                </div>
 
                                 <div className="space-y-2">
                                     <p className="text-xs text-muted-foreground">기간</p>
@@ -552,19 +613,39 @@ const ProfileMain = () => {
                 )}
 
                 {/* 필터 칩 */}
-                <div className="filter-chips">
-                    {categoryOptions.map((option) => (
-                        <button
-                            key={option.value}
-                            className={`filter-chip ${categoryFilter === option.value ? 'active' : ''}`}
-                            onClick={() => {
-                                requestScrollRestore();
-                                setCategoryFilter(option.value);
-                            }}
-                        >
-                            {option.label}
-                        </button>
-                    ))}
+                <div className="space-y-2">
+                    <div className="filter-chips">
+                        {questionTypeOptions.map((option) => (
+                            <button
+                                key={option.value}
+                                className={`filter-chip ${questionTypeFilter === option.value ? 'active' : ''}`}
+                                onClick={() => {
+                                    requestScrollRestore();
+                                    setQuestionTypeFilter(option.value);
+                                    setCategoryFilter(ALL_FILTER_VALUE);
+                                }}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    {questionTypeFilter !== ALL_FILTER_VALUE && (
+                        <div className="filter-chips">
+                            {categoryOptions.map((option) => (
+                                <button
+                                    key={option.value}
+                                    className={`filter-chip ${categoryFilter === option.value ? 'active' : ''}`}
+                                    onClick={() => {
+                                        requestScrollRestore();
+                                        setCategoryFilter(option.value);
+                                    }}
+                                >
+                                    {option.label}
+                                </button>
+                            ))}
+                        </div>
+                    )}
                 </div>
 
                 {error && (
@@ -576,10 +657,13 @@ const ProfileMain = () => {
                 {/* 학습 기록 리스트 */}
                 <div className="history-list">
                     {recentActivities.map((activity) => {
-                        const categoryLabel = activity.question?.category 
-                            ? (categoryMap[activity.question.category] || activity.question.category)
+                        const categoryKey = activity.question?.category;
+                        const categoryLabel = categoryKey
+                            ? getQuestionCategoryLabel(categoryKey, categoryMap)
                             : null;
-                        const categoryColor = categoryLabel ? categoryColors[categoryLabel] : null;
+                        const categoryColor = categoryKey
+                            ? getQuestionCategoryColor(categoryKey)
+                            : null;
                         
                         return (
                             <HistoryItem

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1726,7 +1726,8 @@
 .history-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 10px;
   margin-bottom: 10px;
 }
 
@@ -1744,7 +1745,10 @@
 .history-meta {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 10px;
+  min-width: 0;
 }
 
 .history-category {
@@ -1752,11 +1756,17 @@
   font-size: 11px;
   font-weight: var(--font-weight-medium);
   border-radius: var(--radius-sm);
+  max-width: 170px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .history-date {
   font-size: var(--text-caption);
   color: var(--gray-500);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .history-title {


### PR DESCRIPTION
## 요약

  질문 카테고리 API 변경(2depth 구조)에 맞춰 필터/라벨 처리 로직을 정리하고, 카테고리 메타(라벨/색상)를 공통 모듈로 통합했습니다.
  프로필 필터를 타입 -> 타입별 카테고리로 확장했고, 추천 질문 없음(404/Q001) 케이스를 에러 대신 빈 상태 UX로 처리했습니다.
  또한 AlertDialog DOM nesting 경고와 프로필 학습기록 카테고리 뱃지 겹침 UI를 함께 개선했습니다.

  ## 변경사항
  - 질문 카테고리 훅을 2depth 응답 구조(byType, flat) 기준으로 정규화
  - 프로필 필터를 질문 타입 + 질문 카테고리 2단계로 분리
  - 답변 목록 조회 훅에 questionType 필터 파라미터 추가
  - 카테고리/타입 라벨 및 카테고리 색상 공통 모듈화
  - 홈/연습/프로필/학습상세에서 공통 라벨 헬퍼 사용으로 표시 기준 통일
  - 프로필 학습기록 카테고리 뱃지와 날짜 겹침 방지 스타일 보정
  ## 수정/추가/삭제 파일

  - 추가
      - src/app/constants/questionCategoryMeta.js
  - 수정
      - src/app/hooks/useAnswersInfinite.js
      - src/app/hooks/useRecommendedQuestion.js
      - src/app/pages/Home.jsx
      - src/app/pages/LearningRecordDetail.jsx
      - src/app/pages/PracticeMain.jsx
      - src/app/pages/ProfileMain.jsx
      - src/styles/theme.css
      - .env.development

  ## 구현 의도 / 목적

  - 카테고리 API 변경에 따른 화면별 파싱/필터 불일치 해소
  - 타입/카테고리 필터의 사용성과 정확도 개선
  - 카테고리 라벨/색상 규칙의 단일 소스화로 유지보수성 향상
  - 추천 질문 없음 상황에서 사용자에게 자연스러운 빈 상태 UX 제공
  - 경고/레이아웃 이슈 제거로 UI 안정성 확보

  ## 관련 Commit, Issue

  - #142 
  
  ## 변경 내용
<img width="494" height="242" alt="image" src="https://github.com/user-attachments/assets/8542a538-2cca-43b5-b843-25e9a488fe9d" /> | <img width="469" height="408" alt="image" src="https://github.com/user-attachments/assets/7c08614b-3663-46e4-b463-c7b8d6cdd551" />

