### PR TITLE
fix:[#145]카테고리/타입 라벨 객체 렌더링 오류 방지

### DIFF
--- a/src/app/constants/questionCategoryMeta.js
+++ b/src/app/constants/questionCategoryMeta.js
@@ -43,12 +43,20 @@ export const QUESTION_CATEGORY_COLOR_BY_KEY = Object.freeze({
 
 export function getQuestionTypeLabel(typeKey, typeMap = {}) {
   if (!typeKey) return ''
-  return typeMap[typeKey] || QUESTION_TYPE_FALLBACK_LABELS[typeKey] || typeKey
+  const mapped = typeMap?.[typeKey]
+  if (typeof mapped === 'string' && mapped.trim()) {
+    return mapped
+  }
+  return QUESTION_TYPE_FALLBACK_LABELS[typeKey] || typeKey
 }
 
 export function getQuestionCategoryLabel(categoryKey, categoryMap = {}) {
   if (!categoryKey) return ''
-  return categoryMap[categoryKey] || QUESTION_CATEGORY_FALLBACK_LABELS[categoryKey] || categoryKey
+  const mapped = categoryMap?.[categoryKey]
+  if (typeof mapped === 'string' && mapped.trim()) {
+    return mapped
+  }
+  return QUESTION_CATEGORY_FALLBACK_LABELS[categoryKey] || categoryKey
 }
 
 export function getQuestionCategoryColor(categoryKey) {

--- a/src/app/hooks/useQuestionTypes.js
+++ b/src/app/hooks/useQuestionTypes.js
@@ -4,7 +4,14 @@ import { fetchQuestionTypes } from '@/api/questionApi'
 function mapTypes(response) {
   const data = response?.data ?? response ?? {}
   const types = data.types ?? {}
-  return types && typeof types === 'object' ? types : {}
+
+  if (!types || typeof types !== 'object' || Array.isArray(types)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(types).filter(([, value]) => typeof value === 'string')
+  )
 }
 
 export function useQuestionTypes() {


### PR DESCRIPTION
 ## 요약

  질문 타입/카테고리 라벨 렌더링 안정성을 개선했습니다.
  API 응답에 객체 값이 섞일 때 React 에러#31(렌더 불가 값)로 이어지던 문제를 방지하기 위해, 타입 응답 정규화와 공통 라벨 헬퍼의 문자열 검증을 강화했습니다.

  ## 변경사항

  - 질문 타입 조회 응답을 string 값만 허용하도록 정규화
  - 라벨 헬퍼에서 객체/빈값을 배제하고 문자열만 렌더링
  - fallback 라벨 적용 순서를 정리해 안정적인 표시 보장

  ## 수정/추가/삭제 파일

  - 수정
      - src/app/hooks/useQuestionTypes.js
      - src/app/constants/questionCategoryMeta.js

  ## 구현 의도 / 목적

  - JSX에 객체가 직접 렌더링되어 발생하는 React#31 에러 방지
  - 타입/카테고리 라벨 처리 일관성 확보

  ## 관련 Commit, Issue

  - #145 