### PR TITLE
feat: Implement a splash screen and a feedback form dialog.

### DIFF
--- a/src/app/hooks/useFeedbackFormDialog.jsx
+++ b/src/app/hooks/useFeedbackFormDialog.jsx
@@ -57,9 +57,9 @@ export const useFeedbackFormDialog = () => {
                                 </div>
                             </div>
                             <ul className="space-y-1.5">
-                                {FEEDBACK_POINTS.map(({ Icon, label }) => (
+                                {FEEDBACK_POINTS.map(({ Icon: IconComp, label }) => (
                                     <li key={label} className="leading-snug flex items-center gap-2">
-                                        <Icon className="w-4 h-4 shrink-0 text-muted-foreground" />
+                                        <IconComp className="w-4 h-4 shrink-0 text-muted-foreground" />
                                         {label}
                                     </li>
                                 ))}

--- a/src/app/pages/Splash.jsx
+++ b/src/app/pages/Splash.jsx
@@ -1,27 +1,10 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
+import { markSplashShown } from '@/app/utils/splashUtils';
 
 /** 스플래시 GIF 1회 재생으로 간주하는 시간(ms). GIF 실제 길이에 맞게 조정 가능 */
 const SPLASH_GIF_DURATION_MS = 3000;
-
-const SPLASH_SHOWN_KEY = 'qfeed_splash_shown';
-
-export function markSplashShown() {
-  try {
-    sessionStorage.setItem(SPLASH_SHOWN_KEY, '1');
-  } catch {
-    // ignore
-  }
-}
-
-export function clearSplashShown() {
-  try {
-    sessionStorage.removeItem(SPLASH_SHOWN_KEY);
-  } catch {
-    // ignore
-  }
-}
 
 const Splash = () => {
   const navigate = useNavigate();

--- a/src/app/utils/splashUtils.js
+++ b/src/app/utils/splashUtils.js
@@ -1,0 +1,17 @@
+const SPLASH_SHOWN_KEY = 'qfeed_splash_shown';
+
+export function markSplashShown() {
+    try {
+        sessionStorage.setItem(SPLASH_SHOWN_KEY, '1');
+    } catch {
+        // ignore
+    }
+}
+
+export function clearSplashShown() {
+    try {
+        sessionStorage.removeItem(SPLASH_SHOWN_KEY);
+    } catch {
+        // ignore
+    }
+}


### PR DESCRIPTION
- 구조분해 시 Icon을 IconComp로 rename.
- 컴포넌트 파일에서 일반 함수(markSplashShown, clearSplashShown)를 같이 export하면 Fast Refresh가 동작하지 않는 문제 
   → 유틸 함수를 새 파일로 분리: