### PR TITLE
feat:[#162]실전면접 API 연동 및 연습모드 피드백 세션 기반 전환

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,7 +8,7 @@ VITE_API_BASE_URL=https://dev.q-feed.com
 
 # Feature flags
 # Show "Real Interview" entry point (true/false)
-VITE_SHOW_REAL_INTERVIEW=false
+VITE_SHOW_REAL_INTERVIEW=true
 
 # Show "Portfolio Interview" entry point (true/false)
 VITE_SHOW_PORTFOLIO_INTERVIEW=false

--- a/src/api/answerApi.js
+++ b/src/api/answerApi.js
@@ -71,7 +71,7 @@ export async function fetchAnswerDetail(
  * @returns {Promise<Object>} 피드백 조회 결과
  */
 export async function fetchAnswerFeedback(answerId) {
-  const response = await api.get(`/api/interviews/answers/${answerId}/feedback`, {
+  const response = await api.get(`/api/answers/practice/${answerId}/feedback`, {
     parseResponse: true,
   })
   return response

--- a/src/api/interviewApi.js
+++ b/src/api/interviewApi.js
@@ -1,0 +1,139 @@
+import { api } from '@/utils/apiUtils'
+import { INTERVIEW_TYPES, QUESTION_TYPES } from '@/app/constants/interviewTaxonomy'
+
+export { INTERVIEW_TYPES, QUESTION_TYPES }
+
+const buildSessionQuery = (sessionId) => {
+  const encoded = encodeURIComponent(String(sessionId))
+  return `?sessionId=${encoded}`
+}
+
+/**
+ * 인터뷰 세션 생성
+ * @param {Object} params
+ * @param {string} params.interviewType - PRACTICE_INTERVIEW | REAL_INTERVIEW
+ * @param {string} params.questionType - CS | SYSTEM_DESIGN | PORTFOLIO
+ */
+export async function createInterviewSession({ interviewType, questionType }) {
+  return api.post(
+    '/api/interview/sessions',
+    { interviewType, questionType },
+    { parseResponse: true }
+  )
+}
+
+/**
+ * 연습 모드 답변 제출 (답변 기록만 수행)
+ * @param {Object} params
+ * @param {string} params.sessionId
+ * @param {number|string} params.questionId
+ * @param {string} params.answerText
+ */
+export async function submitPracticeInterviewAnswer({ sessionId, questionId, answerText }) {
+  return api.post(
+    '/api/answers/practice',
+    { sessionId, questionId, answerText },
+    { parseResponse: true }
+  )
+}
+
+/**
+ * 실전 모드 답변 제출
+ * @param {Object} params
+ * @param {Object} [params.payload] - 서버 스키마를 그대로 전달할 요청 payload
+ * @param {string} [params.sessionId]
+ * @param {string} [params.answerText]
+ * @param {number|string} [params.questionId]
+ * @param {number} [params.userId]
+ * @param {string} [params.questionType]
+ * @param {Array<Object>} [params.interviewHistory]
+ * @param {string} [params.turnType]
+ * @param {number} [params.turnOrder]
+ * @param {number} [params.topicId]
+ * @param {string} [params.category]
+ */
+export async function submitRealInterviewAnswer(params = {}) {
+  const {
+    payload: rawPayload,
+    sessionId,
+    answerText,
+    questionId,
+    userId,
+    questionType,
+    interviewHistory,
+    turnType,
+    turnOrder,
+    topicId,
+    category,
+  } = params
+
+  if (rawPayload && typeof rawPayload === 'object') {
+    return api.post('/api/answers/real', rawPayload, { parseResponse: true })
+  }
+
+  const payload = {}
+
+  if (sessionId !== undefined && sessionId !== null && sessionId !== '') {
+    payload.sessionId = sessionId
+  }
+  if (answerText !== undefined && answerText !== null && answerText !== '') {
+    payload.answerText = answerText
+  }
+  if (questionId !== undefined && questionId !== null && questionId !== '') {
+    payload.questionId = questionId
+  }
+
+  // snake_case 스키마를 요구하는 실전모드 백엔드와의 호환 필드
+  if (userId !== undefined && userId !== null) {
+    payload.user_id = userId
+  }
+  if (questionType !== undefined && questionType !== null && questionType !== '') {
+    payload.question_type = questionType
+  }
+  if (Array.isArray(interviewHistory)) {
+    payload.interview_history = interviewHistory
+  }
+  if (turnType !== undefined && turnType !== null && turnType !== '') {
+    payload.turn_type = turnType
+  }
+  if (typeof turnOrder === 'number' && Number.isInteger(turnOrder)) {
+    payload.turn_order = turnOrder
+  }
+  if (topicId !== undefined && topicId !== null) {
+    payload.topic_id = topicId
+  }
+  if (category !== undefined && category !== null && category !== '') {
+    payload.category = category
+  }
+
+  return api.post('/api/answers/real', payload, { parseResponse: true })
+}
+
+/**
+ * 세션 상태 조회
+ * @param {string} sessionId
+ */
+export async function fetchInterviewSession(sessionId) {
+  return api.get(`/api/interview/sessions${buildSessionQuery(sessionId)}`, { parseResponse: true })
+}
+
+/**
+ * 세션 최종 피드백 조회(폴링)
+ * @param {string} sessionId
+ */
+export async function fetchInterviewSessionFeedback(sessionId) {
+  return api.get(`/api/interview/sessions/feedback${buildSessionQuery(sessionId)}`, { parseResponse: true })
+}
+
+/**
+ * 세션 최종 피드백 요청
+ * @param {Object} params
+ * @param {string} params.sessionId
+ */
+export async function requestInterviewSessionFeedback({ sessionId }) {
+  return api.post(
+    '/api/interview/sessions/feedback/request',
+    { sessionId },
+    { parseResponse: true }
+  )
+}

--- a/src/api/sttApi.js
+++ b/src/api/sttApi.js
@@ -4,14 +4,17 @@ import { api, handleResponse } from '@/utils/apiUtils'
  * STT 요청 - 음성 파일을 텍스트로 변환
  * @param {Object} params
  * @param {number} params.userId - 사용자 ID
- * @param {number} params.sessionId - 세션 ID
+ * @param {string|number} params.sessionId - 세션 ID (요청 시 string으로 직렬화)
  * @param {string} params.audioUrl - S3 음성 파일 URL (.mp3 또는 .m4a)
  * @returns {Promise<{data: {text: string}}>}
  */
 export async function requestSTT({ userId, sessionId, audioUrl }) {
-  const response = await api.post('/ai/stt', {
+  const normalizedSessionId =
+    sessionId === undefined || sessionId === null ? '' : String(sessionId).trim()
+
+  const response = await api.post('/api/ai/stt', {
     user_id: userId,
-    session_id: sessionId,
+    session_id: normalizedSessionId,
     audio_url: audioUrl,
   })
   return handleResponse(response)

--- a/src/api/ttsApi.js
+++ b/src/api/ttsApi.js
@@ -1,0 +1,203 @@
+import { api, extractErrorMessage } from '@/utils/apiUtils'
+
+const DEFAULT_TTS_ERROR_MESSAGE = '음성 변환에 실패했습니다.'
+const TTS_PARSE_ERROR_MESSAGE = 'TTS 응답 파싱에 실패했습니다.'
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+function extractBoundary(contentType) {
+  const match = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i)
+  return (match?.[1] || match?.[2] || '').trim()
+}
+
+function findSequence(source, target, startIndex = 0) {
+  if (!target.length || source.length < target.length) {
+    return -1
+  }
+
+  for (let i = startIndex; i <= source.length - target.length; i += 1) {
+    let matched = true
+    for (let j = 0; j < target.length; j += 1) {
+      if (source[i + j] !== target[j]) {
+        matched = false
+        break
+      }
+    }
+    if (matched) {
+      return i
+    }
+  }
+
+  return -1
+}
+
+function trimTrailingLineBreak(bytes) {
+  let end = bytes.length
+
+  if (end >= 2 && bytes[end - 2] === 13 && bytes[end - 1] === 10) {
+    end -= 2
+  } else if (end >= 1 && (bytes[end - 1] === 13 || bytes[end - 1] === 10)) {
+    end -= 1
+  }
+
+  return bytes.slice(0, end)
+}
+
+function splitHeadersAndBody(partBytes) {
+  const crlfDelimiter = new Uint8Array([13, 10, 13, 10])
+  const lfDelimiter = new Uint8Array([10, 10])
+
+  let headerEndIndex = findSequence(partBytes, crlfDelimiter)
+  let bodyOffset = 4
+
+  if (headerEndIndex === -1) {
+    headerEndIndex = findSequence(partBytes, lfDelimiter)
+    bodyOffset = 2
+  }
+
+  if (headerEndIndex === -1) {
+    return null
+  }
+
+  return {
+    headerBytes: partBytes.slice(0, headerEndIndex),
+    bodyBytes: partBytes.slice(headerEndIndex + bodyOffset),
+  }
+}
+
+function parseHeaders(headerBytes) {
+  const lines = textDecoder.decode(headerBytes).split(/\r?\n/)
+  const headers = {}
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf(':')
+    if (separatorIndex === -1) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex).trim().toLowerCase()
+    const value = line.slice(separatorIndex + 1).trim()
+
+    if (key) {
+      headers[key] = value
+    }
+  }
+
+  return headers
+}
+
+function extractFileName(contentDisposition = '') {
+  const quoted = contentDisposition.match(/filename="([^"]+)"/i)
+  if (quoted?.[1]) {
+    return quoted[1]
+  }
+
+  const unquoted = contentDisposition.match(/filename=([^;]+)/i)
+  if (!unquoted?.[1]) {
+    return null
+  }
+
+  return unquoted[1].trim().replace(/^"|"$/g, '')
+}
+
+function parseMultipartMixed(bodyBytes, boundary) {
+  const boundaryBytes = textEncoder.encode(`--${boundary}`)
+
+  let cursor = 0
+  let jsonPart = null
+  let audioBytes = null
+  let audioContentType = 'audio/mpeg'
+  let fileName = 'tts_output.mp3'
+
+  while (cursor < bodyBytes.length) {
+    const boundaryIndex = findSequence(bodyBytes, boundaryBytes, cursor)
+    if (boundaryIndex === -1) {
+      break
+    }
+
+    let lineEndIndex = boundaryIndex + boundaryBytes.length
+
+    const isClosingBoundary = bodyBytes[lineEndIndex] === 45 && bodyBytes[lineEndIndex + 1] === 45
+    if (isClosingBoundary) {
+      break
+    }
+
+    if (bodyBytes[lineEndIndex] === 13 && bodyBytes[lineEndIndex + 1] === 10) {
+      lineEndIndex += 2
+    } else if (bodyBytes[lineEndIndex] === 10) {
+      lineEndIndex += 1
+    }
+
+    const nextBoundaryIndex = findSequence(bodyBytes, boundaryBytes, lineEndIndex)
+    if (nextBoundaryIndex === -1) {
+      break
+    }
+
+    const rawPartBytes = trimTrailingLineBreak(bodyBytes.slice(lineEndIndex, nextBoundaryIndex))
+    const splitResult = splitHeadersAndBody(rawPartBytes)
+
+    if (splitResult) {
+      const headers = parseHeaders(splitResult.headerBytes)
+      const contentType = (headers['content-type'] || '').toLowerCase()
+
+      if (contentType.includes('application/json')) {
+        jsonPart = JSON.parse(textDecoder.decode(splitResult.bodyBytes))
+      }
+
+      if (contentType.includes('audio/mpeg')) {
+        audioBytes = splitResult.bodyBytes
+        audioContentType = headers['content-type']?.split(';')[0].trim() || 'audio/mpeg'
+        fileName = extractFileName(headers['content-disposition']) || fileName
+      }
+    }
+
+    cursor = nextBoundaryIndex
+  }
+
+  if (!jsonPart || !audioBytes) {
+    throw new Error(TTS_PARSE_ERROR_MESSAGE)
+  }
+
+  return {
+    jsonPart,
+    audioBlob: new Blob([audioBytes], { type: audioContentType }),
+    fileName,
+  }
+}
+
+/**
+ * TTS 요청 - 텍스트를 음성(mp3)으로 변환
+ * @param {Object} params
+ * @param {number} params.userId - 사용자 ID
+ * @param {string} params.sessionId - 면접 세션 ID
+ * @param {string} params.text - 음성 변환 텍스트
+ * @returns {Promise<{message: string, data: {user_id: number, session_id: string}, audioBlob: Blob, fileName: string}>}
+ */
+export async function requestTTS({ userId, sessionId, text }) {
+  const response = await api.post('/api/ai/tts', {
+    user_id: userId,
+    session_id: sessionId,
+    text,
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, DEFAULT_TTS_ERROR_MESSAGE))
+  }
+
+  const contentType = response.headers.get('Content-Type') || ''
+  const boundary = extractBoundary(contentType)
+
+  if (!boundary) {
+    throw new Error(TTS_PARSE_ERROR_MESSAGE)
+  }
+
+  const bodyBytes = new Uint8Array(await response.arrayBuffer())
+  const { jsonPart, audioBlob, fileName } = parseMultipartMixed(bodyBytes, boundary)
+
+  return {
+    ...jsonPart,
+    audioBlob,
+    fileName,
+  }
+}

--- a/src/app/constants/interviewTaxonomy.js
+++ b/src/app/constants/interviewTaxonomy.js
@@ -1,0 +1,44 @@
+export const INTERVIEW_TYPES = Object.freeze({
+    PRACTICE: 'PRACTICE_INTERVIEW',
+    REAL: 'REAL_INTERVIEW',
+    PORTFOLIO: 'PORTFOLIO_INTERVIEW',
+});
+
+export const INTERVIEW_TYPE_LABELS = Object.freeze({
+    [INTERVIEW_TYPES.PRACTICE]: '연습',
+    [INTERVIEW_TYPES.REAL]: '실전',
+    [INTERVIEW_TYPES.PORTFOLIO]: '포트폴리오',
+});
+
+export const QUESTION_TYPES = Object.freeze({
+    CS: 'CS',
+    SYSTEM_DESIGN: 'SYSTEM_DESIGN',
+    PORTFOLIO: 'PORTFOLIO',
+});
+
+export const QUESTION_CATEGORIES = Object.freeze({
+    CS: Object.freeze({
+        OS: 'OS',
+        NETWORK: 'NETWORK',
+        DB: 'DB',
+        COMPUTER_ARCHITECTURE: 'COMPUTER_ARCHITECTURE',
+        DATA_STRUCTURE_ALGORITHM: 'DATA_STRUCTURE_ALGORITHM',
+    }),
+    SYSTEM_DESIGN: Object.freeze({
+        SOCIAL: 'SOCIAL',
+        NOTIFICATION: 'NOTIFICATION',
+        REALTIME: 'REALTIME',
+        SEARCH: 'SEARCH',
+        MEDIA: 'MEDIA',
+        STORAGE: 'STORAGE',
+        PLATFORM: 'PLATFORM',
+        TRANSACTION: 'TRANSACTION',
+    }),
+});
+
+const SYSTEM_DESIGN_CATEGORY_KEYS = new Set(Object.values(QUESTION_CATEGORIES.SYSTEM_DESIGN));
+
+export function isSystemDesignCategoryKey(value) {
+    if (typeof value !== 'string') return false;
+    return SYSTEM_DESIGN_CATEGORY_KEYS.has(value.trim().toUpperCase());
+}

--- a/src/app/constants/questionCategoryMeta.js
+++ b/src/app/constants/questionCategoryMeta.js
@@ -1,23 +1,28 @@
+import { QUESTION_CATEGORIES, QUESTION_TYPES } from '@/app/constants/interviewTaxonomy'
+
+const CS = QUESTION_CATEGORIES.CS
+const SYSTEM_DESIGN = QUESTION_CATEGORIES.SYSTEM_DESIGN
+
 export const QUESTION_TYPE_FALLBACK_LABELS = Object.freeze({
-  CS: 'CS',
-  SYSTEM_DESIGN: '시스템 디자인',
-  PORTFOLIO: '포트폴리오',
+  [QUESTION_TYPES.CS]: 'CS',
+  [QUESTION_TYPES.SYSTEM_DESIGN]: '시스템 디자인',
+  [QUESTION_TYPES.PORTFOLIO]: '포트폴리오',
 })
 
 export const QUESTION_CATEGORY_FALLBACK_LABELS = Object.freeze({
-  OS: '운영체제',
-  NETWORK: '네트워크',
-  DB: '데이터베이스',
-  COMPUTER_ARCHITECTURE: '컴퓨터 구조',
-  DATA_STRUCTURE_ALGORITHM: '자료구조&알고리즘',
-  SOCIAL: '소셜/피드 시스템',
-  NOTIFICATION: '알림 시스템',
-  REALTIME: '실시간 통신 시스템',
-  SEARCH: '검색 시스템',
-  MEDIA: '미디어/스트리밍 시스템',
-  STORAGE: '파일 저장/협업 시스템',
-  PLATFORM: '플랫폼 인프라 시스템',
-  TRANSACTION: '거래/정산 시스템',
+  [CS.OS]: '운영체제',
+  [CS.NETWORK]: '네트워크',
+  [CS.DB]: '데이터베이스',
+  [CS.COMPUTER_ARCHITECTURE]: '컴퓨터 구조',
+  [CS.DATA_STRUCTURE_ALGORITHM]: '자료구조&알고리즘',
+  [SYSTEM_DESIGN.SOCIAL]: '소셜/피드 시스템',
+  [SYSTEM_DESIGN.NOTIFICATION]: '알림 시스템',
+  [SYSTEM_DESIGN.REALTIME]: '실시간 통신 시스템',
+  [SYSTEM_DESIGN.SEARCH]: '검색 시스템',
+  [SYSTEM_DESIGN.MEDIA]: '미디어/스트리밍 시스템',
+  [SYSTEM_DESIGN.STORAGE]: '파일 저장/협업 시스템',
+  [SYSTEM_DESIGN.PLATFORM]: '플랫폼 인프라 시스템',
+  [SYSTEM_DESIGN.TRANSACTION]: '거래/정산 시스템',
 })
 
 export const DEFAULT_QUESTION_CATEGORY_COLOR = Object.freeze({
@@ -26,19 +31,19 @@ export const DEFAULT_QUESTION_CATEGORY_COLOR = Object.freeze({
 })
 
 export const QUESTION_CATEGORY_COLOR_BY_KEY = Object.freeze({
-  OS: { bg: '#F3E5F5', text: '#7B1FA2' },
-  NETWORK: { bg: '#E8F5E9', text: '#2E7D32' },
-  DB: { bg: '#FFF3E0', text: '#E65100' },
-  COMPUTER_ARCHITECTURE: { bg: '#E8EAF6', text: '#3949AB' },
-  DATA_STRUCTURE_ALGORITHM: { bg: '#E3F2FD', text: '#1565C0' },
-  SOCIAL: { bg: '#F3E5F5', text: '#7B1FA2' },
-  NOTIFICATION: { bg: '#E0F2F1', text: '#00695C' },
-  REALTIME: { bg: '#E8F0FE', text: '#1A73E8' },
-  SEARCH: { bg: '#FFF8E1', text: '#F57F17' },
-  MEDIA: { bg: '#FCE4EC', text: '#AD1457' },
-  STORAGE: { bg: '#EDE7F6', text: '#5E35B1' },
-  PLATFORM: { bg: '#E1F5FE', text: '#0277BD' },
-  TRANSACTION: { bg: '#F1F8E9', text: '#558B2F' },
+  [CS.OS]: { bg: '#F3E5F5', text: '#7B1FA2' },
+  [CS.NETWORK]: { bg: '#E8F5E9', text: '#2E7D32' },
+  [CS.DB]: { bg: '#FFF3E0', text: '#E65100' },
+  [CS.COMPUTER_ARCHITECTURE]: { bg: '#E8EAF6', text: '#3949AB' },
+  [CS.DATA_STRUCTURE_ALGORITHM]: { bg: '#E3F2FD', text: '#1565C0' },
+  [SYSTEM_DESIGN.SOCIAL]: { bg: '#F3E5F5', text: '#7B1FA2' },
+  [SYSTEM_DESIGN.NOTIFICATION]: { bg: '#E0F2F1', text: '#00695C' },
+  [SYSTEM_DESIGN.REALTIME]: { bg: '#E8F0FE', text: '#1A73E8' },
+  [SYSTEM_DESIGN.SEARCH]: { bg: '#FFF8E1', text: '#F57F17' },
+  [SYSTEM_DESIGN.MEDIA]: { bg: '#FCE4EC', text: '#AD1457' },
+  [SYSTEM_DESIGN.STORAGE]: { bg: '#EDE7F6', text: '#5E35B1' },
+  [SYSTEM_DESIGN.PLATFORM]: { bg: '#E1F5FE', text: '#0277BD' },
+  [SYSTEM_DESIGN.TRANSACTION]: { bg: '#F1F8E9', text: '#558B2F' },
 })
 
 export function getQuestionTypeLabel(typeKey, typeMap = {}) {

--- a/src/app/constants/storageKeys.js
+++ b/src/app/constants/storageKeys.js
@@ -1,0 +1,15 @@
+export const SESSION_STORAGE_KEYS = Object.freeze({
+    SELECTED_PRACTICE_QUESTION: 'qfeed_selected_practice_question',
+    PRACTICE_INTERVIEW_SESSION: 'qfeed_practice_interview_session',
+    REAL_INTERVIEW_SESSION: 'qfeed_real_interview_session',
+    PRACTICE_FEEDBACK_PREFIX: 'qfeed_ai_feedback_',
+});
+
+export const PRACTICE_FEEDBACK_UPDATED_EVENT = 'qfeed:practice-feedback-updated';
+
+// 현재 로컬 스토리지 사용 키는 없지만, 저장소 키를 한 곳에서 관리하기 위한 엔트리입니다.
+export const LOCAL_STORAGE_KEYS = Object.freeze({});
+
+export function getPracticeFeedbackStorageKey(questionId) {
+    return `${SESSION_STORAGE_KEYS.PRACTICE_FEEDBACK_PREFIX}${questionId}`;
+}

--- a/src/app/hooks/usePracticeAnswerSubmit.js
+++ b/src/app/hooks/usePracticeAnswerSubmit.js
@@ -1,23 +1,163 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
-import { submitPracticeAnswer } from '@/api/answerApi';
+import {
+    createInterviewSession,
+    requestInterviewSessionFeedback,
+    submitPracticeInterviewAnswer,
+} from '@/api/interviewApi';
+import {
+    getPracticeFeedbackStorageKey,
+    PRACTICE_FEEDBACK_UPDATED_EVENT,
+    SESSION_STORAGE_KEYS,
+} from '@/app/constants/storageKeys';
+import {
+    INTERVIEW_TYPES,
+    QUESTION_TYPES,
+    isSystemDesignCategoryKey,
+} from '@/app/constants/interviewTaxonomy';
 
 const TEXT_SUBMIT_ERROR = '피드백 요청에 실패했습니다';
 const TEXT_FEEDBACK_REQUEST_FAILED = '피드백 요청 실패';
-const TEXT_ANSWER_TOO_SHORT = '답변이 너무 짧아요. 조금 더 구체적으로 작성해 주세요. (최소 20자)';
-const INTERVIEW_TYPE = 'PRACTICE_INTERVIEW';
-const FEEDBACK_STORAGE_PREFIX = 'qfeed_ai_feedback_';
+const TEXT_SESSION_CREATE_FAILED = '면접 세션 생성에 실패했습니다';
+const TEXT_FEEDBACK_NOT_READY = '피드백 생성이 완료되지 않았습니다. 잠시 후 다시 시도해주세요.';
+const TEXT_ANSWER_TOO_SHORT = '답변이 너무 짧아요. 20자 이상 입력해주세요.';
+
+const PRACTICE_SESSION_STORAGE_KEY = SESSION_STORAGE_KEYS.PRACTICE_INTERVIEW_SESSION;
+const SELECTED_QUESTION_STORAGE_KEY = SESSION_STORAGE_KEYS.SELECTED_PRACTICE_QUESTION;
+
+const FEEDBACK_STATUS_COMPLETED = 'COMPLETED';
+const FEEDBACK_STATUS_FAILED = 'FAILED';
+
 const STORAGE_STATUS_PENDING = 'pending';
+const STORAGE_STATUS_DONE = 'done';
 const STORAGE_STATUS_ERROR = 'error';
 /** AI 피드백 서비스에서 거부할 수 있는 너무 짧은 답변 방지 */
 const MIN_ANSWER_LENGTH = 20;
+
+const normalizeQuestionType = (value) => {
+    if (typeof value !== 'string') return '';
+    const normalized = value.trim().toUpperCase();
+    return Object.values(QUESTION_TYPES).includes(normalized) ? normalized : '';
+};
+
+const inferQuestionTypeFromCategory = (value) => {
+    return isSystemDesignCategoryKey(value)
+        ? QUESTION_TYPES.SYSTEM_DESIGN
+        : QUESTION_TYPES.CS;
+};
+
+const safeGetItem = (key) => {
+    try {
+        return sessionStorage.getItem(key);
+    } catch {
+        return null;
+    }
+};
+
+const safeSetItem = (key, value) => {
+    try {
+        sessionStorage.setItem(key, value);
+    } catch {
+        // sessionStorage 사용 불가 환경에서는 무시
+    }
+};
+
+const safeParseJson = (raw) => {
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return null;
+    }
+};
+
+const emitPracticeFeedbackUpdated = (storageKey) => {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(
+        new CustomEvent(PRACTICE_FEEDBACK_UPDATED_EVENT, {
+            detail: { storageKey },
+        })
+    );
+};
+
+const writeFeedbackStorage = (storageKey, payload) => {
+    safeSetItem(storageKey, JSON.stringify(payload));
+    emitPracticeFeedbackUpdated(storageKey);
+};
+
+const resolveQuestionType = (question, questionId) => {
+    const selectedQuestion = safeParseJson(safeGetItem(SELECTED_QUESTION_STORAGE_KEY));
+    const hasMatchedSelectedQuestion =
+        selectedQuestion && String(selectedQuestion.id) === String(questionId);
+
+    const typeCandidates = [
+        hasMatchedSelectedQuestion ? selectedQuestion?.type : null,
+        hasMatchedSelectedQuestion ? selectedQuestion?.questionType : null,
+        question?.type,
+        question?.questionType,
+    ];
+
+    for (const candidate of typeCandidates) {
+        const normalized = normalizeQuestionType(candidate);
+        if (normalized) return normalized;
+    }
+
+    return inferQuestionTypeFromCategory(
+        hasMatchedSelectedQuestion ? selectedQuestion?.category : question?.category
+    );
+};
+
+const savePracticeSession = ({ sessionId, questionType, expiresAt }) => {
+    safeSetItem(
+        PRACTICE_SESSION_STORAGE_KEY,
+        JSON.stringify({
+            sessionId,
+            interviewType: INTERVIEW_TYPES.PRACTICE,
+            questionType,
+            expiresAt: expiresAt || null,
+            createdAt: new Date().toISOString(),
+        })
+    );
+};
+
+const hasFinalFeedbackPayload = (payload) => {
+    return Boolean(
+        Array.isArray(payload?.metrics) ||
+        payload?.overall_feedback ||
+        payload?.keyword_result ||
+        payload?.bad_case_feedback
+    );
+};
+
+const resolveFeedbackState = (response) => {
+    const payload = response?.data;
+    const status = payload?.status;
+
+    if (status === FEEDBACK_STATUS_FAILED) {
+        return {
+            kind: STORAGE_STATUS_ERROR,
+            message: payload?.message || TEXT_FEEDBACK_REQUEST_FAILED,
+        };
+    }
+
+    if (status === FEEDBACK_STATUS_COMPLETED || (!status && hasFinalFeedbackPayload(payload))) {
+        return {
+            kind: STORAGE_STATUS_DONE,
+            response,
+        };
+    }
+
+    return {
+        kind: STORAGE_STATUS_PENDING,
+    };
+};
 
 export const usePracticeAnswerSubmit = () => {
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const submitAnswer = useCallback(
-        ({ questionId, question, answerText, onAfterSubmit }) => {
-            const trimmedAnswer = (answerText ?? '').trim();
+        async ({ questionId, question, answerText, onAfterSubmit }) => {
+            const trimmedAnswer = answerText.trim();
             if (!trimmedAnswer || isSubmitting) return;
             if (trimmedAnswer.length < MIN_ANSWER_LENGTH) {
                 toast.error(TEXT_ANSWER_TOO_SHORT);
@@ -27,41 +167,96 @@ export const usePracticeAnswerSubmit = () => {
             setIsSubmitting(true);
 
             const numericQuestionId = Number(question?.id ?? questionId);
-            const storageKey = `${FEEDBACK_STORAGE_PREFIX}${questionId}`;
+            const resolvedQuestionId = Number.isNaN(numericQuestionId) ? questionId : numericQuestionId;
+            const storageKey = getPracticeFeedbackStorageKey(questionId);
 
-            sessionStorage.setItem(
-                storageKey,
-                JSON.stringify({ status: STORAGE_STATUS_PENDING })
-            );
+            try {
+                const questionType = resolveQuestionType(question, resolvedQuestionId);
 
-            submitPracticeAnswer({
-                questionId: Number.isNaN(numericQuestionId) ? questionId : numericQuestionId,
-                answerText: trimmedAnswer,
-                answerType: INTERVIEW_TYPE,
-            })
-                .then((response) => {
-                    const answerId = response?.data?.answerId;
-                    sessionStorage.setItem(
-                        storageKey,
-                        JSON.stringify({ status: STORAGE_STATUS_PENDING, answerId })
-                    );
-                })
-                .catch((err) => {
-                    sessionStorage.setItem(
-                        storageKey,
-                        JSON.stringify({
-                            status: STORAGE_STATUS_ERROR,
-                            message: err?.message || TEXT_FEEDBACK_REQUEST_FAILED,
-                        })
-                    );
-                    toast.error(err?.message || TEXT_SUBMIT_ERROR);
-                })
-                .finally(() => {
-                    setIsSubmitting(false);
+                // 연습모드는 답변 제출마다 새 세션을 생성한다.
+                const sessionResponse = await createInterviewSession({
+                    interviewType: INTERVIEW_TYPES.PRACTICE,
+                    questionType,
                 });
 
-            if (onAfterSubmit) {
-                onAfterSubmit(trimmedAnswer);
+                const sessionId = sessionResponse?.data?.session_id ?? sessionResponse?.data?.sessionId;
+                if (!sessionId) {
+                    throw new Error(TEXT_SESSION_CREATE_FAILED);
+                }
+
+                savePracticeSession({
+                    sessionId,
+                    questionType,
+                    expiresAt: sessionResponse?.data?.expires_at ?? sessionResponse?.data?.expiresAt,
+                });
+
+                const createdAt = new Date().toISOString();
+                writeFeedbackStorage(storageKey, {
+                    status: STORAGE_STATUS_PENDING,
+                    sessionId,
+                    createdAt,
+                });
+
+                if (onAfterSubmit) {
+                    onAfterSubmit(trimmedAnswer);
+                }
+
+                // 결과 화면에서 프로그래스를 보여줄 수 있도록 제출/요청은 백그라운드로 진행한다.
+                void (async () => {
+                    try {
+                        await submitPracticeInterviewAnswer({
+                            sessionId,
+                            questionId: resolvedQuestionId,
+                            answerText: trimmedAnswer,
+                        });
+
+                        const requestedAt = new Date().toISOString();
+                        writeFeedbackStorage(storageKey, {
+                            status: STORAGE_STATUS_PENDING,
+                            sessionId,
+                            createdAt,
+                            requestedAt,
+                        });
+
+                        const requestResponse = await requestInterviewSessionFeedback({ sessionId });
+                        const resolved = resolveFeedbackState(requestResponse);
+
+                        if (resolved.kind === STORAGE_STATUS_DONE) {
+                            writeFeedbackStorage(storageKey, {
+                                status: STORAGE_STATUS_DONE,
+                                sessionId,
+                                response: resolved.response,
+                            });
+                            return;
+                        }
+
+                        if (resolved.kind === STORAGE_STATUS_ERROR) {
+                            writeFeedbackStorage(storageKey, {
+                                status: STORAGE_STATUS_ERROR,
+                                message: resolved.message,
+                            });
+                            return;
+                        }
+
+                        writeFeedbackStorage(storageKey, {
+                            status: STORAGE_STATUS_ERROR,
+                            message: TEXT_FEEDBACK_NOT_READY,
+                        });
+                    } catch (err) {
+                        writeFeedbackStorage(storageKey, {
+                            status: STORAGE_STATUS_ERROR,
+                            message: err?.message || TEXT_FEEDBACK_REQUEST_FAILED,
+                        });
+                    }
+                })();
+            } catch (err) {
+                writeFeedbackStorage(storageKey, {
+                    status: STORAGE_STATUS_ERROR,
+                    message: err?.message || TEXT_FEEDBACK_REQUEST_FAILED,
+                });
+                toast.error(err?.message || TEXT_SUBMIT_ERROR);
+            } finally {
+                setIsSubmitting(false);
             }
         },
         [isSubmitting]

--- a/src/app/hooks/useQuestionTtsPlayer.js
+++ b/src/app/hooks/useQuestionTtsPlayer.js
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { requestTTS } from '@/api/ttsApi';
+
+const toTrimmedString = (value) => {
+    if (typeof value !== 'string') return '';
+    const trimmed = value.trim();
+    return trimmed || '';
+};
+
+export function useQuestionTtsPlayer({
+    sessionId,
+    userId,
+    questionText,
+    finishedQuestionText = '',
+    autoPlayEnabled = true,
+    noSessionErrorMessage = '세션 정보를 찾을 수 없습니다.',
+    onError,
+}) {
+    const audioRef = useRef(null);
+    const audioUrlRef = useRef('');
+    const autoPlayedKeyRef = useRef('');
+
+    const [isLoading, setIsLoading] = useState(false);
+    const [isPlaying, setIsPlaying] = useState(false);
+
+    const stop = useCallback(() => {
+        if (audioRef.current) {
+            audioRef.current.onended = null;
+            audioRef.current.onpause = null;
+            audioRef.current.pause();
+            audioRef.current = null;
+        }
+
+        if (audioUrlRef.current) {
+            URL.revokeObjectURL(audioUrlRef.current);
+            audioUrlRef.current = '';
+        }
+
+        setIsPlaying(false);
+    }, []);
+
+    const playText = useCallback(async (text, { silent = false, allowFinishedText = false } = {}) => {
+        const normalizedText = toTrimmedString(text);
+        const normalizedSessionId = toTrimmedString(sessionId);
+        const normalizedFinishedText = toTrimmedString(finishedQuestionText);
+
+        if (!normalizedText) {
+            return false;
+        }
+        if (!allowFinishedText && normalizedText === normalizedFinishedText) {
+            return false;
+        }
+        if (!normalizedSessionId) {
+            if (!silent) {
+                onError?.(new Error(noSessionErrorMessage));
+            }
+            return false;
+        }
+
+        setIsLoading(true);
+        try {
+            stop();
+
+            const response = await requestTTS({
+                userId,
+                sessionId: normalizedSessionId,
+                text: normalizedText,
+            });
+
+            const objectUrl = URL.createObjectURL(response.audioBlob);
+            audioUrlRef.current = objectUrl;
+
+            const audio = new Audio(objectUrl);
+            audioRef.current = audio;
+            audio.onended = () => setIsPlaying(false);
+            audio.onpause = () => setIsPlaying(false);
+
+            await audio.play();
+            setIsPlaying(true);
+            return true;
+        } catch (error) {
+            stop();
+            if (!silent) {
+                onError?.(error);
+            }
+            return false;
+        } finally {
+            setIsLoading(false);
+        }
+    }, [finishedQuestionText, noSessionErrorMessage, onError, sessionId, stop, userId]);
+
+    const play = useCallback(async ({ silent = false } = {}) => {
+        const normalizedQuestion = toTrimmedString(questionText);
+        return playText(normalizedQuestion, { silent });
+    }, [playText, questionText]);
+
+    const toggle = useCallback(async () => {
+        if (isLoading) return false;
+        if (isPlaying) {
+            stop();
+            return true;
+        }
+        return play();
+    }, [isLoading, isPlaying, play, stop]);
+
+    useEffect(() => {
+        stop();
+
+        const normalizedQuestion = toTrimmedString(questionText);
+        const normalizedSessionId = toTrimmedString(sessionId);
+        const normalizedFinishedText = toTrimmedString(finishedQuestionText);
+
+        const shouldAutoPlay =
+            autoPlayEnabled &&
+            Boolean(normalizedQuestion) &&
+            normalizedQuestion !== normalizedFinishedText &&
+            Boolean(normalizedSessionId);
+
+        if (!shouldAutoPlay) {
+            return;
+        }
+
+        const autoPlayKey = `${normalizedSessionId}:${normalizedQuestion}`;
+        if (autoPlayedKeyRef.current === autoPlayKey) {
+            return;
+        }
+
+        autoPlayedKeyRef.current = autoPlayKey;
+        void play({ silent: true });
+    }, [autoPlayEnabled, finishedQuestionText, play, questionText, sessionId, stop]);
+
+    useEffect(() => {
+        return () => {
+            stop();
+        };
+    }, [stop]);
+
+    return {
+        isLoading,
+        isPlaying,
+        play,
+        playText,
+        stop,
+        toggle,
+    };
+}

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -37,7 +37,11 @@ const PracticeAnswerEdit = () => {
     const [showConfirm, setShowConfirm] = useState(false);
     const [showLengthWarning, setShowLengthWarning] = useState(false);
     const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();
-    const [answer, setAnswer] = useState(state?.transcribedText);
+    const [answer, setAnswer] = useState(() => {
+        if (typeof state?.transcribedText === 'string') return state.transcribedText;
+        if (typeof state?.prefillAnswerText === 'string') return state.prefillAnswerText;
+        return '';
+    });
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const handleToggleEdit = () => {
@@ -54,7 +58,7 @@ const PracticeAnswerEdit = () => {
     };
 
     const handleSubmit = () => {
-        if (!answer.trim()) return;
+        if (!(answer || '').trim()) return;
         setShowConfirm(true);
     };
 

--- a/src/app/pages/PracticeAnswerText.jsx
+++ b/src/app/pages/PracticeAnswerText.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Textarea } from '@/app/components/ui/textarea';
 import { Card } from '@/app/components/ui/card';
@@ -37,7 +37,10 @@ const MAX_ANSWER_LENGTH = 1500;
 const PracticeAnswerText = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
-    const [answer, setAnswer] = useState('');
+    const { state } = useLocation();
+    const [answer, setAnswer] = useState(() => (
+        typeof state?.prefillAnswerText === 'string' ? state.prefillAnswerText : ''
+    ));
     const [showConfirm, setShowConfirm] = useState(false);
     const [showLengthWarning, setShowLengthWarning] = useState(false);
     const { submitAnswer, isSubmitting } = usePracticeAnswerSubmit();

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { motion as Motion } from 'motion/react';
 import { AppHeader } from '@/app/components/AppHeader';
@@ -26,6 +26,7 @@ const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
 const PracticeAnswerVoice = () => {
   const navigate = useNavigate();
   const { questionId } = useParams();
+  const { state } = useLocation();
   const [seconds, setSeconds] = useState(0);
   const [isUploading, setIsUploading] = useState(false);
   const [showBackModal, setShowBackModal] = useState(false);
@@ -47,6 +48,18 @@ const PracticeAnswerVoice = () => {
     error: recorderError,
     resetAudioBlob,
   } = useAudioRecorder();
+
+  const prefillAnswerText =
+    typeof state?.prefillAnswerText === 'string' ? state.prefillAnswerText : '';
+
+  useEffect(() => {
+    if (!prefillAnswerText.trim()) return;
+
+    navigate(`/practice/answer-edit/${questionId}`, {
+      replace: true,
+      state: { transcribedText: prefillAnswerText },
+    });
+  }, [navigate, prefillAnswerText, questionId]);
 
   // 녹음 타이머 (recording 상태일 때만 동작)
   useEffect(() => {

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -1,12 +1,20 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
 import { ThumbsUp, AlertCircle, Home, Target } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
-import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, ResponsiveContainer } from 'recharts';
+import {
+    RadarChart,
+    PolarGrid,
+    PolarAngleAxis,
+    PolarRadiusAxis,
+    Radar,
+    ResponsiveContainer,
+} from 'recharts';
 import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
 import { usePracticeQuestion } from '@/context/practiceQuestionContext.jsx';
+import { SESSION_STORAGE_KEYS } from '@/app/constants/storageKeys';
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
@@ -20,50 +28,87 @@ const TEXT_AI_FEEDBACK_TITLE = 'AI 피드백';
 const TEXT_BAD_CASE_STRENGTHS = '더 잘 할 수 있어요. 지금의 시도가 충분히 의미 있습니다.';
 const TEXT_BAD_CASE_IMPROVEMENTS = '조금만 더 자세히 설명해도 충분히 좋아질 수 있어요.';
 const TEXT_RADAR_LABEL = '평가';
-const FEEDBACK_SECTION_DELIMITER = '\n\n';
+
 const FEEDBACK_SPLIT_DELIMITER = '●';
 const FEEDBACK_BULLET = '•';
 const FEEDBACK_DASH = '-';
+const PRACTICE_SESSION_STORAGE_KEY = SESSION_STORAGE_KEYS.PRACTICE_INTERVIEW_SESSION;
+
+const RADAR_DOMAIN_MAX = 100;
+const METRIC_SCORE_MAX = 5;
+
+const normalizeScore = (score) => {
+    if (typeof score !== 'number' || Number.isNaN(score)) return 0;
+    const clamped = Math.max(0, Math.min(METRIC_SCORE_MAX, score));
+    return Math.round((clamped / METRIC_SCORE_MAX) * RADAR_DOMAIN_MAX);
+};
+
+const splitFeedbackText = (text) => {
+    if (typeof text !== 'string') return [];
+    const normalized = text.replace(/\n+/g, '\n').trim();
+    if (!normalized) return [];
+    return normalized
+        .split(FEEDBACK_SPLIT_DELIMITER)
+        .map((line) => line.trim())
+        .filter(Boolean);
+};
 
 const PracticeResultAI = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const { state } = useLocation();
+
     const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
     const { clearSelectedQuestion } = usePracticeQuestion();
 
     const feedbackResponse = state?.feedbackResponse;
-    const feedbackData = feedbackResponse?.data;
+    const feedbackData = useMemo(() => feedbackResponse?.data ?? null, [feedbackResponse]);
+
+    const metrics = useMemo(() => {
+        return Array.isArray(feedbackData?.metrics)
+            ? feedbackData.metrics.filter((metric) => metric && typeof metric === 'object')
+            : [];
+    }, [feedbackData]);
+
+    const radarData = useMemo(() => {
+        return metrics.map((metric, idx) => ({
+            subject: metric?.name || `평가 ${idx + 1}`,
+            value: normalizeScore(metric?.score),
+        }));
+    }, [metrics]);
+
+    const overallFeedback = feedbackData?.overall_feedback ?? {};
     const badCaseFeedback = feedbackData?.bad_case_feedback;
-    const isBadCase = Boolean(badCaseFeedback) || !feedbackData?.radarChart;
-    // score를 maxScore 기준 0~100으로 변환해 레이더 차트에 사용한다.
-    const radarData = Array.isArray(feedbackData?.radarChart)
-        ? feedbackData.radarChart.map((metric) => ({
-            subject: metric.metricName,
-            value: Math.min(100, Math.max(0, Math.round((metric.score / metric.maxScore) * 100))),
-        }))
-        : [];
-    // bad case일 때는 100%로 채워 긍정적 UI를 유지한다.
-    // const filledRadarData = radarData.length
-    //     ? radarData.map((metric) => ({ ...metric, value: 100 }))
-    //     : [];
-    const feedbackText = feedbackData?.feedback || '';
-    const [strengthsText, improvementsText] = isBadCase
-        ? [TEXT_BAD_CASE_STRENGTHS, TEXT_BAD_CASE_IMPROVEMENTS]
-        : [
-            feedbackText.split(FEEDBACK_SECTION_DELIMITER)[0] || '',
-            feedbackText.split(FEEDBACK_SECTION_DELIMITER)[1] || '',
-        ];
+    const failedFeedbackMessage = feedbackData?.status === 'FAILED' ? feedbackData?.message : '';
+
+    const hasRadarData = radarData.length > 0;
+    const isBadCase = Boolean(badCaseFeedback) || !hasRadarData;
+
+    const strengthsText =
+        overallFeedback?.strengths ||
+        badCaseFeedback?.message ||
+        failedFeedbackMessage ||
+        TEXT_BAD_CASE_STRENGTHS;
+
+    const improvementsText =
+        overallFeedback?.improvements ||
+        badCaseFeedback?.guidance ||
+        TEXT_BAD_CASE_IMPROVEMENTS;
 
     const renderFeedbackText = (text, className) => {
-        const normalized = text.replace(/\n+/g, '\n').trim();
-        const lines = normalized
-            ? normalized.split(FEEDBACK_SPLIT_DELIMITER).map((line) => line.trim()).filter(Boolean)
-            : [];
+        const lines = splitFeedbackText(text);
+
+        if (lines.length === 0) {
+            return <p className={className}>{TEXT_BAD_CASE_FALLBACK}</p>;
+        }
+
         return (
             <div className={`space-y-2 ${className}`}>
                 {lines.map((line, idx) => {
-                    const content = line.startsWith(FEEDBACK_DASH) ? line.slice(1).trim() : line;
+                    const content = line.startsWith(FEEDBACK_DASH)
+                        ? line.slice(1).trim()
+                        : line;
+
                     return (
                         <p key={idx} className="leading-relaxed pl-5 relative">
                             <span className="absolute left-0">{FEEDBACK_BULLET}</span>
@@ -76,12 +121,13 @@ const PracticeResultAI = () => {
     };
 
     useEffect(() => {
-        if (!badCaseFeedback) return;
-    }, [badCaseFeedback]);
-
-    useEffect(() => {
         return () => {
             clearSelectedQuestion();
+            try {
+                sessionStorage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
+            } catch {
+                // sessionStorage 사용 불가 환경에서는 무시
+            }
         };
     }, [clearSelectedQuestion]);
 
@@ -112,27 +158,30 @@ const PracticeResultAI = () => {
             </div>
 
             <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-                <>
-                    <Card className="p-6 bg-white shadow-lg">
-                        {isBadCase && (
-                            <div className="text-center mb-4 space-y-2">
-                                <p className="text-sm text-rose-900 font-medium">
-                                    {badCaseFeedback?.message || feedbackText.split(FEEDBACK_SECTION_DELIMITER)[0] || TEXT_BAD_CASE_FALLBACK}
+                <Card className="p-6 bg-white shadow-lg">
+                    {isBadCase ? (
+                        <div className="text-center space-y-2">
+                            <p className="text-sm text-rose-900 font-medium">
+                                {failedFeedbackMessage || badCaseFeedback?.message || TEXT_BAD_CASE_FALLBACK}
+                            </p>
+                            {(badCaseFeedback?.guidance || overallFeedback?.improvements) && (
+                                <p className="text-xs text-rose-700">
+                                    {badCaseFeedback?.guidance || overallFeedback?.improvements}
                                 </p>
-                                {(badCaseFeedback?.guidance || feedbackText.split(FEEDBACK_SECTION_DELIMITER)[1]) && (
-                                    <p className="text-xs text-rose-700">
-                                        {badCaseFeedback?.guidance || feedbackText.split(FEEDBACK_SECTION_DELIMITER)[1]}
-                                    </p>
-                                )}
-                            </div>
-                        )}
-
-                        {isBadCase ? null : (
+                            )}
+                        </div>
+                    ) : (
+                        <>
                             <ResponsiveContainer width="100%" height={250}>
                                 <RadarChart data={radarData}>
                                     <PolarGrid />
                                     <PolarAngleAxis dataKey="subject" />
-                                    <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} axisLine={false} />
+                                    <PolarRadiusAxis
+                                        angle={90}
+                                        domain={[0, RADAR_DOMAIN_MAX]}
+                                        tick={false}
+                                        axisLine={false}
+                                    />
                                     <Radar
                                         name={TEXT_RADAR_LABEL}
                                         dataKey="value"
@@ -142,33 +191,34 @@ const PracticeResultAI = () => {
                                     />
                                 </RadarChart>
                             </ResponsiveContainer>
-                        )}
-                    </Card>
+                        </>
+                    )}
+                </Card>
 
-                    <Card className="p-5 border-2 border-rose-200 bg-rose-50">
-                        <div className="flex items-start gap-3">
-                            <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                                <ThumbsUp className="w-5 h-5 text-pink-600" />
-                            </div>
-                            <div className="flex-1">
-                                <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
-                                {renderFeedbackText(strengthsText, 'text-sm text-rose-800')}
-                            </div>
+                <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+                    <div className="flex items-start gap-3">
+                        <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+                            <ThumbsUp className="w-5 h-5 text-pink-600" />
                         </div>
-                    </Card>
+                        <div className="flex-1">
+                            <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
+                            {renderFeedbackText(strengthsText, 'text-sm text-rose-800')}
+                        </div>
+                    </div>
+                </Card>
 
-                    <Card className="p-5 border-2 border-pink-200 bg-pink-50">
-                        <div className="flex items-start gap-3">
-                            <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
-                                <AlertCircle className="w-5 h-5 text-pink-600" />
-                            </div>
-                            <div className="flex-1">
-                                <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
-                                {renderFeedbackText(improvementsText, 'text-sm text-pink-800')}
-                            </div>
+                <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+                    <div className="flex items-start gap-3">
+                        <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
+                            <AlertCircle className="w-5 h-5 text-pink-600" />
                         </div>
-                    </Card>
-                </>
+                        <div className="flex-1">
+                            <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+                            {renderFeedbackText(improvementsText, 'text-sm text-pink-800')}
+                        </div>
+                    </div>
+                </Card>
+
                 <Button
                     onClick={() => {
                         clearSelectedQuestion();

--- a/src/app/pages/PracticeResultKeyword.jsx
+++ b/src/app/pages/PracticeResultKeyword.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
@@ -7,7 +7,11 @@ import { Progress } from '@/app/components/ui/progress';
 import { Sparkles } from 'lucide-react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
-import { fetchAnswerFeedback } from '@/api/answerApi';
+import {
+    getPracticeFeedbackStorageKey,
+    PRACTICE_FEEDBACK_UPDATED_EVENT,
+    SESSION_STORAGE_KEYS,
+} from '@/app/constants/storageKeys';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -21,9 +25,12 @@ import {
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
+const TEXT_SUBMITTING = '답변을 제출하고 분석 요청을 준비하고 있어요...';
 const TEXT_ANALYZING = 'AI가 답변을 분석중이에요...';
 const TEXT_ERROR_FALLBACK = '피드백 요청에 실패했습니다.';
 const TEXT_ERROR_PARSE = '피드백 결과를 불러오는 중 오류가 발생했습니다.';
+const TEXT_ERROR_TIMEOUT = '피드백 생성이 지연되고 있습니다. 잠시 후 다시 시도해주세요.';
+const TEXT_ERROR_MISSING_REQUEST = '피드백 요청 정보를 찾을 수 없습니다. 다시 답변을 제출해주세요.';
 const TEXT_BACK_MODAL_TITLE = 'AI가 답변 분석 중입니다.';
 const TEXT_BACK_MODAL_DESC = '연습모드로 돌아가시겠습니까?';
 const TEXT_BACK_MODAL_CONFIRM = '연습모드로 돌아가기';
@@ -33,38 +40,83 @@ const TEXT_RETRY_BUTTON = '다시 답변하기';
 const TEXT_PAGE_TITLE = '답변 분석';
 const TEXT_QUESTION_LABEL = '질문';
 const TEXT_MY_ANSWER_LABEL = '나의 답변';
-const TEXT_KEYWORD_TITLE = '핵심 키워드';
-const TEXT_KEYWORD_HELP = '답변에 이 키워드들이 포함되어 있는지 확인해보세요';
+const TEXT_KEYWORD_TITLE = '핵심 키워드 분석';
+const TEXT_KEYWORD_HELP = '답변에서 반영된 키워드와 보완이 필요한 키워드를 확인해보세요';
+const TEXT_KEYWORD_COVERED = '반영된 키워드';
+const TEXT_KEYWORD_MISSING = '보완이 필요한 키워드';
+const TEXT_KEYWORD_COVERAGE = '키워드 커버리지';
+const TEXT_KEYWORD_NONE = '모든 핵심 키워드를 반영했어요.';
 const TEXT_PROGRESS_SUFFIX = '%';
-const FEEDBACK_STORAGE_PREFIX = 'qfeed_ai_feedback_';
-const FEEDBACK_POLL_INTERVAL_MS = 800;
-const FEEDBACK_STATUS_COMPLETED = 'COMPLETED';
+
+const PRACTICE_SESSION_STORAGE_KEY = SESSION_STORAGE_KEYS.PRACTICE_INTERVIEW_SESSION;
+
+const FEEDBACK_WAIT_TIMEOUT_MS = 60 * 1000;
 const STORAGE_STATUS_PENDING = 'pending';
 const STORAGE_STATUS_DONE = 'done';
 const STORAGE_STATUS_ERROR = 'error';
+
 const PROGRESS_WAIT_MAX = 95;
-const PROGRESS_WAIT_STEP = 4;
-const PROGRESS_WAIT_INTERVAL_MS = 450;
+const PROGRESS_WAIT_STEP = 3;
+const PROGRESS_WAIT_INTERVAL_MS = 500;
 const PROGRESS_COMPLETE = 100;
 const PROGRESS_COMPLETE_STEP = 1;
-const PROGRESS_COMPLETE_INTERVAL_MS = 25;
+const PROGRESS_COMPLETE_INTERVAL_MS = 50;
+
+const safeRemoveSessionKey = () => {
+    try {
+        sessionStorage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
+    } catch {
+        // sessionStorage 사용 불가 환경에서는 무시
+    }
+};
 
 const PracticeResultKeyword = () => {
     const navigate = useNavigate();
     const { questionId } = useParams();
     const { state } = useLocation();
+
     const [isAnalyzing, setIsAnalyzing] = useState(true);
     const [progress, setProgress] = useState(0);
     const [showBackModal, setShowBackModal] = useState(false);
     const [feedbackResponse, setFeedbackResponse] = useState(null);
-    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
     const [feedbackError, setFeedbackError] = useState('');
+    const [analysisStatusText, setAnalysisStatusText] = useState(TEXT_SUBMITTING);
+
+    const { question, isLoading, errorMessage } = usePracticeQuestionLoader(questionId);
 
     const myAnswer = state?.answerText || '';
     const retryPath = state?.retryPath || `/practice/answer/${questionId}`;
+    const retryState = myAnswer
+        ? { prefillAnswerText: myAnswer }
+        : undefined;
 
-    // 0~95%까지 천천히 올라가며 대기 상태를 표현한다.
+    const keywordResult = feedbackResponse?.data?.keyword_result;
+
+    const coveredKeywords = useMemo(() => {
+        return Array.isArray(keywordResult?.covered_keywords)
+            ? keywordResult.covered_keywords.filter((keyword) => typeof keyword === 'string' && keyword.trim())
+            : [];
+    }, [keywordResult]);
+
+    const missingKeywords = useMemo(() => {
+        return Array.isArray(keywordResult?.missing_keywords)
+            ? keywordResult.missing_keywords.filter((keyword) => typeof keyword === 'string' && keyword.trim())
+            : [];
+    }, [keywordResult]);
+    const fallbackKeywords = Array.isArray(question?.keywords)
+        ? question.keywords.filter((keyword) => typeof keyword === 'string' && keyword.trim())
+        : [];
+
+    const coveragePercent = useMemo(() => {
+        const ratio = keywordResult?.coverage_ratio;
+        if (typeof ratio !== 'number') return null;
+        const clamped = Math.max(0, Math.min(1, ratio));
+        return Math.round(clamped * 100);
+    }, [keywordResult]);
+
     useEffect(() => {
+        if (!isAnalyzing) return undefined;
+
         const interval = setInterval(() => {
             setProgress((prev) => {
                 if (prev >= PROGRESS_WAIT_MAX) return PROGRESS_WAIT_MAX;
@@ -73,87 +125,124 @@ const PracticeResultKeyword = () => {
         }, PROGRESS_WAIT_INTERVAL_MS);
 
         return () => clearInterval(interval);
-    }, []);
+    }, [isAnalyzing]);
 
-    // 세션에 저장된 피드백 상태를 폴링하여 완료 시 결과 화면으로 넘긴다.
     useEffect(() => {
-        const storageKey = `${FEEDBACK_STORAGE_PREFIX}${questionId}`;
-        let isFetching = false;
-        let timer = null;
-        const poll = () => {
+        const storageKey = getPracticeFeedbackStorageKey(questionId);
+        let disposed = false;
+        let timeoutId = null;
+
+        const clearWatchdog = () => {
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }
+        };
+
+        const stopWatching = () => {
+            disposed = true;
+            clearWatchdog();
+        };
+
+        const finalizeSuccess = (response) => {
+            setIsAnalyzing(false);
+            setFeedbackResponse(response);
+            sessionStorage.removeItem(storageKey);
+            stopWatching();
+        };
+
+        const finalizeError = (message) => {
+            setIsAnalyzing(false);
+            setFeedbackError(message || TEXT_ERROR_FALLBACK);
+            sessionStorage.removeItem(storageKey);
+            stopWatching();
+        };
+
+        const applyStoredState = () => {
+            if (disposed) return;
+
             const raw = sessionStorage.getItem(storageKey);
-            if (!raw) return;
+            if (!raw) {
+                finalizeError(TEXT_ERROR_MISSING_REQUEST);
+                return;
+            }
+
             try {
                 const data = JSON.parse(raw);
-                if (data.status === STORAGE_STATUS_DONE) {
-                    if (!feedbackResponse) {
-                        setIsAnalyzing(false);
-                        setFeedbackResponse(data.response);
-                    }
-                    sessionStorage.removeItem(storageKey);
-                    if (timer) clearInterval(timer);
+
+                if (data.status === STORAGE_STATUS_DONE && data.response) {
+                    finalizeSuccess(data.response);
                     return;
                 }
+
                 if (data.status === STORAGE_STATUS_ERROR) {
-                    setIsAnalyzing(false);
-                    setFeedbackError(data.message || TEXT_ERROR_FALLBACK);
-                    sessionStorage.removeItem(storageKey);
-                    if (timer) clearInterval(timer);
+                    finalizeError(data.message || TEXT_ERROR_FALLBACK);
                     return;
                 }
 
-                const answerId = data.answerId;
-                if (!answerId || isFetching || feedbackResponse) return;
+                if (data.status !== STORAGE_STATUS_PENDING) {
+                    finalizeError(TEXT_ERROR_PARSE);
+                    return;
+                }
 
-                isFetching = true;
-                fetchAnswerFeedback(answerId)
-                    .then((response) => {
-                        const status = response?.data?.status;
-                        if (status === FEEDBACK_STATUS_COMPLETED) {
-                            setIsAnalyzing(false);
-                            setFeedbackResponse(response);
-                            sessionStorage.setItem(
-                                storageKey,
-                                JSON.stringify({ status: STORAGE_STATUS_DONE, answerId, response })
-                            );
-                            sessionStorage.removeItem(storageKey);
-                            if (timer) clearInterval(timer);
-                        }
-                    })
-                    .catch((err) => {
-                        setIsAnalyzing(false);
-                        setFeedbackError(err?.message || TEXT_ERROR_FALLBACK);
-                        sessionStorage.removeItem(storageKey);
-                        if (timer) clearInterval(timer);
-                    })
-                    .finally(() => {
-                        isFetching = false;
-                    });
+                const sessionId = data.sessionId;
+                if (!sessionId) {
+                    finalizeError(TEXT_ERROR_PARSE);
+                    return;
+                }
+
+                const createdAt = Date.parse(data.createdAt || '');
+                if (Number.isFinite(createdAt) && Date.now() - createdAt >= FEEDBACK_WAIT_TIMEOUT_MS) {
+                    finalizeError(TEXT_ERROR_TIMEOUT);
+                    return;
+                }
+
+                if (data.requestedAt) {
+                    setAnalysisStatusText(TEXT_ANALYZING);
+                } else {
+                    setAnalysisStatusText(TEXT_SUBMITTING);
+                }
             } catch {
-                setIsAnalyzing(false);
-                setFeedbackError(TEXT_ERROR_PARSE);
-                if (timer) clearInterval(timer);
+                finalizeError(TEXT_ERROR_PARSE);
             }
         };
 
-        timer = setInterval(poll, FEEDBACK_POLL_INTERVAL_MS);
-        poll();
+        const handleFeedbackUpdated = (event) => {
+            if (disposed) return;
+            if (event?.detail?.storageKey !== storageKey) return;
+            applyStoredState();
+        };
+
+        timeoutId = setTimeout(() => {
+            if (disposed) return;
+            finalizeError(TEXT_ERROR_TIMEOUT);
+        }, FEEDBACK_WAIT_TIMEOUT_MS);
+
+        if (typeof window !== 'undefined') {
+            window.addEventListener(PRACTICE_FEEDBACK_UPDATED_EVENT, handleFeedbackUpdated);
+        }
+
+        applyStoredState();
+
         return () => {
-            if (timer) clearInterval(timer);
-        };
-    }, [questionId, navigate, myAnswer, feedbackResponse]);
-
-    // 응답 완료 후 95% → 100%를 부드럽게 채운다.
-    useEffect(() => {
-        if (!feedbackResponse) return;
-
-        let current = PROGRESS_WAIT_MAX;
-        const interval = setInterval(() => {
-            current += PROGRESS_COMPLETE_STEP;
-            setProgress(current);
-            if (current >= PROGRESS_COMPLETE) {
-                clearInterval(interval);
+            stopWatching();
+            if (typeof window !== 'undefined') {
+                window.removeEventListener(PRACTICE_FEEDBACK_UPDATED_EVENT, handleFeedbackUpdated);
             }
+        };
+    }, [questionId]);
+
+    useEffect(() => {
+        if (!feedbackResponse) return undefined;
+
+        const interval = setInterval(() => {
+            setProgress((prev) => {
+                if (prev >= PROGRESS_COMPLETE) {
+                    clearInterval(interval);
+                    return PROGRESS_COMPLETE;
+                }
+                return Math.min(PROGRESS_COMPLETE, prev + PROGRESS_COMPLETE_STEP);
+            });
         }, PROGRESS_COMPLETE_INTERVAL_MS);
 
         return () => clearInterval(interval);
@@ -166,10 +255,14 @@ const PracticeResultKeyword = () => {
     const handleBackClick = () => {
         if (isAnalyzing) {
             setShowBackModal(true);
-        } else {
-            navigate('/practice');
+            return;
         }
+
+        safeRemoveSessionKey();
+        navigate('/practice');
     };
+
+    const hasAnalyzedKeywordData = coveredKeywords.length > 0 || missingKeywords.length > 0;
 
     return (
         <div className="min-h-screen bg-background">
@@ -192,27 +285,69 @@ const PracticeResultKeyword = () => {
                     </div>
                 </Card>
 
-                <Card className="p-4 bg-gradient-to-br from-rose-50 to-white">
-                    <div className="flex items-center gap-2 mb-3">
+                <Card className="p-4 bg-gradient-to-br from-rose-50 to-white space-y-4">
+                    <div className="flex items-center gap-2">
                         <Sparkles className="w-5 h-5 text-pink-600" />
                         <h3>{TEXT_KEYWORD_TITLE}</h3>
                     </div>
 
-                    <div className="flex flex-wrap gap-2">
-                        {question.keywords.map((keyword, idx) => (
-                            <Badge
-                                key={idx}
-                                variant="secondary"
-                                className="bg-rose-100 text-rose-700 px-3 py-1"
-                            >
-                                #{keyword}
-                            </Badge>
-                        ))}
-                    </div>
+                    {coveragePercent !== null && !isAnalyzing && (
+                        <div className="rounded-lg bg-white/80 px-3 py-2 text-sm text-rose-900">
+                            {TEXT_KEYWORD_COVERAGE}: <span className="font-semibold">{coveragePercent}%</span>
+                        </div>
+                    )}
 
-                    <p className="text-xs text-muted-foreground mt-3">
-                        {TEXT_KEYWORD_HELP}
-                    </p>
+                    {isAnalyzing || !hasAnalyzedKeywordData ? (
+                        <div className="flex flex-wrap gap-2">
+                            {fallbackKeywords.map((keyword, idx) => (
+                                <Badge
+                                    key={`${keyword}-${idx}`}
+                                    variant="secondary"
+                                    className="bg-rose-100 text-rose-700 px-3 py-1"
+                                >
+                                    #{keyword}
+                                </Badge>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="space-y-3">
+                            <div>
+                                <p className="text-xs font-semibold text-emerald-700 mb-2">{TEXT_KEYWORD_COVERED}</p>
+                                <div className="flex flex-wrap gap-2">
+                                    {coveredKeywords.map((keyword, idx) => (
+                                        <Badge
+                                            key={`covered-${keyword}-${idx}`}
+                                            variant="secondary"
+                                            className="bg-emerald-100 text-emerald-700 px-3 py-1"
+                                        >
+                                            #{keyword}
+                                        </Badge>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <div>
+                                <p className="text-xs font-semibold text-amber-700 mb-2">{TEXT_KEYWORD_MISSING}</p>
+                                {missingKeywords.length > 0 ? (
+                                    <div className="flex flex-wrap gap-2">
+                                        {missingKeywords.map((keyword, idx) => (
+                                            <Badge
+                                                key={`missing-${keyword}-${idx}`}
+                                                variant="secondary"
+                                                className="bg-amber-100 text-amber-700 px-3 py-1"
+                                            >
+                                                #{keyword}
+                                            </Badge>
+                                        ))}
+                                    </div>
+                                ) : (
+                                    <p className="text-xs text-muted-foreground">{TEXT_KEYWORD_NONE}</p>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    <p className="text-xs text-muted-foreground">{TEXT_KEYWORD_HELP}</p>
                 </Card>
 
                 {isAnalyzing ? (
@@ -221,7 +356,7 @@ const PracticeResultKeyword = () => {
                             <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-pink-400 to-rose-400 flex items-center justify-center">
                                 <Sparkles className="w-8 h-8 text-white animate-pulse" />
                             </div>
-                            <p className="mb-4">{TEXT_ANALYZING}</p>
+                            <p className="mb-4">{analysisStatusText}</p>
                             <Progress value={progress} className="h-2" />
                             <p className="text-xs text-muted-foreground mt-2">
                                 {progress}{TEXT_PROGRESS_SUFFIX}
@@ -234,8 +369,11 @@ const PracticeResultKeyword = () => {
                             {feedbackError}
                         </div>
                         <Button
-                            onClick={() => navigate(retryPath)}
-                            className="w-full rounded-md h-12"
+                            onClick={() => {
+                                safeRemoveSessionKey();
+                                navigate(retryPath, retryState ? { state: retryState } : undefined);
+                            }}
+                            className="w-full rounded-xl h-12"
                         >
                             {TEXT_RETRY_BUTTON}
                         </Button>
@@ -263,7 +401,12 @@ const PracticeResultKeyword = () => {
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <AlertDialogCancel>{TEXT_BACK_MODAL_CANCEL}</AlertDialogCancel>
-                        <AlertDialogAction onClick={() => navigate('/practice')}>
+                        <AlertDialogAction
+                            onClick={() => {
+                                safeRemoveSessionKey();
+                                navigate('/practice');
+                            }}
+                        >
                             {TEXT_BACK_MODAL_CONFIRM}
                         </AlertDialogAction>
                     </AlertDialogFooter>

--- a/src/app/pages/PracticeSTT.jsx
+++ b/src/app/pages/PracticeSTT.jsx
@@ -27,12 +27,14 @@ const PracticeSTT = () => {
             try {
                 setStatusMessage('답변을 텍스트로 변환 중입니다...');
 
-                const sessionId = Number(questionId);
-                console.log(audioUrl);
-                // 백엔드 스키마(user_id, session_id, audio_url)에 맞춰 전달
+                const sessionId = typeof questionId === 'string' ? questionId.trim() : '';
+                if (!sessionId) {
+                    throw new Error('세션 정보를 확인할 수 없습니다');
+                }
+                // 백엔드 스키마(user_id, session_id, audio_url)에 맞춰 전달 (session_id string)
                 const result = await requestSTT({
                     userId: DEFAULT_USER_ID,
-                    sessionId: Number.isNaN(sessionId) ? questionId : sessionId,
+                    sessionId,
                     audioUrl,
                 });
                 const { text } = result.data;

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -14,14 +14,11 @@ import {
     getQuestionCategoryLabel,
     getQuestionTypeLabel,
 } from '@/app/constants/questionCategoryMeta';
+import { INTERVIEW_TYPES, INTERVIEW_TYPE_LABELS } from '@/app/constants/interviewTaxonomy';
 
-const ANSWER_TYPE_LABELS = {
-    PRACTICE_INTERVIEW: '연습',
-    REAL_INTERVIEW: '실전',
-    PORTFOLIO_INTERVIEW: '포트폴리오',
-};
+const ANSWER_TYPE_LABELS = INTERVIEW_TYPE_LABELS;
 
-const MODE_OPTIONS = [{ value: 'PRACTICE_INTERVIEW', label: '연습' }];
+const MODE_OPTIONS = [{ value: INTERVIEW_TYPES.PRACTICE, label: INTERVIEW_TYPE_LABELS[INTERVIEW_TYPES.PRACTICE] }];
 const SERVICE_LAUNCH_DATE = '2026-02-04';
 const EMPTY_CATEGORY_MAP = Object.freeze({});
 const ALL_FILTER_VALUE = 'ALL';

--- a/src/app/pages/RealInterview.jsx
+++ b/src/app/pages/RealInterview.jsx
@@ -1,13 +1,106 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
 import BottomNav from '@/app/components/BottomNav';
 import { toast } from 'sonner';
-
 import { AppHeader } from '@/app/components/AppHeader';
+import { createInterviewSession } from '@/api/interviewApi';
+import { SESSION_STORAGE_KEYS } from '@/app/constants/storageKeys';
+import { INTERVIEW_TYPES, QUESTION_TYPES } from '@/app/constants/interviewTaxonomy';
+import { useAuth } from '@/context/AuthContext';
 
 const SHOW_PORTFOLIO_INTERVIEW = import.meta.env.VITE_SHOW_PORTFOLIO_INTERVIEW === 'true';
+const REAL_SESSION_STORAGE_KEY = SESSION_STORAGE_KEYS.REAL_INTERVIEW_SESSION;
+const TEXT_SESSION_CREATE_FAILED = '면접 세션 생성에 실패했습니다.';
+const TEXT_SESSION_CREATING = '실전면접 준비 중';
+const DEFAULT_REAL_USER_ID = 1;
+
+const safeSetSessionItem = (key, value) => {
+    try {
+        sessionStorage.setItem(key, value);
+    } catch {
+        // sessionStorage 사용 불가 환경에서는 무시한다.
+    }
+};
+
+const normalizeTurnType = (value, fallback = 'main') => {
+    if (typeof value !== 'string') return fallback;
+    const normalized = value.trim().toLowerCase();
+    return normalized || fallback;
+};
+
+const resolveUserIdFromAccessToken = (token) => {
+    if (!token) return DEFAULT_REAL_USER_ID;
+
+    const parts = token.split('.');
+    if (parts.length < 2) return DEFAULT_REAL_USER_ID;
+
+    try {
+        const normalized = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+        const padded = normalized.padEnd(
+            normalized.length + (4 - (normalized.length % 4 || 4)) % 4,
+            '='
+        );
+        const payload = JSON.parse(atob(padded));
+        const candidates = [
+            payload?.userId,
+            payload?.user_id,
+            payload?.memberId,
+            payload?.member_id,
+            payload?.id,
+            payload?.sub,
+        ];
+
+        for (const candidate of candidates) {
+            if (typeof candidate === 'number' && Number.isInteger(candidate)) {
+                return candidate;
+            }
+            if (typeof candidate === 'string' && /^\d+$/.test(candidate.trim())) {
+                return Number(candidate.trim());
+            }
+        }
+    } catch {
+        return DEFAULT_REAL_USER_ID;
+    }
+
+    return DEFAULT_REAL_USER_ID;
+};
+
+const saveRealInterviewSession = ({ userId, questionType, sessionData }) => {
+    const sessionId = sessionData?.session_id ?? sessionData?.sessionId;
+    if (!sessionId) return;
+
+    const questionText = sessionData?.question_text ?? sessionData?.questionText ?? '';
+    const turnType = normalizeTurnType(sessionData?.turn_type ?? sessionData?.turnType, 'main');
+    const turnOrderRaw = sessionData?.turn_order ?? sessionData?.turnOrder;
+    const turnOrder = Number.isInteger(turnOrderRaw) ? turnOrderRaw : 0;
+    const resolvedQuestionType = sessionData?.question_type ?? sessionData?.questionType ?? questionType;
+
+    safeSetSessionItem(
+        REAL_SESSION_STORAGE_KEY,
+        JSON.stringify({
+            user_id: userId,
+            session_id: String(sessionId),
+            interview_type: INTERVIEW_TYPES.REAL,
+            question_type: resolvedQuestionType,
+            current_question: {
+                question: questionText,
+                turn_type: turnType,
+                turn_order: turnOrder,
+                topic_id: sessionData?.topic_id ?? sessionData?.topicId ?? null,
+                category: sessionData?.category ?? '',
+            },
+            interview_history: [],
+            expires_at: sessionData?.expires_at ?? sessionData?.expiresAt ?? null,
+            created_at: new Date().toISOString(),
+        })
+    );
+};
 
 const RealInterview = () => {
     const navigate = useNavigate();
+    const { accessToken } = useAuth();
+    const [isCreatingSession, setIsCreatingSession] = useState(false);
 
     const handleComingSoon = (title) => {
         toast.info(`${title} 서비스는 현재 준비 중입니다.`, {
@@ -15,24 +108,58 @@ const RealInterview = () => {
         });
     };
 
+    const handleStartRealInterview = async (questionType) => {
+        if (isCreatingSession) return;
+
+        setIsCreatingSession(true);
+        try {
+            const sessionResponse = await createInterviewSession({
+                interviewType: INTERVIEW_TYPES.REAL,
+                questionType,
+            });
+
+            const sessionData = sessionResponse?.data ?? {};
+            const sessionId = sessionData?.session_id ?? sessionData?.sessionId;
+            if (!sessionId) {
+                throw new Error(TEXT_SESSION_CREATE_FAILED);
+            }
+
+            const userId = resolveUserIdFromAccessToken(accessToken);
+            saveRealInterviewSession({
+                userId,
+                questionType,
+                sessionData,
+            });
+
+            navigate('/real-interview/session');
+        } catch (error) {
+            toast.error(error?.message || TEXT_SESSION_CREATE_FAILED);
+        } finally {
+            setIsCreatingSession(false);
+        }
+    };
+
     const menuItems = [
         {
             title: 'CS 기초',
             description: '운영체제, 네트워크, 데이터베이스 등 핵심 전공 지식',
+            questionType: QUESTION_TYPES.CS,
             gradient: 'from-pink-500 to-rose-500',
-            onClick: () => navigate('/real-interview/session'),
+            onClick: () => handleStartRealInterview(QUESTION_TYPES.CS),
         },
         {
             title: '시스템 디자인',
             description: '대규모 아키텍처 및 분산 시스템 설계 연습',
+            questionType: QUESTION_TYPES.SYSTEM_DESIGN,
             gradient: 'from-rose-500 to-pink-600',
-            onClick: () => navigate('/real-interview/session'),
+            onClick: () => handleStartRealInterview(QUESTION_TYPES.SYSTEM_DESIGN),
         },
         ...(SHOW_PORTFOLIO_INTERVIEW
             ? [
                 {
                     title: '개별 포트폴리오',
                     description: '내 프로젝트 기반의 1:1 맞춤형 기술 면접',
+                    questionType: QUESTION_TYPES.PORTFOLIO,
                     gradient: 'from-pink-600 to-rose-600',
                     onClick: () => handleComingSoon('개별 포트폴리오'),
                 },
@@ -41,34 +168,47 @@ const RealInterview = () => {
     ];
 
     return (
-        <div className="flex flex-col h-screen bg-background overflow-hidden max-w-lg mx-auto border-x border-transparent">
+        <div className="relative flex flex-col h-screen bg-background overflow-hidden max-w-lg mx-auto border-x border-transparent">
             <AppHeader title="실전 면접" onBack={() => navigate('/')} />
 
             <div className="flex-1 flex flex-col p-4 gap-4 pb-24 min-h-0">
-                {menuItems.map((item, index) => (
-                    <button
-                        key={index}
-                        onClick={item.onClick}
-                        className={`flex-1 relative overflow-hidden rounded-2xl p-5 flex flex-col justify-center text-left text-white transition-all active:scale-[0.98] bg-gradient-to-br ${item.gradient} shadow-lg shadow-pink-200/50 min-h-[100px]`}
-                    >
-                        <div className="relative z-10">
-                            <h2 className="text-xl font-bold mb-1">{item.title}</h2>
-                            <p className="text-white/80 text-xs leading-relaxed max-w-[200px]">
-                                {item.description}
-                            </p>
-                        </div>
-
-                        <div className="absolute -right-8 -bottom-8 w-24 h-24 bg-white/10 rounded-full blur-2xl" />
-                        {item.title === '개별 포트폴리오' && (
-                            <div className="absolute top-2 right-4 text-[10px] font-medium bg-white/20 px-2 py-0.5 rounded-full backdrop-blur-sm">
-                                Coming Soon
+                {menuItems.map((item, index) => {
+                    return (
+                        <button
+                            key={index}
+                            onClick={item.onClick}
+                            disabled={isCreatingSession}
+                            className={`flex-1 relative overflow-hidden rounded-2xl p-5 flex flex-col justify-center text-left text-white transition-all active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed bg-gradient-to-br ${item.gradient} shadow-lg shadow-pink-200/50 min-h-[100px]`}
+                        >
+                            <div className="relative z-10">
+                                <h2 className="text-xl font-bold mb-1">{item.title}</h2>
+                                <p className="text-white/80 text-xs leading-relaxed max-w-[200px]">
+                                    {item.description}
+                                </p>
                             </div>
-                        )}
-                    </button>
-                ))}
+
+                            <div className="absolute -right-8 -bottom-8 w-24 h-24 bg-white/10 rounded-full blur-2xl" />
+
+                            {item.title === '개별 포트폴리오' && (
+                                <div className="absolute top-2 right-4 text-[10px] font-medium bg-white/20 px-2 py-0.5 rounded-full backdrop-blur-sm">
+                                    Coming Soon
+                                </div>
+                            )}
+                        </button>
+                    );
+                })}
             </div>
 
             <BottomNav />
+
+            {isCreatingSession && (
+                <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-[4px] flex items-center justify-center">
+                    <div className="inline-flex items-center gap-2.5 rounded-full bg-black/45 px-4 py-2.5 text-sm font-medium text-white">
+                        <Loader2 size={18} className="animate-spin" />
+                        <span>{TEXT_SESSION_CREATING}</span>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/context/practiceQuestionContext.jsx
+++ b/src/context/practiceQuestionContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { SESSION_STORAGE_KEYS } from '@/app/constants/storageKeys';
 
-const STORAGE_KEY = 'qfeed_selected_practice_question';
+const STORAGE_KEY = SESSION_STORAGE_KEYS.SELECTED_PRACTICE_QUESTION;
 
 const PracticeQuestionContext = createContext(null);
 


### PR DESCRIPTION
  ## 오약
  실전면접(Real Interview) 흐름을 백엔드 API와 본격 연동하고, 연습모드 피드백 처리 플로우를 세션/스토리지 기반 비동기로 정리했습니다.
  또한 TTS모듈 추가, 공통 taxonomy/storage key 정리, UI/UX 보완을 포함합니다.

  ## 주요 변경사항

  ### 1) 실전면접 API/상태 관리 연동
  - `src/api/interviewApi.js` 신규
    - 세션 생성/조회
    - 실전 답변 제출
    - 최종 피드백 요청/조회
  - `src/app/pages/RealInterview.jsx`
    - 카드 클릭 시 실전 세션 생성 요청
    - 세션 정보를 `sessionStorage`에 저장
    - 세션 생성 중 전체 화면 스피너/블러 오버레이 표시
  - `src/app/pages/RealInterviewSession.jsx`
    - 저장된 세션 기준 초기화 + 질문 로딩
    - 누적 `interview_history` 기반 답변 제출
    - `turn_type` 매핑 처리(`main -> new_topic`)
    - `turn_order` 순차 증가 보장(누적 배열 기준)
    - `session_end`/`is_final` 처리 후 `AI 분석하기` 전환
    - 시작 게이트(모달) + 카메라/마이크 권한 확인/요청
    - 질문 내역 UI 개선(상단 토글/세로 스크롤 패널)

  ### 2) TTS/STT 모듈 추가 및 재생 훅 분리
  - `src/api/ttsApi.js` 신규
    - `multipart/mixed` 응답 파싱(JSON + mp3)
  - `src/app/hooks/useQuestionTtsPlayer.js` 신규
    - 질문 TTS 재생/중지/자동재생 제어
    - 임의 텍스트 재생(`playText`) 지원
  - `src/api/sttApi.js`
    - `session_id`를 문자열로 직렬화해 전송하도록 보정
  - `src/app/pages/PracticeSTT.jsx`
    - STT 호출 시 `sessionId` 문자열 전달

  ### 3) 실전면접 bad_case 처리
  - `bad_case_detected` 응답 감지 시:
    - `bad_case_feedback.message`를 TTS로 재생
    - 재녹화 유도(READY 상태 복귀)
    - 재제출 시 `turn_order` 증가 반영
  - bad case 메시지는 하드코딩하지 않고 서버 응답값 우선 사용

  ### 4) 연습모드 제출/결과 플로우 개선
  - `src/app/hooks/usePracticeAnswerSubmit.js`
    - 답변 제출 시 세션 생성 + 피드백 요청 백그라운드 처리
    - 상태를 sessionStorage에 저장하고 이벤트로 결과 화면에 전달
    - 너무 짧은 답변 방어(최소 길이)
  - `src/app/pages/PracticeResultKeyword.jsx`
    - 스토리지 상태(`pending/done/error`) 구독 기반 분석 대기/완료 처리
  - `src/app/pages/PracticeResultAI.jsx`
    - bad case/실패 응답 대응 렌더링 강화
  - `src/app/pages/PracticeAnswerText.jsx`
  - `src/app/pages/PracticeAnswerEdit.jsx`
  - `src/app/pages/PracticeAnswerVoice.jsx`
    - 재시도 시 기존 답변 프리필 처리

  ### 5) 공통 상수/호환성 정리
  - `src/app/constants/interviewTaxonomy.js` 신규
  - `src/app/constants/storageKeys.js` 신규
  - `src/app/constants/questionCategoryMeta.js` 리팩터링(공통 taxonomy 사용)
  - `src/context/practiceQuestionContext.jsx` 저장 키 상수 사용
  - `src/api/answerApi.js` 피드백 API 경로 수정
  - `src/app/pages/ProfileMain.jsx` 인터뷰 타입 라벨 공통화
  - `.env.development`에서 `VITE_SHOW_REAL_INTERVIEW=true` 활성화

  ## 변경 파일
  총 20개 파일
  (신규: `interviewApi.js`, `ttsApi.js`, `interviewTaxonomy.js`, `storageKeys.js`, `useQuestionTtsPlayer.js` 포함)

  ## 확인 포인트
  - 실전면접 세션 생성 → 질문 노출/재생 → 답변 제출 → 다음 질문 전환
  - `interview_history`의 `turn_order` 순차 증가 여부
  - bad case 응답 시 재녹화 유도 + bad_case 메시지 TTS 재생
  - session_end 시 `AI 분석하기` 버튼 전환
  - 연습모드 답변 제출 후 결과 페이지 분석 대기/완료 전이 정상 동작
  - STT 요청 시 `session_id` string 전송 확인