### PR TITLE
feat:[#164]실전/연습 인터뷰 세션 플로우 재구성 및 실전 결과 조회 경로 확장

### DIFF
--- a/src/api/answerApi.js
+++ b/src/api/answerApi.js
@@ -45,21 +45,14 @@ export async function fetchAnswers({
  * 답변 상세 조회 API
  * @param {number|string} answerId - 답변 ID
  * @param {Object} [params]
- * @param {string|string[]} [params.expand] - 확장 필드
  * @param {AbortSignal} [params.signal] - AbortController signal
  * @returns {Promise<Object>} 답변 상세 정보
  */
 export async function fetchAnswerDetail(
   answerId,
-  { expand = ['question', 'feedback', 'immediate_feedback'], signal } = {}
+  { signal } = {}
 ) {
-  const queryParams = new URLSearchParams()
-  const expandValue = Array.isArray(expand) ? expand.join(',') : expand
-
-  if (expandValue) queryParams.append('expand', expandValue)
-
-  const queryString = queryParams.toString()
-  const url = `/api/answers/${answerId}${queryString ? `?${queryString}` : ''}`
+  const url = `/api/answers/${answerId}`
 
   const response = await api.get(url, { signal })
   return handleResponse(response)

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -21,6 +21,7 @@ import PracticeResultKeyword from '@/app/pages/PracticeResultKeyword';
 import PracticeResultAI from '@/app/pages/PracticeResultAI';
 import ProfileMain from '@/app/pages/ProfileMain';
 import LearningRecordDetail from '@/app/pages/LearningRecordDetail';
+import RealLearningRecordDetail from '@/app/pages/RealLearningRecordDetail';
 import SettingMain from '@/app/pages/SettingMain';
 import RealInterview from '@/app/pages/RealInterview';
 import RealInterviewSession from '@/app/pages/RealInterviewSession';
@@ -83,6 +84,7 @@ function AppRoutes() {
 
                         {/* Profile */}
                         <Route path="/profile" element={<ProfileMain />} />
+                        <Route path="/profile/records/real/:answerId" element={<RealLearningRecordDetail />} />
                         <Route path="/profile/records/:answerId" element={<LearningRecordDetail />} />
                         <Route path="/settings" element={<SettingMain />} />
 

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -24,6 +24,7 @@ import LearningRecordDetail from '@/app/pages/LearningRecordDetail';
 import SettingMain from '@/app/pages/SettingMain';
 import RealInterview from '@/app/pages/RealInterview';
 import RealInterviewSession from '@/app/pages/RealInterviewSession';
+import RealInterviewResultAI from '@/app/pages/RealInterviewResultAI';
 import OAuthCallback from '@/app/pages/OAuthCallback';
 
 const SPLASH_SHOWN_KEY = 'qfeed_splash_shown';
@@ -76,6 +77,7 @@ function AppRoutes() {
                             <>
                                 <Route path="/real-interview" element={<RealInterview />} />
                                 <Route path="/real-interview/session" element={<RealInterviewSession />} />
+                                <Route path="/real-interview/result-ai" element={<RealInterviewResultAI />} />
                             </>
                         )}
 

--- a/src/app/hooks/useAnswerDetail.js
+++ b/src/app/hooks/useAnswerDetail.js
@@ -4,10 +4,7 @@ import { fetchAnswerDetail } from '@/api/answerApi'
 export function useAnswerDetail(answerId) {
   return useQuery({
     queryKey: ['answerDetail', answerId],
-    queryFn: () =>
-      fetchAnswerDetail(answerId, {
-        expand: ['question', 'feedback', 'immediate_feedback'],
-      }),
+    queryFn: () => fetchAnswerDetail(answerId),
     enabled: Boolean(answerId),
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/src/app/hooks/useAudioSttPipeline.js
+++ b/src/app/hooks/useAudioSttPipeline.js
@@ -1,0 +1,183 @@
+import { useCallback, useState } from 'react';
+import { getPresignedUrl, uploadToS3, confirmFileUpload } from '@/api/fileApi';
+import { requestSTT } from '@/api/sttApi';
+
+const STT_PIPELINE_STAGE = {
+  IDLE: 'idle',
+  UPLOADING: 'uploading',
+  STT: 'stt',
+  SUCCESS: 'success',
+  ERROR: 'error',
+};
+
+const UPLOAD_FAILED_MESSAGE = '업로드에 실패했습니다';
+const STT_FAILED_MESSAGE = '음성 변환에 실패했습니다';
+
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed || '';
+};
+
+const toError = (error, fallbackMessage) => {
+  if (error instanceof Error) return error;
+  return new Error(error?.message || fallbackMessage);
+};
+
+const resolveAudioMeta = (rawType = '') => {
+  const normalized = toTrimmedString(rawType).toLowerCase();
+
+  if (normalized.includes('wav')) {
+    return { extension: 'wav', mimeType: 'audio/wav' };
+  }
+  if (normalized.includes('mp4') || normalized.includes('m4a') || normalized.includes('aac')) {
+    return { extension: 'm4a', mimeType: 'audio/mp4' };
+  }
+  if (normalized.includes('mpeg') || normalized.includes('mp3')) {
+    return { extension: 'mp3', mimeType: 'audio/mpeg' };
+  }
+  if (normalized.includes('ogg')) {
+    return { extension: 'ogg', mimeType: 'audio/ogg' };
+  }
+  if (normalized.includes('webm')) {
+    return { extension: 'webm', mimeType: 'audio/webm' };
+  }
+
+  return { extension: 'webm', mimeType: 'audio/webm' };
+};
+
+export function useAudioSttPipeline(options = {}) {
+  const { category = 'AUDIO' } = options;
+  const [stage, setStage] = useState(STT_PIPELINE_STAGE.IDLE);
+  const [error, setError] = useState(null);
+
+  const reset = useCallback(() => {
+    setStage(STT_PIPELINE_STAGE.IDLE);
+    setError(null);
+  }, []);
+
+  const uploadAudioBlob = useCallback(async ({ audioBlob, fileNamePrefix = 'voice' }) => {
+    if (!audioBlob || typeof audioBlob.size !== 'number' || audioBlob.size <= 0) {
+      const invalidAudioError = new Error('녹음된 음성이 없습니다.');
+      setError(invalidAudioError);
+      setStage(STT_PIPELINE_STAGE.ERROR);
+      throw invalidAudioError;
+    }
+
+    const { extension, mimeType } = resolveAudioMeta(audioBlob.type);
+
+    setError(null);
+    setStage(STT_PIPELINE_STAGE.UPLOADING);
+
+    try {
+      const uploadBlob = audioBlob.type === mimeType
+        ? audioBlob
+        : new Blob([audioBlob], { type: mimeType });
+
+      const presignedResult = await getPresignedUrl({
+        fileName: `${fileNamePrefix}_${Date.now()}.${extension}`,
+        fileSize: uploadBlob.size,
+        mimeType,
+        category,
+      });
+      const presignedPayload = presignedResult?.data ?? {};
+      const fileId = presignedPayload.fileId ?? presignedPayload.file_id;
+      const presignedUrl = presignedPayload.presignedUrl ?? presignedPayload.presigned_url;
+
+      if (!fileId || !presignedUrl) {
+        throw new Error('업로드 URL을 받지 못했습니다.');
+      }
+
+      await uploadToS3(presignedUrl, uploadBlob, mimeType);
+      const confirmResult = await confirmFileUpload(fileId);
+      const confirmPayload = confirmResult?.data ?? {};
+      const audioUrl = confirmPayload.fileUrl ?? confirmPayload.file_url;
+
+      if (!audioUrl) {
+        throw new Error('업로드 확인 URL을 받지 못했습니다.');
+      }
+
+      setStage(STT_PIPELINE_STAGE.SUCCESS);
+      return {
+        audioUrl,
+        fileId,
+        mimeType,
+        extension,
+      };
+    } catch (uploadError) {
+      const normalizedError = toError(uploadError, UPLOAD_FAILED_MESSAGE);
+      setError(normalizedError);
+      setStage(STT_PIPELINE_STAGE.ERROR);
+      throw normalizedError;
+    }
+  }, [category]);
+
+  const transcribeAudioUrl = useCallback(async ({ userId, sessionId, audioUrl }) => {
+    const normalizedAudioUrl = toTrimmedString(audioUrl);
+    if (!normalizedAudioUrl) {
+      const missingAudioUrlError = new Error('음성 파일 URL이 없습니다.');
+      setError(missingAudioUrlError);
+      setStage(STT_PIPELINE_STAGE.ERROR);
+      throw missingAudioUrlError;
+    }
+
+    setError(null);
+    setStage(STT_PIPELINE_STAGE.STT);
+
+    try {
+      const sttResult = await requestSTT({
+        userId,
+        sessionId,
+        audioUrl: normalizedAudioUrl,
+      });
+
+      const sttPayload = sttResult?.data ?? sttResult ?? {};
+      const text = toTrimmedString(
+        sttPayload.text ?? sttPayload.answer_text ?? sttPayload.transcript
+      );
+
+      setStage(STT_PIPELINE_STAGE.SUCCESS);
+      return {
+        text,
+        raw: sttResult,
+      };
+    } catch (sttError) {
+      const normalizedError = toError(sttError, STT_FAILED_MESSAGE);
+      setError(normalizedError);
+      setStage(STT_PIPELINE_STAGE.ERROR);
+      throw normalizedError;
+    }
+  }, []);
+
+  const uploadAndTranscribe = useCallback(async ({
+    audioBlob,
+    userId,
+    sessionId,
+    fileNamePrefix = 'voice',
+  }) => {
+    const uploadResult = await uploadAudioBlob({
+      audioBlob,
+      fileNamePrefix,
+    });
+    const transcribeResult = await transcribeAudioUrl({
+      userId,
+      sessionId,
+      audioUrl: uploadResult.audioUrl,
+    });
+
+    return {
+      ...uploadResult,
+      ...transcribeResult,
+    };
+  }, [transcribeAudioUrl, uploadAudioBlob]);
+
+  return {
+    stage,
+    error,
+    reset,
+    uploadAudioBlob,
+    transcribeAudioUrl,
+    uploadAndTranscribe,
+    STT_PIPELINE_STAGE,
+  };
+}

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -100,7 +100,7 @@ const PracticeAnswerVoice = () => {
       try {
         const { audioUrl } = await uploadAudioBlob({
           audioBlob,
-          fileNamePrefix: `voice_${questionId}`,
+          mode: 'PRACTICE',
         });
 
         // 4. STT 페이지로 이동 (S3 URL과 questionId 전달)

--- a/src/app/pages/PracticeSTT.jsx
+++ b/src/app/pages/PracticeSTT.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { motion as Motion } from 'motion/react';
 import { Loader2 } from 'lucide-react';
-import { requestSTT } from '@/api/sttApi';
+import { useAudioSttPipeline } from '@/app/hooks/useAudioSttPipeline';
 import { toast } from 'sonner';
 
 // TODO: 인증 연동 후 실제 사용자 ID로 교체
@@ -15,6 +15,7 @@ const PracticeSTT = () => {
     const audioUrl = state?.audioUrl;
 
     const [statusMessage, setStatusMessage] = useState('음성을 분석하고 있어요');
+    const { transcribeAudioUrl } = useAudioSttPipeline();
 
     useEffect(() => {
         if (!audioUrl) {
@@ -32,12 +33,12 @@ const PracticeSTT = () => {
                     throw new Error('세션 정보를 확인할 수 없습니다');
                 }
                 // 백엔드 스키마(user_id, session_id, audio_url)에 맞춰 전달 (session_id string)
-                const result = await requestSTT({
+                const result = await transcribeAudioUrl({
                     userId: DEFAULT_USER_ID,
                     sessionId,
                     audioUrl,
                 });
-                const { text } = result.data;
+                const text = result?.text || '';
 
                 navigate(`/practice/answer-edit/${questionId}`, {
                     state: { transcribedText: text },
@@ -49,7 +50,7 @@ const PracticeSTT = () => {
         };
 
         processSTT();
-    }, [audioUrl, questionId, navigate]);
+    }, [audioUrl, navigate, questionId, transcribeAudioUrl]);
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-rose-50/80 via-white to-pink-50/80 flex flex-col items-center justify-center p-6">

--- a/src/app/pages/RealInterviewResultAI.jsx
+++ b/src/app/pages/RealInterviewResultAI.jsx
@@ -1,0 +1,329 @@
+import { useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '@/app/components/ui/button';
+import { Card } from '@/app/components/ui/card';
+import { Badge } from '@/app/components/ui/badge';
+import { AlertCircle, Home, ListChecks, Target, ThumbsUp } from 'lucide-react';
+import { AppHeader } from '@/app/components/AppHeader';
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from 'recharts';
+import { SESSION_STORAGE_KEYS } from '@/app/constants/storageKeys';
+
+const TEXT_PAGE_TITLE = '실전 면접 AI 피드백';
+const TEXT_COMPLETE_TITLE = '분석 완료!';
+const TEXT_COMPLETE_DESC = '실전 면접 답변을 분석했어요';
+const TEXT_HOME_BUTTON = '홈으로 이동';
+const TEXT_METRICS_TITLE = '종합 역량 점수';
+const TEXT_STRENGTHS_TITLE = '전체 강점';
+const TEXT_IMPROVEMENTS_TITLE = '전체 개선점';
+const TEXT_TOPIC_FEEDBACK_TITLE = '주제별 피드백';
+const TEXT_TOPIC_LABEL = '주제';
+const TEXT_MAIN_QUESTION = '메인 질문';
+const TEXT_TOPIC_STRENGTHS = '좋았던 점';
+const TEXT_TOPIC_IMPROVEMENTS = '개선 포인트';
+const TEXT_FEEDBACK_EMPTY = '피드백 정보가 없습니다.';
+const TEXT_MISSING_RESULT = '분석 결과 정보를 찾을 수 없습니다.';
+const TEXT_COVERAGE = '키워드 커버리지';
+const TEXT_COVERED = '반영된 키워드';
+const TEXT_MISSING = '누락 키워드';
+const TEXT_NONE = '없음';
+const TEXT_RADAR_LABEL = '평가';
+const TEXT_QUESTION_COUNT_SUFFIX = '개 질문 분석';
+
+const FEEDBACK_SPLIT_DELIMITER = '●';
+const FEEDBACK_BULLET = '•';
+const FEEDBACK_DASH = '-';
+const METRIC_SCORE_MAX = 5;
+const RADAR_DOMAIN_MAX = 100;
+const REAL_SESSION_STORAGE_KEY = SESSION_STORAGE_KEYS.REAL_INTERVIEW_SESSION;
+
+const safeRemoveRealSession = () => {
+  try {
+    sessionStorage.removeItem(REAL_SESSION_STORAGE_KEY);
+  } catch {
+    // sessionStorage 사용 불가 환경에서는 무시
+  }
+};
+
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed || '';
+};
+
+const normalizeScore = (score) => {
+  if (typeof score !== 'number' || Number.isNaN(score)) return 0;
+  const clamped = Math.max(0, Math.min(METRIC_SCORE_MAX, score));
+  return Math.round((clamped / METRIC_SCORE_MAX) * RADAR_DOMAIN_MAX);
+};
+
+const splitFeedbackText = (text) => {
+  if (typeof text !== 'string') return [];
+  const normalized = text.replace(/\n+/g, '\n').trim();
+  if (!normalized) return [];
+  return normalized
+    .split(FEEDBACK_SPLIT_DELIMITER)
+    .map((line) => line.trim())
+    .filter(Boolean);
+};
+
+const renderFeedbackText = (text, className) => {
+  const lines = splitFeedbackText(text);
+
+  if (lines.length === 0) {
+    return <p className={className}>{TEXT_FEEDBACK_EMPTY}</p>;
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {lines.map((line, idx) => {
+        const content = line.startsWith(FEEDBACK_DASH)
+          ? line.slice(1).trim()
+          : line;
+
+        return (
+          <p key={idx} className="leading-relaxed pl-5 relative">
+            <span className="absolute left-0">{FEEDBACK_BULLET}</span>
+            {content}
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+const normalizeKeywordItems = (value) => {
+  return Array.isArray(value)
+    ? value.map((item) => toTrimmedString(item)).filter(Boolean)
+    : [];
+};
+
+const toCoveragePercent = (coverageRatio) => {
+  if (typeof coverageRatio !== 'number' || Number.isNaN(coverageRatio)) return null;
+  const normalized = Math.max(0, Math.min(1, coverageRatio));
+  return Math.round(normalized * 100);
+};
+
+const RealInterviewResultAI = () => {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+
+  const feedbackResponse = state?.feedbackResponse;
+  const feedbackData = useMemo(
+    () => (feedbackResponse?.data ?? feedbackResponse ?? null),
+    [feedbackResponse]
+  );
+  const interviewEntries = Array.isArray(state?.interviewEntries)
+    ? state.interviewEntries
+    : [];
+
+  const metrics = useMemo(() => {
+    return Array.isArray(feedbackData?.metrics)
+      ? feedbackData.metrics.filter((metric) => metric && typeof metric === 'object')
+      : [];
+  }, [feedbackData]);
+
+  const radarData = useMemo(() => {
+    return metrics.map((metric, idx) => ({
+      subject: metric?.name || `${TEXT_METRICS_TITLE} ${idx + 1}`,
+      value: normalizeScore(metric?.score),
+    }));
+  }, [metrics]);
+
+  const overallFeedback = feedbackData?.overall_feedback ?? {};
+  const topicsFeedback = useMemo(() => {
+    return Array.isArray(feedbackData?.topics_feedback)
+      ? feedbackData.topics_feedback.filter((item) => item && typeof item === 'object')
+      : [];
+  }, [feedbackData]);
+
+  const keywordResult = useMemo(() => {
+    const rawKeywordResult = feedbackData?.keyword_result;
+    if (rawKeywordResult && typeof rawKeywordResult === 'object') {
+      return rawKeywordResult;
+    }
+    return null;
+  }, [feedbackData]);
+  const coveredKeywords = useMemo(
+    () => normalizeKeywordItems(keywordResult?.covered_keywords),
+    [keywordResult]
+  );
+  const missingKeywords = useMemo(
+    () => normalizeKeywordItems(keywordResult?.missing_keywords),
+    [keywordResult]
+  );
+  const coveragePercent = useMemo(
+    () => toCoveragePercent(keywordResult?.coverage_ratio),
+    [keywordResult]
+  );
+  const hasResult = Boolean(feedbackData);
+  const hasRadarData = radarData.length > 0;
+  const hasKeywordSummary = coveredKeywords.length > 0 || missingKeywords.length > 0;
+
+  useEffect(() => {
+    safeRemoveRealSession();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader
+        title={TEXT_PAGE_TITLE}
+        onBack={() => navigate('/real-interview')}
+        showNotifications={false}
+        tone="light"
+      />
+
+      <div
+        className="text-center pb-6 px-6 pt-2"
+        style={{
+          background:
+            'linear-gradient(165deg, var(--primary-50) 0%, var(--primary-100) 50%, var(--primary-50) 100%)',
+        }}
+      >
+        <div className="mb-2 flex justify-center">
+          <Target className="w-14 h-14 text-primary-500" />
+        </div>
+        <h2 className="text-2xl mb-1 font-semibold text-[var(--gray-900)]">{TEXT_COMPLETE_TITLE}</h2>
+        <p className="text-[var(--gray-600)] text-sm">{TEXT_COMPLETE_DESC}</p>
+        <div className="mt-3 flex items-center justify-center gap-2">
+          <Badge variant="outline" className="border-pink-200 text-pink-700 bg-white/80">
+            {interviewEntries.length}
+            {TEXT_QUESTION_COUNT_SUFFIX}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
+        {!hasResult && (
+          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+            <p className="text-sm text-rose-800">{TEXT_MISSING_RESULT}</p>
+          </Card>
+        )}
+
+        {hasResult && (
+          <Card className="p-6 bg-white shadow-lg">
+            <h3 className="text-base mb-3">{TEXT_METRICS_TITLE}</h3>
+            {hasRadarData ? (
+              <ResponsiveContainer width="100%" height={250}>
+                <RadarChart data={radarData}>
+                  <PolarGrid />
+                  <PolarAngleAxis dataKey="subject" />
+                  <PolarRadiusAxis angle={90} domain={[0, RADAR_DOMAIN_MAX]} tick={false} axisLine={false} />
+                  <Radar
+                    name={TEXT_RADAR_LABEL}
+                    dataKey="value"
+                    stroke="#ec4899"
+                    fill="#ec4899"
+                    fillOpacity={0.6}
+                  />
+                </RadarChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-sm text-muted-foreground">{TEXT_FEEDBACK_EMPTY}</p>
+            )}
+          </Card>
+        )}
+
+        {hasResult && hasKeywordSummary && (
+          <Card className="p-5 bg-white shadow-sm space-y-3">
+            <h3>{TEXT_COVERAGE}</h3>
+            <p className="text-sm text-gray-700">
+              {coveragePercent === null ? TEXT_FEEDBACK_EMPTY : `${coveragePercent}%`}
+            </p>
+            <div className="space-y-2">
+              <div>
+                <p className="text-xs text-emerald-700 mb-1">{TEXT_COVERED}</p>
+                <p className="text-sm text-gray-700">
+                  {coveredKeywords.length > 0 ? coveredKeywords.join(', ') : TEXT_NONE}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-rose-700 mb-1">{TEXT_MISSING}</p>
+                <p className="text-sm text-gray-700">
+                  {missingKeywords.length > 0 ? missingKeywords.join(', ') : TEXT_NONE}
+                </p>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {topicsFeedback.length > 0 && (
+          <Card className="p-5 bg-white shadow-sm space-y-3">
+            <div className="flex items-center gap-2">
+              <ListChecks className="w-5 h-5 text-pink-600" />
+              <h3>{TEXT_TOPIC_FEEDBACK_TITLE}</h3>
+            </div>
+            <div className="space-y-3">
+              {topicsFeedback.map((topic, idx) => (
+                <div
+                  key={`${topic?.topic_id ?? 'topic'}-${idx}`}
+                  className="rounded-xl border border-rose-100 bg-rose-50/60 p-4 space-y-3"
+                >
+                  <p className="text-sm text-rose-700 font-semibold">
+                    {TEXT_TOPIC_LABEL} {topic?.topic_id ?? idx + 1}
+                  </p>
+                  <p className="text-[15px] leading-relaxed text-gray-900">
+                    <span className="font-semibold">{TEXT_MAIN_QUESTION}: </span>
+                    {toTrimmedString(topic?.main_question) || TEXT_FEEDBACK_EMPTY}
+                  </p>
+                  <div>
+                    <p className="text-sm font-semibold text-emerald-700 mb-1.5">{TEXT_TOPIC_STRENGTHS}</p>
+                    {renderFeedbackText(topic?.strengths, 'text-sm text-gray-700')}
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-pink-700 mb-1.5">{TEXT_TOPIC_IMPROVEMENTS}</p>
+                    {renderFeedbackText(topic?.improvements, 'text-sm text-gray-700')}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        {hasResult && (
+          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+                <ThumbsUp className="w-5 h-5 text-pink-600" />
+              </div>
+              <div className="flex-1">
+                <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
+                {renderFeedbackText(overallFeedback?.strengths, 'text-sm text-rose-800')}
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {hasResult && (
+          <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-5 h-5 text-pink-600" />
+              </div>
+              <div className="flex-1">
+                <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+                {renderFeedbackText(overallFeedback?.improvements, 'text-sm text-pink-800')}
+              </div>
+            </div>
+          </Card>
+        )}
+
+        <Button
+          onClick={() => navigate('/')}
+          className="w-full rounded-md h-12 gap-2"
+        >
+          <Home className="w-5 h-5" />
+          {TEXT_HOME_BUTTON}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default RealInterviewResultAI;

--- a/src/app/pages/RealInterviewSession.jsx
+++ b/src/app/pages/RealInterviewSession.jsx
@@ -1024,7 +1024,7 @@ const RealInterviewSession = () => {
             setPhase(PHASE.UPLOADING);
             const uploadResult = await uploadAudioBlob({
                 audioBlob,
-                fileNamePrefix: `real_answer_${realSessionId}`,
+                mode: 'REAL',
             });
 
             setPhase(PHASE.STT);

--- a/src/app/pages/RealInterviewSession.jsx
+++ b/src/app/pages/RealInterviewSession.jsx
@@ -1337,14 +1337,20 @@ const RealInterviewSession = () => {
         setAnalysisNotice('');
 
         try {
-            await requestInterviewSessionFeedback({ sessionId: realSessionId });
+            const feedbackResponse = await requestInterviewSessionFeedback({ sessionId: realSessionId });
             setAnalysisState('success');
             setAnalysisNotice(COPY.analysisRequestAccepted);
+            navigate('/real-interview/result-ai', {
+                state: {
+                    feedbackResponse,
+                    interviewEntries,
+                },
+            });
         } catch (error) {
             setAnalysisState('error');
             setAnalysisNotice(error?.message || COPY.analysisRequestRetry);
         }
-    }, [analysisState, interviewEntries.length, realSessionId]);
+    }, [analysisState, interviewEntries, navigate, realSessionId]);
 
     const processingLabel = useMemo(() => {
         if (phase === PHASE.UPLOADING || phase === PHASE.STT) {

--- a/src/app/pages/RealLearningRecordDetail.jsx
+++ b/src/app/pages/RealLearningRecordDetail.jsx
@@ -1,0 +1,404 @@
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AppHeader } from '@/app/components/AppHeader';
+import { Card } from '@/app/components/ui/card';
+import { Button } from '@/app/components/ui/button';
+import { AlertCircle, Home, ListChecks, Loader2, Sparkles, ThumbsUp } from 'lucide-react';
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from 'recharts';
+import { useAnswerDetail } from '@/app/hooks/useAnswerDetail';
+
+const TEXT_PAGE_TITLE = '실전 학습 기록 상세';
+const TEXT_HEADER_DESC = '실전 면접 결과와 AI 피드백을 확인해보세요';
+const TEXT_LOADING = '실전 학습 기록을 불러오는 중...';
+const TEXT_NOT_FOUND = '실전 학습 기록을 찾을 수 없습니다';
+const TEXT_GO_PROFILE = '학습 기록으로 돌아가기';
+const TEXT_RETRY_HELP = '잠시 후 다시 시도해 주세요.';
+const TEXT_QUESTION_LABEL = '질문';
+const TEXT_MY_ANSWER_LABEL = '내 답변';
+const TEXT_METRICS_TITLE = '종합 역량 점수';
+const TEXT_STRENGTHS_TITLE = '전체 강점';
+const TEXT_IMPROVEMENTS_TITLE = '전체 개선점';
+const TEXT_TOPIC_FEEDBACK_TITLE = '주제별 피드백';
+const TEXT_TOPIC_LABEL = '주제';
+const TEXT_MAIN_QUESTION = '메인 질문';
+const TEXT_TOPIC_STRENGTHS = '좋았던 점';
+const TEXT_TOPIC_IMPROVEMENTS = '개선 포인트';
+const TEXT_COVERAGE = '키워드 커버리지';
+const TEXT_COVERED = '반영된 키워드';
+const TEXT_MISSING = '누락 키워드';
+const TEXT_NONE = '없음';
+const TEXT_FEEDBACK_EMPTY = '피드백 정보가 없습니다.';
+const TEXT_RADAR_LABEL = '평가';
+
+const FEEDBACK_SPLIT_DELIMITER = '●';
+const FEEDBACK_BULLET = '•';
+const FEEDBACK_DASH = '-';
+const METRIC_SCORE_MAX = 5;
+const RADAR_DOMAIN_MAX = 100;
+
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed || '';
+};
+
+const normalizeScore = (score) => {
+  if (typeof score !== 'number' || Number.isNaN(score)) return 0;
+  const clamped = Math.max(0, Math.min(METRIC_SCORE_MAX, score));
+  return Math.round((clamped / METRIC_SCORE_MAX) * RADAR_DOMAIN_MAX);
+};
+
+const splitFeedbackText = (text) => {
+  if (typeof text !== 'string') return [];
+  const normalized = text.replace(/\n+/g, '\n').trim();
+  if (!normalized) return [];
+  return normalized
+    .split(FEEDBACK_SPLIT_DELIMITER)
+    .map((line) => line.trim())
+    .filter(Boolean);
+};
+
+const renderFeedbackText = (text, className) => {
+  const lines = splitFeedbackText(text);
+
+  if (lines.length === 0) {
+    return <p className={className}>{TEXT_FEEDBACK_EMPTY}</p>;
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {lines.map((line, idx) => {
+        const content = line.startsWith(FEEDBACK_DASH)
+          ? line.slice(1).trim()
+          : line;
+
+        return (
+          <p key={idx} className="leading-relaxed pl-5 relative">
+            <span className="absolute left-0">{FEEDBACK_BULLET}</span>
+            {content}
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+const normalizeKeywordItems = (value) => {
+  return Array.isArray(value)
+    ? value.map((item) => toTrimmedString(item)).filter(Boolean)
+    : [];
+};
+
+const toCoveragePercent = (coverageRatio) => {
+  if (typeof coverageRatio !== 'number' || Number.isNaN(coverageRatio)) return null;
+  const normalized = Math.max(0, Math.min(1, coverageRatio));
+  return Math.round(normalized * 100);
+};
+
+const hasRealFeedbackShape = (candidate) => {
+  if (!candidate || typeof candidate !== 'object') return false;
+  return Boolean(
+    Array.isArray(candidate.metrics) ||
+      Array.isArray(candidate.topics_feedback) ||
+      candidate.overall_feedback ||
+      candidate.keyword_result ||
+      candidate.bad_case_feedback
+  );
+};
+
+const resolveRealFeedback = (detail) => {
+  const candidates = [
+    detail?.sessionFinalFeedback,
+    detail?.session_final_feedback,
+    detail?.final_feedback,
+    detail?.finalFeedback,
+    detail?.aiFeedback,
+    detail?.feedback,
+    detail?.immediateFeedback,
+    detail?.immediate_feedback,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    if (hasRealFeedbackShape(candidate)) return candidate;
+
+    const nestedData = candidate?.data;
+    if (hasRealFeedbackShape(nestedData)) return nestedData;
+
+    const nestedResponse = candidate?.response?.data;
+    if (hasRealFeedbackShape(nestedResponse)) return nestedResponse;
+  }
+
+  return null;
+};
+
+const RealLearningRecordDetail = () => {
+  const navigate = useNavigate();
+  const { answerId } = useParams();
+  const { data, isLoading, error } = useAnswerDetail(answerId);
+
+  const answerDetail = useMemo(() => {
+    const resolved = data?.data ?? data;
+    if (resolved && typeof resolved === 'object') {
+      return resolved;
+    }
+    return null;
+  }, [data]);
+  const hasAnswerDetail = Boolean(answerDetail?.answerId);
+  const feedbackData = useMemo(() => resolveRealFeedback(answerDetail), [answerDetail]);
+
+  const metrics = useMemo(() => {
+    return Array.isArray(feedbackData?.metrics)
+      ? feedbackData.metrics.filter((metric) => metric && typeof metric === 'object')
+      : [];
+  }, [feedbackData]);
+
+  const radarData = useMemo(() => {
+    return metrics.map((metric, idx) => ({
+      subject: metric?.name || `${TEXT_METRICS_TITLE} ${idx + 1}`,
+      value: normalizeScore(metric?.score),
+    }));
+  }, [metrics]);
+
+  const topicsFeedback = useMemo(() => {
+    return Array.isArray(feedbackData?.topics_feedback)
+      ? feedbackData.topics_feedback.filter((item) => item && typeof item === 'object')
+      : [];
+  }, [feedbackData]);
+
+  const overallFeedback = feedbackData?.overall_feedback ?? {};
+  const keywordResult = useMemo(() => {
+    const rawKeywordResult = feedbackData?.keyword_result;
+    if (rawKeywordResult && typeof rawKeywordResult === 'object') return rawKeywordResult;
+    return null;
+  }, [feedbackData]);
+
+  const coveredKeywords = useMemo(
+    () => normalizeKeywordItems(keywordResult?.covered_keywords),
+    [keywordResult]
+  );
+  const missingKeywords = useMemo(
+    () => normalizeKeywordItems(keywordResult?.missing_keywords),
+    [keywordResult]
+  );
+  const coveragePercent = useMemo(
+    () => toCoveragePercent(keywordResult?.coverage_ratio),
+    [keywordResult]
+  );
+  const hasKeywordSummary = coveredKeywords.length > 0 || missingKeywords.length > 0;
+  const hasRadarData = radarData.length > 0;
+
+  const questionText = toTrimmedString(
+    answerDetail?.question?.content ?? answerDetail?.question?.title
+  );
+  const answerText = toTrimmedString(answerDetail?.content ?? answerDetail?.answer_text);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <AppHeader title={TEXT_PAGE_TITLE} onBack={() => navigate('/profile')} showNotifications={false} />
+        <div className="p-6 max-w-lg mx-auto">
+          <Card className="p-6 flex items-center gap-3">
+            <Loader2 className="w-5 h-5 animate-spin text-pink-600" />
+            <p className="text-sm text-muted-foreground">{TEXT_LOADING}</p>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !hasAnswerDetail) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+          <AppHeader
+            title={TEXT_PAGE_TITLE}
+            onBack={() => navigate('/profile')}
+            showNotifications={false}
+            tone="dark"
+            className="!static"
+          />
+          <div className="text-center pb-6 pt-1 px-6">
+            <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+          </div>
+        </div>
+
+        <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
+          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-5 h-5 text-rose-600" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm text-rose-800">{error?.message || TEXT_NOT_FOUND}</p>
+                <p className="text-xs text-rose-700 mt-1">{TEXT_RETRY_HELP}</p>
+              </div>
+            </div>
+          </Card>
+
+          <Button
+            onClick={() => navigate('/profile')}
+            className="w-full rounded-xl h-12 gap-2"
+            variant="default"
+          >
+            <Home className="w-5 h-5" />
+            {TEXT_GO_PROFILE}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+        <AppHeader
+          title={TEXT_PAGE_TITLE}
+          onBack={() => navigate('/profile')}
+          showNotifications={false}
+          tone="dark"
+          className="!static"
+        />
+
+        <div className="text-center pb-6 pt-1 px-6">
+          <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+        </div>
+      </div>
+
+      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
+        {questionText && (
+          <Card className="p-5 bg-white shadow-sm">
+            <p className="text-sm text-muted-foreground mb-2">{TEXT_QUESTION_LABEL}</p>
+            <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{questionText}</p>
+          </Card>
+        )}
+
+        {answerText && (
+          <Card className="p-5">
+            <p className="text-sm text-muted-foreground mb-2">{TEXT_MY_ANSWER_LABEL}</p>
+            <div className="h-44 overflow-y-auto overscroll-contain pr-1">
+              <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{answerText}</p>
+            </div>
+          </Card>
+        )}
+
+        <Card className="p-5 bg-white shadow-lg">
+          <div className="flex items-center gap-2 mb-4">
+            <Sparkles className="w-5 h-5 text-pink-600" />
+            <h3>{TEXT_METRICS_TITLE}</h3>
+          </div>
+          {hasRadarData ? (
+            <ResponsiveContainer width="100%" height={250}>
+              <RadarChart data={radarData}>
+                <PolarGrid />
+                <PolarAngleAxis dataKey="subject" />
+                <PolarRadiusAxis angle={90} domain={[0, RADAR_DOMAIN_MAX]} tick={false} axisLine={false} />
+                <Radar name={TEXT_RADAR_LABEL} dataKey="value" stroke="#ec4899" fill="#ec4899" fillOpacity={0.6} />
+              </RadarChart>
+            </ResponsiveContainer>
+          ) : (
+            <p className="text-sm text-muted-foreground">{TEXT_FEEDBACK_EMPTY}</p>
+          )}
+        </Card>
+
+        {hasKeywordSummary && (
+          <Card className="p-5 bg-white shadow-sm space-y-3">
+            <h3>{TEXT_COVERAGE}</h3>
+            <p className="text-sm text-gray-700">
+              {coveragePercent === null ? TEXT_FEEDBACK_EMPTY : `${coveragePercent}%`}
+            </p>
+            <div className="space-y-2">
+              <div>
+                <p className="text-xs text-emerald-700 mb-1">{TEXT_COVERED}</p>
+                <p className="text-sm text-gray-700">
+                  {coveredKeywords.length > 0 ? coveredKeywords.join(', ') : TEXT_NONE}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-rose-700 mb-1">{TEXT_MISSING}</p>
+                <p className="text-sm text-gray-700">
+                  {missingKeywords.length > 0 ? missingKeywords.join(', ') : TEXT_NONE}
+                </p>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {topicsFeedback.length > 0 && (
+          <Card className="p-5 bg-white shadow-sm space-y-3">
+            <div className="flex items-center gap-2">
+              <ListChecks className="w-5 h-5 text-pink-600" />
+              <h3>{TEXT_TOPIC_FEEDBACK_TITLE}</h3>
+            </div>
+            <div className="space-y-3">
+              {topicsFeedback.map((topic, idx) => (
+                <div
+                  key={`${topic?.topic_id ?? 'topic'}-${idx}`}
+                  className="rounded-xl border border-rose-100 bg-rose-50/60 p-4 space-y-3"
+                >
+                  <p className="text-sm text-rose-700 font-semibold">
+                    {TEXT_TOPIC_LABEL} {topic?.topic_id ?? idx + 1}
+                  </p>
+                  <p className="text-[15px] leading-relaxed text-gray-900">
+                    <span className="font-semibold">{TEXT_MAIN_QUESTION}: </span>
+                    {toTrimmedString(topic?.main_question) || TEXT_FEEDBACK_EMPTY}
+                  </p>
+                  <div>
+                    <p className="text-sm font-semibold text-emerald-700 mb-1.5">{TEXT_TOPIC_STRENGTHS}</p>
+                    {renderFeedbackText(topic?.strengths, 'text-sm text-gray-700')}
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-pink-700 mb-1.5">{TEXT_TOPIC_IMPROVEMENTS}</p>
+                    {renderFeedbackText(topic?.improvements, 'text-sm text-gray-700')}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
+              <ThumbsUp className="w-5 h-5 text-pink-600" />
+            </div>
+            <div className="flex-1">
+              <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
+              {renderFeedbackText(overallFeedback?.strengths, 'text-sm text-rose-800')}
+            </div>
+          </div>
+        </Card>
+
+        <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
+              <AlertCircle className="w-5 h-5 text-pink-600" />
+            </div>
+            <div className="flex-1">
+              <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+              {renderFeedbackText(overallFeedback?.improvements, 'text-sm text-pink-800')}
+            </div>
+          </div>
+        </Card>
+
+        <Button
+          onClick={() => navigate('/profile')}
+          className="w-full rounded-xl h-12 gap-2"
+          variant="default"
+        >
+          <Home className="w-5 h-5" />
+          {TEXT_GO_PROFILE}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default RealLearningRecordDetail;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1543,6 +1543,37 @@
   color: var(--gray-900);
 }
 
+.history-filters-panel {
+  margin-bottom: 16px;
+  padding: 12px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--gray-200);
+  background: white;
+}
+
+.history-filter-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.history-filter-item {
+  min-width: 0;
+}
+
+.history-filter-label {
+  margin-bottom: 6px;
+  font-size: clamp(10px, 2.4vw, 11px);
+  color: var(--gray-500);
+}
+
+.history-date-row {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
 .filter-btn {
   display: flex;
   align-items: center;
@@ -1609,11 +1640,11 @@
 
 .filter-select-btn {
   width: 100%;
-  padding: 12px 16px;
+  padding: 10px 12px;
   background: var(--gray-50);
   border: 1px solid var(--gray-200);
   border-radius: var(--radius-md);
-  font-size: var(--text-body);
+  font-size: clamp(11px, 2.9vw, 13px);
   color: var(--gray-900);
   cursor: pointer;
   display: flex;
@@ -1661,22 +1692,22 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  font-size: var(--text-body);
+  font-size: clamp(11px, 2.9vw, 13px);
   color: var(--gray-900);
-  background: transparent;
+  background: white;
   border: none;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .filter-dropdown-item:hover {
-  background: var(--primary-50);
-  color: var(--primary-600);
+  background: var(--gray-50);
+  color: var(--gray-900);
 }
 
 .filter-dropdown-item.active {
-  background: var(--primary-100);
-  color: var(--primary-600);
+  background: white;
+  color: var(--gray-900);
   font-weight: var(--font-weight-medium);
 }
 
@@ -1687,7 +1718,7 @@
   background: var(--gray-50);
   border: 1px solid var(--gray-200);
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: clamp(11px, 2.9vw, 13px);
   color: var(--gray-900);
   pointer-events: none;
 }


### PR DESCRIPTION
## 요약

  실전/연습 인터뷰 흐름을 FE 기준으로 세션 중심으로 정리하고, 실전 최종 피드백 결과 화면 및 프로필 학습기록 조회 경로를 확장했습니다.
  동시에 답변 상세조회 요청에서 expand 쿼리를 제거해 서버 입력값 오류를 방지하고, STT 업로드 파일명 규칙을 표준화했습니다.

  ## 변경사항

  - 실전 면접 API 연동 및 세션 진행/답변/종료 플로우 정리
  - 연습/실전 공통 STT 파이프라인 훅 도입 (useAudioSttPipeline)
  - 실전 면접 AI 분석 결과 페이지 추가 및 분석 완료 후 자동 전환
  - 프로필 최근 학습기록에서 연습/실전 통합 조회(기본 전체) 및 모드 필터 추가
  - 실전 기록 클릭 시 전용 상세 페이지(RealLearningRecordDetail) 라우팅/조회 추가
  - 답변 상세조회 API에서 expand 제거 (/api/answers/:answerId 고정)
  - STT 업로드 파일명 규칙 통일
    YYYY-MM-DD_HH:MM:SS_<MODE>_STT_<UUID>.<ext>

  ## 수정/추가/삭제 파일

  - 주요 수정: src/app/pages/RealInterview.jsx
  - 주요 수정: src/app/pages/RealInterviewSession.jsx
  - 주요 수정: src/app/hooks/useAudioSttPipeline.js
  - 주요 수정: src/app/pages/PracticeAnswerVoice.jsx
  - 주요 수정: src/app/pages/PracticeSTT.jsx
  - 주요 수정: src/app/pages/ProfileMain.jsx
  - 주요 수정: src/app/hooks/useAnswerDetail.js
  - 주요 수정: src/api/answerApi.js
  - 주요 수정: src/app/App.jsx
  - 주요 추가: src/app/pages/RealInterviewResultAI.jsx
  - 주요 추가: src/app/pages/RealLearningRecordDetail.jsx

  ## 구현 의도 / 목적

  - 실전/연습 모드 공통 처리 로직을 줄여 유지보수성 향상
  - 불필요 쿼리 파라미터 제거로 API 오류 가능성 축소
  - STT 파일명 표준화로 운영/추적 편의성 강화

  ## 관련 Commit, Issue

  - 53b9800 feat: 실전면접 API 연동 및 인터뷰 플로우/UX 개선
  - 420500f refactor(stt): 공통 오디오 업로드/STT 훅 도입 및 연습·실전 모드 적용
  - 9f45d43 feat(real-interview): AI 분석 결과 페이지 추가 및 분석 완료 전환 연결
  - 28a92a2 feat(profile): 실전 학습기록 상세 페이지 및 모드 통합 조회 추가
  - 0bd3334 feat(stt): STT 업로드 파일명 규칙을 모드/UUID 기반으로 통일
  - #164 