### PR TITLE
feat: 실전 면접 A/V 제출 플로우 및 학습기록 영상 UX 개선

### DIFF
--- a/src/api/fileApi.js
+++ b/src/api/fileApi.js
@@ -6,19 +6,30 @@ import { api, handleResponse } from '@/utils/apiUtils'
 /**
  * S3 presigned URL 요청
  * @param {Object} params
- * @param {string} params.fileName - 파일명
+ * @param {string} [params.fileName] - 파일명(서버에서 키 생성 시 무시될 수 있음)
  * @param {number} params.fileSize - 파일 크기 (bytes)
  * @param {string} params.mimeType - MIME 타입 (예: audio/webm)
  * @param {string} params.category - 파일 카테고리 (예: AUDIO)
+ * @param {string} [params.method='PUT'] - 업로드 HTTP 메서드
  * @returns {Promise<{data: {fileId: string, presignedUrl: string}}>}
  */
-export async function getPresignedUrl({ fileName, fileSize, mimeType, category }) {
-  const response = await api.post('/api/files/presigned-url', {
-    file_name: fileName,
+export async function getPresignedUrl({
+  fileName,
+  fileSize,
+  mimeType,
+  category,
+  method = 'PUT',
+}) {
+  const payload = {
+    method,
     file_size: fileSize,
     mime_type: mimeType,
     category,
-  })
+  }
+
+  if (fileName) payload.file_name = fileName
+
+  const response = await api.post('/api/files/presigned-url', payload)
   const result = await handleResponse(response)
   const data = result?.data ?? result ?? {}
   return {
@@ -27,8 +38,66 @@ export async function getPresignedUrl({ fileName, fileSize, mimeType, category }
       ...data,
       fileId: data.fileId ?? data.file_id,
       presignedUrl: data.presignedUrl ?? data.presigned_url,
+      uploadMode: data.uploadMode ?? data.upload_mode,
+      partSize: data.partSize ?? data.part_size,
     },
   }
+}
+
+/**
+ * VIDEO multipart 파트 업로드 URL 발급
+ * @param {string|number} fileId
+ * @param {number} partNumber
+ * @returns {Promise<{data: {partNumber: number, presignedUrl: string}}>}
+ */
+export async function getMultipartPartPresignedUrl(fileId, partNumber) {
+  const response = await api.post(`/api/files/${fileId}/multipart/parts`, {
+    part_number: partNumber,
+  })
+  const result = await handleResponse(response)
+  const data = result?.data ?? result ?? {}
+
+  return {
+    ...result,
+    data: {
+      ...data,
+      partNumber: data.partNumber ?? data.part_number,
+      presignedUrl: data.presignedUrl ?? data.presigned_url,
+    },
+  }
+}
+
+/**
+ * VIDEO multipart 완료 처리
+ * @param {string|number} fileId
+ * @param {Object} params
+ * @param {Array<{part_number:number,etag:string}>} params.parts
+ */
+export async function completeMultipartUpload(fileId, { parts } = {}) {
+  const payload = {
+    parts,
+  }
+
+  const response = await api.post(`/api/files/${fileId}/multipart/complete`, payload)
+  const result = await handleResponse(response)
+  const data = result?.data ?? result ?? {}
+
+  return {
+    ...result,
+    data: {
+      ...data,
+      fileId: data.fileId ?? data.file_id,
+    },
+  }
+}
+
+/**
+ * VIDEO multipart 업로드 중단
+ * @param {string|number} fileId
+ */
+export async function abortMultipartUpload(fileId) {
+  const response = await api.post(`/api/files/${fileId}/multipart/abort`)
+  return handleResponse(response)
 }
 
 /**
@@ -49,6 +118,74 @@ export async function uploadToS3(presignedUrl, file, contentType) {
   if (!response.ok) {
     throw new Error('S3 업로드 실패')
   }
+}
+
+/**
+ * S3 multipart part 업로드
+ * @param {string} presignedUrl
+ * @param {Blob} partBlob
+ * @returns {Promise<string>} ETag
+ */
+export async function uploadPartToS3(presignedUrl, partBlob) {
+  const response = await fetch(presignedUrl, {
+    method: 'PUT',
+    body: partBlob,
+  })
+
+  if (!response.ok) {
+    throw new Error('S3 멀티파트 업로드 실패')
+  }
+
+  const etag = response.headers.get('ETag') || response.headers.get('etag')
+  const normalized = typeof etag === 'string' ? etag.trim() : ''
+  if (!normalized) {
+    throw new Error('멀티파트 ETag를 확인할 수 없습니다.')
+  }
+  return normalized
+}
+
+/**
+ * 기존 업로드 파일 조회용 GET presigned URL 발급
+ * @param {string|number} fileId
+ * @returns {Promise<{data: {fileId: string|number, presignedUrl: string, method: string}}>}
+ */
+export async function getFileReadPresignedUrl(fileId) {
+  const response = await api.post('/api/files/presigned-url', {
+    file_id: fileId,
+    method: 'GET',
+  })
+  const result = await handleResponse(response)
+  const data = result?.data ?? result ?? {}
+
+  return {
+    ...result,
+    data: {
+      ...data,
+      fileId: data.fileId ?? data.file_id,
+      presignedUrl: data.presignedUrl ?? data.presigned_url,
+      method: data.method ?? 'GET',
+    },
+  }
+}
+
+/**
+ * S3 URL로 리소스를 조회해 Blob으로 반환
+ * @param {string} resourceUrl
+ * @param {Object} [options]
+ * @param {AbortSignal} [options.signal]
+ * @returns {Promise<Blob>}
+ */
+export async function fetchS3ResourceBlob(resourceUrl, { signal } = {}) {
+  const response = await fetch(resourceUrl, {
+    method: 'GET',
+    signal,
+  })
+
+  if (!response.ok) {
+    throw new Error('S3 리소스 조회 실패')
+  }
+
+  return response.blob()
 }
 
 /**

--- a/src/api/interviewApi.js
+++ b/src/api/interviewApi.js
@@ -51,6 +51,8 @@ export async function submitPracticeInterviewAnswer({ sessionId, questionId, ans
  * @param {number} [params.turnOrder]
  * @param {number} [params.topicId]
  * @param {string} [params.category]
+ * @param {number|string} [params.audioFileId]
+ * @param {number|string} [params.videoFileId]
  */
 export async function submitRealInterviewAnswer(params = {}) {
   const {
@@ -65,6 +67,8 @@ export async function submitRealInterviewAnswer(params = {}) {
     turnOrder,
     topicId,
     category,
+    audioFileId,
+    videoFileId,
   } = params
 
   if (rawPayload && typeof rawPayload === 'object') {
@@ -104,6 +108,12 @@ export async function submitRealInterviewAnswer(params = {}) {
   }
   if (category !== undefined && category !== null && category !== '') {
     payload.category = category
+  }
+  if (audioFileId !== undefined && audioFileId !== null && audioFileId !== '') {
+    payload.audio_file_id = Number.isNaN(Number(audioFileId)) ? audioFileId : Number(audioFileId)
+  }
+  if (videoFileId !== undefined && videoFileId !== null && videoFileId !== '') {
+    payload.video_file_id = Number.isNaN(Number(videoFileId)) ? videoFileId : Number(videoFileId)
   }
 
   return api.post('/api/answers/real', payload, { parseResponse: true })

--- a/src/api/ttsApi.js
+++ b/src/api/ttsApi.js
@@ -3,90 +3,6 @@ import { api, extractErrorMessage } from '@/utils/apiUtils'
 const DEFAULT_TTS_ERROR_MESSAGE = '음성 변환에 실패했습니다.'
 const TTS_PARSE_ERROR_MESSAGE = 'TTS 응답 파싱에 실패했습니다.'
 
-const textEncoder = new TextEncoder()
-const textDecoder = new TextDecoder()
-
-function extractBoundary(contentType) {
-  const match = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i)
-  return (match?.[1] || match?.[2] || '').trim()
-}
-
-function findSequence(source, target, startIndex = 0) {
-  if (!target.length || source.length < target.length) {
-    return -1
-  }
-
-  for (let i = startIndex; i <= source.length - target.length; i += 1) {
-    let matched = true
-    for (let j = 0; j < target.length; j += 1) {
-      if (source[i + j] !== target[j]) {
-        matched = false
-        break
-      }
-    }
-    if (matched) {
-      return i
-    }
-  }
-
-  return -1
-}
-
-function trimTrailingLineBreak(bytes) {
-  let end = bytes.length
-
-  if (end >= 2 && bytes[end - 2] === 13 && bytes[end - 1] === 10) {
-    end -= 2
-  } else if (end >= 1 && (bytes[end - 1] === 13 || bytes[end - 1] === 10)) {
-    end -= 1
-  }
-
-  return bytes.slice(0, end)
-}
-
-function splitHeadersAndBody(partBytes) {
-  const crlfDelimiter = new Uint8Array([13, 10, 13, 10])
-  const lfDelimiter = new Uint8Array([10, 10])
-
-  let headerEndIndex = findSequence(partBytes, crlfDelimiter)
-  let bodyOffset = 4
-
-  if (headerEndIndex === -1) {
-    headerEndIndex = findSequence(partBytes, lfDelimiter)
-    bodyOffset = 2
-  }
-
-  if (headerEndIndex === -1) {
-    return null
-  }
-
-  return {
-    headerBytes: partBytes.slice(0, headerEndIndex),
-    bodyBytes: partBytes.slice(headerEndIndex + bodyOffset),
-  }
-}
-
-function parseHeaders(headerBytes) {
-  const lines = textDecoder.decode(headerBytes).split(/\r?\n/)
-  const headers = {}
-
-  for (const line of lines) {
-    const separatorIndex = line.indexOf(':')
-    if (separatorIndex === -1) {
-      continue
-    }
-
-    const key = line.slice(0, separatorIndex).trim().toLowerCase()
-    const value = line.slice(separatorIndex + 1).trim()
-
-    if (key) {
-      headers[key] = value
-    }
-  }
-
-  return headers
-}
-
 function extractFileName(contentDisposition = '') {
   const quoted = contentDisposition.match(/filename="([^"]+)"/i)
   if (quoted?.[1]) {
@@ -95,75 +11,16 @@ function extractFileName(contentDisposition = '') {
 
   const unquoted = contentDisposition.match(/filename=([^;]+)/i)
   if (!unquoted?.[1]) {
-    return null
+    return 'tts_output.mp3'
   }
 
-  return unquoted[1].trim().replace(/^"|"$/g, '')
+  return unquoted[1].trim().replace(/^"|"$/g, '') || 'tts_output.mp3'
 }
 
-function parseMultipartMixed(bodyBytes, boundary) {
-  const boundaryBytes = textEncoder.encode(`--${boundary}`)
-
-  let cursor = 0
-  let jsonPart = null
-  let audioBytes = null
-  let audioContentType = 'audio/mpeg'
-  let fileName = 'tts_output.mp3'
-
-  while (cursor < bodyBytes.length) {
-    const boundaryIndex = findSequence(bodyBytes, boundaryBytes, cursor)
-    if (boundaryIndex === -1) {
-      break
-    }
-
-    let lineEndIndex = boundaryIndex + boundaryBytes.length
-
-    const isClosingBoundary = bodyBytes[lineEndIndex] === 45 && bodyBytes[lineEndIndex + 1] === 45
-    if (isClosingBoundary) {
-      break
-    }
-
-    if (bodyBytes[lineEndIndex] === 13 && bodyBytes[lineEndIndex + 1] === 10) {
-      lineEndIndex += 2
-    } else if (bodyBytes[lineEndIndex] === 10) {
-      lineEndIndex += 1
-    }
-
-    const nextBoundaryIndex = findSequence(bodyBytes, boundaryBytes, lineEndIndex)
-    if (nextBoundaryIndex === -1) {
-      break
-    }
-
-    const rawPartBytes = trimTrailingLineBreak(bodyBytes.slice(lineEndIndex, nextBoundaryIndex))
-    const splitResult = splitHeadersAndBody(rawPartBytes)
-
-    if (splitResult) {
-      const headers = parseHeaders(splitResult.headerBytes)
-      const contentType = (headers['content-type'] || '').toLowerCase()
-
-      if (contentType.includes('application/json')) {
-        jsonPart = JSON.parse(textDecoder.decode(splitResult.bodyBytes))
-      }
-
-      if (contentType.includes('audio/mpeg')) {
-        audioBytes = splitResult.bodyBytes
-        audioContentType = headers['content-type']?.split(';')[0].trim() || 'audio/mpeg'
-        fileName = extractFileName(headers['content-disposition']) || fileName
-      }
-    }
-
-    cursor = nextBoundaryIndex
-  }
-
-  if (!jsonPart || !audioBytes) {
-    throw new Error(TTS_PARSE_ERROR_MESSAGE)
-  }
-
-  return {
-    jsonPart,
-    audioBlob: new Blob([audioBytes], { type: audioContentType }),
-    fileName,
-  }
+function toIntegerOrNull(value) {
+  const number = Number(value)
+  if (!Number.isInteger(number)) return null
+  return number
 }
 
 /**
@@ -172,32 +29,42 @@ function parseMultipartMixed(bodyBytes, boundary) {
  * @param {number} params.userId - 사용자 ID
  * @param {string} params.sessionId - 면접 세션 ID
  * @param {string} params.text - 음성 변환 텍스트
- * @returns {Promise<{message: string, data: {user_id: number, session_id: string}, audioBlob: Blob, fileName: string}>}
+ * @param {AbortSignal} [params.signal] - 요청 취소 시그널
+ * @returns {Promise<{message: string, data: {user_id: number|null, session_id: string}, audioBlob: Blob, fileName: string}>}
  */
-export async function requestTTS({ userId, sessionId, text }) {
+export async function requestTTS({ userId, sessionId, text, signal }) {
   const response = await api.post('/api/ai/tts', {
     user_id: userId,
     session_id: sessionId,
     text,
-  })
+  }, { signal })
 
   if (!response.ok) {
     throw new Error(await extractErrorMessage(response, DEFAULT_TTS_ERROR_MESSAGE))
   }
 
-  const contentType = response.headers.get('Content-Type') || ''
-  const boundary = extractBoundary(contentType)
-
-  if (!boundary) {
+  const contentType = (response.headers.get('Content-Type') || '').toLowerCase()
+  if (!contentType.startsWith('audio/')) {
     throw new Error(TTS_PARSE_ERROR_MESSAGE)
   }
 
-  const bodyBytes = new Uint8Array(await response.arrayBuffer())
-  const { jsonPart, audioBlob, fileName } = parseMultipartMixed(bodyBytes, boundary)
+  const audioBlob = await response.blob()
+  if (!audioBlob || audioBlob.size <= 0) {
+    throw new Error(TTS_PARSE_ERROR_MESSAGE)
+  }
+
+  const messageHeader = response.headers.get('X-TTS-Message')
+  const userIdHeader = response.headers.get('X-TTS-User-Id')
+  const sessionIdHeader = response.headers.get('X-TTS-Session-Id')
+  const contentDisposition = response.headers.get('Content-Disposition') || ''
 
   return {
-    ...jsonPart,
+    message: messageHeader || 'get_audio_file_success',
+    data: {
+      user_id: toIntegerOrNull(userIdHeader) ?? toIntegerOrNull(userId),
+      session_id: (sessionIdHeader || String(sessionId || '')).trim(),
+    },
     audioBlob,
-    fileName,
+    fileName: extractFileName(contentDisposition),
   }
 }

--- a/src/app/hooks/useAudioSttPipeline.js
+++ b/src/app/hooks/useAudioSttPipeline.js
@@ -1,5 +1,13 @@
 import { useCallback, useState } from 'react';
-import { getPresignedUrl, uploadToS3, confirmFileUpload } from '@/api/fileApi';
+import {
+  abortMultipartUpload,
+  completeMultipartUpload,
+  confirmFileUpload,
+  getMultipartPartPresignedUrl,
+  getPresignedUrl,
+  uploadPartToS3,
+  uploadToS3,
+} from '@/api/fileApi';
 import { requestSTT } from '@/api/sttApi';
 
 const STT_PIPELINE_STAGE = {
@@ -12,6 +20,8 @@ const STT_PIPELINE_STAGE = {
 
 const UPLOAD_FAILED_MESSAGE = '업로드에 실패했습니다';
 const STT_FAILED_MESSAGE = '음성 변환에 실패했습니다';
+const VIDEO_UPLOAD_FAILED_MESSAGE = '영상 업로드에 실패했습니다';
+const DEFAULT_VIDEO_PART_SIZE = 8 * 1024 * 1024;
 
 const toTrimmedString = (value) => {
   if (typeof value !== 'string') return '';
@@ -44,6 +54,19 @@ const resolveAudioMeta = (rawType = '') => {
   }
 
   return { extension: 'webm', mimeType: 'audio/webm' };
+};
+
+const resolveVideoMeta = (rawType = '') => {
+  const normalized = toTrimmedString(rawType).toLowerCase();
+
+  if (normalized.includes('mp4')) {
+    return { extension: 'mp4', mimeType: 'video/mp4' };
+  }
+  if (normalized.includes('webm')) {
+    return { extension: 'webm', mimeType: 'video/webm' };
+  }
+
+  return { extension: 'webm', mimeType: 'video/webm' };
 };
 
 const formatTimestampPrefix = (date = new Date()) => {
@@ -85,7 +108,10 @@ export function useAudioSttPipeline(options = {}) {
     setError(null);
   }, []);
 
-  const uploadAudioBlob = useCallback(async ({ audioBlob, mode = 'UNKNOWN' }) => {
+  const uploadAudioBlob = useCallback(async ({
+    audioBlob,
+    mode = 'UNKNOWN',
+  }) => {
     if (!audioBlob || typeof audioBlob.size !== 'number' || audioBlob.size <= 0) {
       const invalidAudioError = new Error('녹음된 음성이 없습니다.');
       setError(invalidAudioError);
@@ -110,6 +136,7 @@ export function useAudioSttPipeline(options = {}) {
         fileSize: uploadBlob.size,
         mimeType,
         category,
+        method: 'PUT',
       });
       const presignedPayload = presignedResult?.data ?? {};
       const fileId = presignedPayload.fileId ?? presignedPayload.file_id;
@@ -142,6 +169,100 @@ export function useAudioSttPipeline(options = {}) {
       throw normalizedError;
     }
   }, [category]);
+
+  const uploadVideoBlobMultipart = useCallback(async ({
+    videoBlob,
+  }) => {
+    if (!videoBlob || typeof videoBlob.size !== 'number' || videoBlob.size <= 0) {
+      const invalidVideoError = new Error('녹화된 영상이 없습니다.');
+      setError(invalidVideoError);
+      setStage(STT_PIPELINE_STAGE.ERROR);
+      throw invalidVideoError;
+    }
+
+    const { extension, mimeType } = resolveVideoMeta(videoBlob.type);
+    const uploadBlob = videoBlob.type === mimeType
+      ? videoBlob
+      : new Blob([videoBlob], { type: mimeType });
+
+    setError(null);
+    setStage(STT_PIPELINE_STAGE.UPLOADING);
+
+    let multipartFileId = null;
+    try {
+      const timestampPrefix = formatTimestampPrefix();
+      const uuid = createUuid();
+      const initResult = await getPresignedUrl({
+        fileName: `${timestampPrefix}_REAL_VIDEO_${uuid}.${extension}`,
+        fileSize: uploadBlob.size,
+        mimeType,
+        category: 'VIDEO',
+        method: 'PUT',
+      });
+
+      const initPayload = initResult?.data ?? {};
+      const fileId = initPayload.fileId ?? initPayload.file_id;
+      if (!fileId) {
+        throw new Error('영상 업로드 초기화에 실패했습니다.');
+      }
+      multipartFileId = fileId;
+      const uploadMode = toTrimmedString(
+        initPayload.uploadMode ?? initPayload.upload_mode
+      ).toUpperCase();
+      if (uploadMode && uploadMode !== 'MULTIPART') {
+        throw new Error('영상 업로드 모드가 올바르지 않습니다.');
+      }
+
+      const rawPartSize = Number(initPayload.partSize ?? initPayload.part_size);
+      const partSize =
+        Number.isFinite(rawPartSize) && rawPartSize > 0
+          ? Math.trunc(rawPartSize)
+          : DEFAULT_VIDEO_PART_SIZE;
+
+      const uploadedParts = [];
+      let partNumber = 1;
+      for (let start = 0; start < uploadBlob.size; start += partSize) {
+        const end = Math.min(start + partSize, uploadBlob.size);
+        const partBlob = uploadBlob.slice(start, end);
+
+        const partUrlResult = await getMultipartPartPresignedUrl(fileId, partNumber);
+        const partPayload = partUrlResult?.data ?? {};
+        const presignedUrl = partPayload.presignedUrl ?? partPayload.presigned_url;
+
+        if (!presignedUrl) {
+          throw new Error('영상 파트 업로드 URL을 받지 못했습니다.');
+        }
+
+        const etag = await uploadPartToS3(presignedUrl, partBlob);
+        uploadedParts.push({
+          part_number: partNumber,
+          etag,
+        });
+        partNumber += 1;
+      }
+
+      await completeMultipartUpload(fileId, { parts: uploadedParts });
+
+      setStage(STT_PIPELINE_STAGE.SUCCESS);
+      return {
+        fileId,
+        mimeType,
+        extension,
+      };
+    } catch (videoUploadError) {
+      if (multipartFileId) {
+        try {
+          await abortMultipartUpload(multipartFileId);
+        } catch {
+          // abort는 실패해도 원래 에러를 유지한다.
+        }
+      }
+      const normalizedError = toError(videoUploadError, VIDEO_UPLOAD_FAILED_MESSAGE);
+      setError(normalizedError);
+      setStage(STT_PIPELINE_STAGE.ERROR);
+      throw normalizedError;
+    }
+  }, []);
 
   const transcribeAudioUrl = useCallback(async ({ userId, sessionId, audioUrl }) => {
     const normalizedAudioUrl = toTrimmedString(audioUrl);
@@ -207,6 +328,7 @@ export function useAudioSttPipeline(options = {}) {
     error,
     reset,
     uploadAudioBlob,
+    uploadVideoBlobMultipart,
     transcribeAudioUrl,
     uploadAndTranscribe,
     STT_PIPELINE_STAGE,

--- a/src/app/hooks/useQuestionTtsPlayer.js
+++ b/src/app/hooks/useQuestionTtsPlayer.js
@@ -15,15 +15,29 @@ export function useQuestionTtsPlayer({
     autoPlayEnabled = true,
     noSessionErrorMessage = '세션 정보를 찾을 수 없습니다.',
     onError,
+    onPlaybackEnded,
 }) {
     const audioRef = useRef(null);
     const audioUrlRef = useRef('');
+    const requestControllerRef = useRef(null);
+    const requestSequenceRef = useRef(0);
     const autoPlayedKeyRef = useRef('');
 
     const [isLoading, setIsLoading] = useState(false);
     const [isPlaying, setIsPlaying] = useState(false);
 
+    const isAbortError = useCallback((error) => {
+        const name = typeof error?.name === 'string' ? error.name : '';
+        const message = typeof error?.message === 'string' ? error.message : '';
+        return name === 'AbortError' || /abort/i.test(message);
+    }, []);
+
     const stop = useCallback(() => {
+        if (requestControllerRef.current) {
+            requestControllerRef.current.abort();
+            requestControllerRef.current = null;
+        }
+
         if (audioRef.current) {
             audioRef.current.onended = null;
             audioRef.current.onpause = null;
@@ -36,6 +50,7 @@ export function useQuestionTtsPlayer({
             audioUrlRef.current = '';
         }
 
+        setIsLoading(false);
         setIsPlaying(false);
     }, []);
 
@@ -57,37 +72,102 @@ export function useQuestionTtsPlayer({
             return false;
         }
 
-        setIsLoading(true);
-        try {
-            stop();
+        const requestSequence = requestSequenceRef.current + 1;
+        requestSequenceRef.current = requestSequence;
 
+        stop();
+        setIsLoading(true);
+
+        const controller = new AbortController();
+        requestControllerRef.current = controller;
+
+        try {
             const response = await requestTTS({
                 userId,
                 sessionId: normalizedSessionId,
                 text: normalizedText,
+                signal: controller.signal,
             });
+            if (requestSequenceRef.current !== requestSequence) {
+                return false;
+            }
+
+            if (import.meta.env.DEV) {
+                console.info('[TTS] play payload', {
+                    blobSize: response?.audioBlob?.size ?? 0,
+                    blobType: response?.audioBlob?.type ?? '',
+                    silent,
+                });
+            }
 
             const objectUrl = URL.createObjectURL(response.audioBlob);
             audioUrlRef.current = objectUrl;
 
             const audio = new Audio(objectUrl);
+            audio.preload = 'auto';
             audioRef.current = audio;
-            audio.onended = () => setIsPlaying(false);
-            audio.onpause = () => setIsPlaying(false);
+            audio.onended = () => {
+                if (requestSequenceRef.current === requestSequence) {
+                    setIsPlaying(false);
+                    onPlaybackEnded?.({
+                        text: normalizedText,
+                        sessionId: normalizedSessionId,
+                    });
+                }
+            };
+            audio.onpause = () => {
+                if (requestSequenceRef.current === requestSequence) {
+                    setIsPlaying(false);
+                }
+            };
+
+            try {
+                audio.currentTime = 0;
+            } catch {
+                // noop
+            }
 
             await audio.play();
+            if (requestSequenceRef.current !== requestSequence) {
+                audio.pause();
+                return false;
+            }
             setIsPlaying(true);
             return true;
         } catch (error) {
+            if (isAbortError(error)) {
+                return false;
+            }
+            if (import.meta.env.DEV) {
+                console.error('[TTS] play failed', {
+                    name: error?.name,
+                    message: error?.message,
+                    silent,
+                });
+            }
             stop();
             if (!silent) {
                 onError?.(error);
             }
             return false;
         } finally {
-            setIsLoading(false);
+            if (requestControllerRef.current === controller) {
+                requestControllerRef.current = null;
+            }
+            if (requestSequenceRef.current === requestSequence) {
+                setIsLoading(false);
+            }
         }
-    }, [finishedQuestionText, noSessionErrorMessage, onError, sessionId, stop, userId]);
+    }, [
+        finishedQuestionText,
+        isAbortError,
+        noSessionErrorMessage,
+        onError,
+        onPlaybackEnded,
+        sessionId,
+        stop,
+        userId,
+    ]);
 
     const play = useCallback(async ({ silent = false } = {}) => {
         const normalizedQuestion = toTrimmedString(questionText);
@@ -104,8 +184,6 @@ export function useQuestionTtsPlayer({
     }, [isLoading, isPlaying, play, stop]);
 
     useEffect(() => {
-        stop();
-
         const normalizedQuestion = toTrimmedString(questionText);
         const normalizedSessionId = toTrimmedString(sessionId);
         const normalizedFinishedText = toTrimmedString(finishedQuestionText);
@@ -119,6 +197,10 @@ export function useQuestionTtsPlayer({
         if (!shouldAutoPlay) {
             return;
         }
+
+        // 자동 재생이 실제로 필요한 경우에만 기존 재생/요청을 정리한다.
+        // 그렇지 않으면(예: 마지막 턴 전환) 수동 재생 요청이 abort될 수 있다.
+        stop();
 
         const autoPlayKey = `${normalizedSessionId}:${normalizedQuestion}`;
         if (autoPlayedKeyRef.current === autoPlayKey) {

--- a/src/app/pages/RealInterviewSession.jsx
+++ b/src/app/pages/RealInterviewSession.jsx
@@ -57,6 +57,9 @@ const COPY = {
     micConnectionFailed: '마이크 연결을 확인한 후 다시 시도해주세요.',
     recordingUnsupported: '현재 브라우저에서 녹화 기능을 지원하지 않습니다.',
     recordingStartFailed: '녹화를 시작하지 못했습니다. 브라우저 권한 또는 장치를 확인해주세요.',
+    recordingFileMissing: '녹화 파일 정보가 누락되었습니다. 다시 답변을 녹화해주세요.',
+    recordingVideoMissing: '답변 영상을 확인하지 못했습니다. 다시 녹화해주세요.',
+    recordingAudioMissing: '답변 음성을 확인하지 못했습니다. 다시 녹화해주세요.',
     interviewFinishedQuestion: '모든 면접 질문이 종료되었습니다. AI 분석 요청으로 종합 피드백을 받아보세요.',
     analysisRequestFailed: 'AI 분석 요청을 전송하지 못했습니다.',
     analysisRequestAccepted: 'AI 분석 요청이 접수되었습니다. 결과가 준비되면 확인할 수 있어요.',
@@ -69,6 +72,7 @@ const COPY = {
     questionTtsStop: '재생 중지',
     questionTtsLoading: '생성 중...',
     questionTtsFailed: '질문 음성 재생에 실패했습니다.',
+    questionTtsCompletionRequired: '질문 음성 재생이 끝나야 답변을 제출할 수 있습니다.',
     badCaseDetected: '답변이 기준을 충족하지 못해 다시 녹화가 필요합니다.',
     badCaseFeedbackFallback: '답변을 보완해 다시 시도해주세요.',
     badCaseRetryPrompt: '피드백을 반영해 다시 답변해주세요.',
@@ -268,8 +272,20 @@ const isSessionEndTurnType = (value) => {
     return normalizeTurnType(value, 'follow_up') === 'session_end';
 };
 
+const getTrailTypeLabel = (turnType, turnOrder, fallbackFollowUpOrder = 1) => {
+    if (isSessionEndTurnType(turnType)) {
+        return '면접 종료';
+    }
+    if (isTopicTurnType(turnType)) {
+        return ORIGIN_QUESTION_TYPE;
+    }
+    return `${COPY.followUpQuestionPrefix} ${Math.max(normalizeTurnOrder(turnOrder, fallbackFollowUpOrder), 1)}`;
+};
+
 const normalizeHistoryItem = (item, index) => {
     const fallbackOrder = index;
+    const audioFileId = toIntegerOrNull(item?.audio_file_id ?? item?.audioFileId);
+    const videoFileId = toIntegerOrNull(item?.video_file_id ?? item?.videoFileId);
     return {
         question: toTrimmedString(item?.question),
         answer_text: toTrimmedString(item?.answer_text ?? item?.answerText),
@@ -277,6 +293,8 @@ const normalizeHistoryItem = (item, index) => {
         turn_order: normalizeTurnOrder(item?.turn_order ?? item?.turnOrder, fallbackOrder),
         topic_id: toIntegerOrNull(item?.topic_id ?? item?.topicId),
         category: toTrimmedString(item?.category),
+        audio_file_id: audioFileId,
+        video_file_id: videoFileId,
     };
 };
 
@@ -556,7 +574,7 @@ const extractBadCaseFeedback = (response, payload) => {
     };
 };
 
-const getRecorderOptions = () => {
+const getAudioRecorderOptions = () => {
     if (typeof MediaRecorder === 'undefined') return {};
 
     if (MediaRecorder.isTypeSupported('audio/mp4')) {
@@ -571,6 +589,24 @@ const getRecorderOptions = () => {
     return {};
 };
 
+const getVideoRecorderOptions = () => {
+    if (typeof MediaRecorder === 'undefined') return {};
+
+    if (MediaRecorder.isTypeSupported('video/webm;codecs=vp9,opus')) {
+        return { mimeType: 'video/webm;codecs=vp9,opus' };
+    }
+    if (MediaRecorder.isTypeSupported('video/webm;codecs=vp8,opus')) {
+        return { mimeType: 'video/webm;codecs=vp8,opus' };
+    }
+    if (MediaRecorder.isTypeSupported('video/webm')) {
+        return { mimeType: 'video/webm' };
+    }
+    if (MediaRecorder.isTypeSupported('video/mp4')) {
+        return { mimeType: 'video/mp4' };
+    }
+    return {};
+};
+
 const BUBBLE_BASE =
     'bg-[linear-gradient(145deg,rgba(255,255,255,0.07)_0%,rgba(255,255,255,0.035)_46%,rgba(255,255,255,0.015)_100%)] border border-white/[0.14] shadow-[inset_0_1px_0_rgba(255,255,255,0.16),inset_0_-1px_0_rgba(255,255,255,0.015),0_6px_12px_rgba(12,7,12,0.08)] backdrop-blur-[18px] backdrop-saturate-150';
 const HUD_TEXT_SHADOW = 'drop-shadow-[0_1px_8px_rgba(0,0,0,0.72)]';
@@ -581,8 +617,15 @@ const RealInterviewSession = () => {
     const videoRef = useRef(null);
     const streamRef = useRef(null);
     const recordingStreamRef = useRef(null);
+    const videoCaptureStreamRef = useRef(null);
     const mediaRecorderRef = useRef(null);
+    const videoRecorderRef = useRef(null);
     const recordedChunksRef = useRef([]);
+    const videoRecordedChunksRef = useRef([]);
+    const pendingStopResultRef = useRef({
+        audio: null,
+        video: null,
+    });
     const timerRef = useRef(null);
     const storedSessionRef = useRef(null);
 
@@ -623,7 +666,12 @@ const RealInterviewSession = () => {
     const [interviewEntries, setInterviewEntries] = useState([]);
     const [questionTrail, setQuestionTrail] = useState([]);
     const [currentQuestion, setCurrentQuestion] = useState(INITIAL_QUESTION);
-    const { uploadAudioBlob, transcribeAudioUrl } = useAudioSttPipeline();
+    const [recordedFileIds, setRecordedFileIds] = useState({
+        audioFileId: null,
+        videoFileId: null,
+    });
+    const [hasQuestionTtsCompleted, setHasQuestionTtsCompleted] = useState(false);
+    const { uploadAudioBlob, uploadVideoBlobMultipart, transcribeAudioUrl } = useAudioSttPipeline();
 
     const isRecording = phase === PHASE.RECORDING;
     const isProcessing =
@@ -872,6 +920,16 @@ const RealInterviewSession = () => {
     const handleQuestionTtsError = useCallback((error) => {
         toast.error(error?.message || COPY.questionTtsFailed);
     }, []);
+    const handleQuestionTtsEnded = useCallback(({ text }) => {
+        if (!realSessionId) return;
+
+        const normalizedPlayedText = toTrimmedString(text);
+        const normalizedCurrentQuestion = toTrimmedString(currentQuestion);
+        if (!normalizedPlayedText || !normalizedCurrentQuestion) return;
+        if (normalizedPlayedText !== normalizedCurrentQuestion) return;
+
+        setHasQuestionTtsCompleted(true);
+    }, [currentQuestion, realSessionId]);
 
     const {
         isLoading: isQuestionTtsLoading,
@@ -887,7 +945,14 @@ const RealInterviewSession = () => {
         autoPlayEnabled: isInterviewStarted && isSessionReady && !isInterviewFinished,
         noSessionErrorMessage: COPY.sessionNotFound,
         onError: handleQuestionTtsError,
+        onPlaybackEnded: handleQuestionTtsEnded,
     });
+    const isReviewSubmitDisabled =
+        !transcriptDraft.trim() ||
+        !hasQuestionTtsCompleted ||
+        isQuestionTtsLoading ||
+        isQuestionPlaying;
+    const shouldShowTtsCompletionNotice = phase === PHASE.REVIEW && !hasQuestionTtsCompleted;
 
     const stopTimer = useCallback(() => {
         if (timerRef.current) {
@@ -914,6 +979,13 @@ const RealInterviewSession = () => {
         if (recordingStreamRef.current) {
             recordingStreamRef.current.getTracks().forEach((track) => track.stop());
             recordingStreamRef.current = null;
+        }
+    }, []);
+
+    const stopVideoCaptureStream = useCallback(() => {
+        if (videoCaptureStreamRef.current) {
+            videoCaptureStreamRef.current.getTracks().forEach((track) => track.stop());
+            videoCaptureStreamRef.current = null;
         }
     }, []);
 
@@ -986,52 +1058,89 @@ const RealInterviewSession = () => {
         }
     }, []);
 
-    const runPostRecordingPipeline = useCallback(async (audioChunks, mimeType = '') => {
+    const runPostRecordingPipeline = useCallback(async (
+        audioChunks,
+        audioMimeType = '',
+        videoChunks = [],
+        videoMimeType = ''
+    ) => {
         if (!Array.isArray(audioChunks) || audioChunks.length === 0) {
             setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
-            toast.error(COPY.micConnectionFailed);
+            toast.error(COPY.recordingAudioMissing);
+            return;
+        }
+        if (!Array.isArray(videoChunks) || videoChunks.length === 0) {
+            setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setIsReviewPanelOpen(true);
+            setPhase(PHASE.REVIEW);
+            toast.error(COPY.recordingVideoMissing);
             return;
         }
         if (!realSessionId) {
             setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
             toast.error(COPY.sessionNotFound);
             return;
         }
 
-        let resolvedMimeType = typeof mimeType === 'string' && mimeType ? mimeType : 'audio/webm';
-        if (!resolvedMimeType || resolvedMimeType === 'application/octet-stream') {
+        let resolvedAudioMimeType =
+            typeof audioMimeType === 'string' && audioMimeType ? audioMimeType : 'audio/webm';
+        if (!resolvedAudioMimeType || resolvedAudioMimeType === 'application/octet-stream') {
             const firstChunkType = toTrimmedString(audioChunks[0]?.type);
             if (firstChunkType) {
-                resolvedMimeType = firstChunkType;
+                resolvedAudioMimeType = firstChunkType;
             }
         }
 
-        const audioBlob = new Blob(audioChunks, { type: resolvedMimeType });
+        let resolvedVideoMimeType =
+            typeof videoMimeType === 'string' && videoMimeType ? videoMimeType : 'video/webm';
+        if (!resolvedVideoMimeType || resolvedVideoMimeType === 'application/octet-stream') {
+            const firstVideoChunkType = toTrimmedString(videoChunks[0]?.type);
+            if (firstVideoChunkType) {
+                resolvedVideoMimeType = firstVideoChunkType;
+            }
+        }
 
-        if (!audioBlob.size) {
+        const audioBlob = new Blob(audioChunks, { type: resolvedAudioMimeType });
+        const videoBlob = new Blob(videoChunks, { type: resolvedVideoMimeType });
+
+        if (!audioBlob.size || !videoBlob.size) {
             setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
-            toast.error(COPY.micConnectionFailed);
+            toast.error(COPY.recordingFileMissing);
             return;
         }
 
         try {
             setPhase(PHASE.UPLOADING);
-            const uploadResult = await uploadAudioBlob({
-                audioBlob,
-                mode: 'REAL',
+            const [audioUploadResult, videoUploadResult] = await Promise.all([
+                uploadAudioBlob({
+                    audioBlob,
+                    mode: 'REAL',
+                }),
+                uploadVideoBlobMultipart({
+                    videoBlob,
+                }),
+            ]);
+
+            setRecordedFileIds({
+                audioFileId: audioUploadResult?.fileId ?? null,
+                videoFileId: videoUploadResult?.fileId ?? null,
             });
 
             setPhase(PHASE.STT);
             const sttResult = await transcribeAudioUrl({
                 userId: realUserId,
                 sessionId: realSessionId,
-                audioUrl: uploadResult.audioUrl,
+                audioUrl: audioUploadResult?.audioUrl ?? '',
             });
             const sttText = toTrimmedString(sttResult?.text);
 
@@ -1039,13 +1148,34 @@ const RealInterviewSession = () => {
             setBadCaseNotice('');
         } catch (error) {
             setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
             toast.error(error?.message || COPY.micConnectionFailed);
         } finally {
             setSeconds(0);
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
         }
-    }, [realSessionId, realUserId, transcribeAudioUrl, uploadAudioBlob]);
+    }, [realSessionId, realUserId, transcribeAudioUrl, uploadAudioBlob, uploadVideoBlobMultipart]);
+
+    const tryRunPostRecordingPipeline = useCallback(() => {
+        const pending = pendingStopResultRef.current;
+        if (!pending.audio || !pending.video) return;
+
+        const audioResult = pending.audio;
+        const videoResult = pending.video;
+
+        pendingStopResultRef.current = {
+            audio: null,
+            video: null,
+        };
+
+        void runPostRecordingPipeline(
+            audioResult.chunks,
+            audioResult.mimeType,
+            videoResult.chunks,
+            videoResult.mimeType
+        );
+    }, [runPostRecordingPipeline]);
 
     const startRecording = useCallback(async () => {
         if (!canStartRecording) return;
@@ -1054,41 +1184,86 @@ const RealInterviewSession = () => {
             return;
         }
 
-        let stream = streamRef.current;
-        if (!stream) {
-            stream = await initializeCamera();
-            if (!stream) return;
+        let cameraStream = streamRef.current;
+        if (!cameraStream) {
+            cameraStream = await initializeCamera();
+            if (!cameraStream) return;
         }
-        stream = await ensureRecordingStream();
-        if (!stream) return;
+
+        const audioStream = await ensureRecordingStream();
+        if (!audioStream) return;
+
+        const videoTrack = cameraStream.getVideoTracks()[0];
+        const micTrack = audioStream.getAudioTracks()[0];
+
+        if (!videoTrack || !micTrack) {
+            setPermissionHint(COPY.micConnectionFailed);
+            return;
+        }
 
         try {
-            const options = getRecorderOptions();
-
-            const recorder = new MediaRecorder(stream, options);
-            mediaRecorderRef.current = recorder;
+            const audioOptions = getAudioRecorderOptions();
+            const audioRecorder = new MediaRecorder(audioStream, audioOptions);
+            mediaRecorderRef.current = audioRecorder;
             recordedChunksRef.current = [];
 
-            recorder.ondataavailable = (event) => {
+            const videoCaptureStream = new MediaStream([
+                videoTrack.clone(),
+                micTrack.clone(),
+            ]);
+            videoCaptureStreamRef.current = videoCaptureStream;
+
+            const videoOptions = getVideoRecorderOptions();
+            const videoRecorder = new MediaRecorder(videoCaptureStream, videoOptions);
+            videoRecorderRef.current = videoRecorder;
+            videoRecordedChunksRef.current = [];
+            pendingStopResultRef.current = { audio: null, video: null };
+
+            audioRecorder.ondataavailable = (event) => {
                 if (event.data.size > 0) {
                     recordedChunksRef.current.push(event.data);
                 }
             };
 
-            recorder.onstop = () => {
+            videoRecorder.ondataavailable = (event) => {
+                if (event.data.size > 0) {
+                    videoRecordedChunksRef.current.push(event.data);
+                }
+            };
+
+            audioRecorder.onstop = () => {
                 const chunks = recordedChunksRef.current;
                 recordedChunksRef.current = [];
-                runPostRecordingPipeline(chunks, recorder.mimeType);
+                pendingStopResultRef.current.audio = {
+                    chunks,
+                    mimeType: audioRecorder.mimeType,
+                };
+                tryRunPostRecordingPipeline();
+            };
+
+            videoRecorder.onstop = () => {
+                const chunks = videoRecordedChunksRef.current;
+                videoRecordedChunksRef.current = [];
+                pendingStopResultRef.current.video = {
+                    chunks,
+                    mimeType: videoRecorder.mimeType,
+                };
+                stopVideoCaptureStream();
+                tryRunPostRecordingPipeline();
             };
 
             setSeconds(0);
             setAutoStopNotice('');
             setBadCaseNotice('');
             setAnalysisNotice('');
+            setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
             setPhase(PHASE.RECORDING);
             startTimer();
-            recorder.start(250);
+            audioRecorder.start(250);
+            videoRecorder.start(250);
         } catch {
+            stopVideoCaptureStream();
             setCameraError(COPY.recordingStartFailed);
             setPhase(PHASE.READY);
             stopTimer();
@@ -1097,22 +1272,50 @@ const RealInterviewSession = () => {
         canStartRecording,
         ensureRecordingStream,
         initializeCamera,
-        runPostRecordingPipeline,
         startTimer,
         stopTimer,
+        stopVideoCaptureStream,
+        tryRunPostRecordingPipeline,
     ]);
 
     const stopRecordingAndSubmit = useCallback(() => {
-        if (!mediaRecorderRef.current) return;
-        if (mediaRecorderRef.current.state === 'inactive') return;
+        const audioRecorder = mediaRecorderRef.current;
+        const videoRecorder = videoRecorderRef.current;
+
+        const isAudioRecording = Boolean(audioRecorder && audioRecorder.state !== 'inactive');
+        const isVideoRecording = Boolean(videoRecorder && videoRecorder.state !== 'inactive');
+        if (!isAudioRecording && !isVideoRecording) return;
 
         stopTimer();
         setPhase(PHASE.UPLOADING);
-        mediaRecorderRef.current.stop();
-    }, [stopTimer]);
+
+        if (isVideoRecording) {
+            videoRecorder.stop();
+        } else {
+            pendingStopResultRef.current.video = {
+                chunks: videoRecordedChunksRef.current,
+                mimeType: '',
+            };
+            videoRecordedChunksRef.current = [];
+            stopVideoCaptureStream();
+        }
+
+        if (isAudioRecording) {
+            audioRecorder.stop();
+        } else {
+            pendingStopResultRef.current.audio = {
+                chunks: recordedChunksRef.current,
+                mimeType: '',
+            };
+            recordedChunksRef.current = [];
+        }
+
+        tryRunPostRecordingPipeline();
+    }, [stopTimer, stopVideoCaptureStream, tryRunPostRecordingPipeline]);
 
     const resetToReady = useCallback(() => {
         setTranscriptDraft('');
+        setRecordedFileIds({ audioFileId: null, videoFileId: null });
         setSeconds(0);
         setAutoStopNotice('');
         setBadCaseNotice('');
@@ -1134,6 +1337,13 @@ const RealInterviewSession = () => {
             return;
         }
 
+        const audioFileId = recordedFileIds.audioFileId;
+        const videoFileId = recordedFileIds.videoFileId;
+        if (!audioFileId || !videoFileId) {
+            toast.error(COPY.recordingFileMissing);
+            return;
+        }
+
         const normalizedCurrentQuestion = toTrimmedString(currentQuestion);
         const historyTurnOrder = (activeSession.interview_history || []).length;
         const historyEntry = {
@@ -1143,6 +1353,8 @@ const RealInterviewSession = () => {
             turn_order: historyTurnOrder,
             topic_id: currentTopicId,
             category: currentCategory,
+            audio_file_id: audioFileId,
+            video_file_id: videoFileId,
         };
 
         const nextInterviewHistory = [...(activeSession.interview_history || []), historyEntry];
@@ -1151,6 +1363,8 @@ const RealInterviewSession = () => {
             question_type: activeSession.question_type || realQuestionType,
             question: normalizedCurrentQuestion,
             answer_text: answerText,
+            audio_file_id: audioFileId,
+            video_file_id: videoFileId,
         };
 
         const submittedAt = new Date().toISOString();
@@ -1197,6 +1411,7 @@ const RealInterviewSession = () => {
 
                 setPhase(PHASE.READY);
                 setTranscriptDraft('');
+                setRecordedFileIds({ audioFileId: null, videoFileId: null });
                 setSeconds(0);
                 setAutoStopNotice('');
                 setBadCaseNotice(noticeMessage);
@@ -1215,6 +1430,8 @@ const RealInterviewSession = () => {
 
             if (isFinished) {
                 const finishedMessage = nextQuestion?.text || COPY.interviewFinishedQuestion;
+                const finishedTurnType = normalizeTurnType(nextQuestion?.turnType, 'session_end');
+                const finishedTurnOrder = normalizeTurnOrder(nextQuestion?.turnOrder, nextInterviewHistory.length);
                 const hasFinishedTtsTarget = Boolean(nextQuestion?.text);
                 const finishedSession = {
                     ...activeSession,
@@ -1228,11 +1445,28 @@ const RealInterviewSession = () => {
 
                 setIsInterviewFinished(true);
                 setCurrentQuestion(finishedMessage);
-                setCurrentTurnType('session_end');
-                setCurrentTurnOrder(nextInterviewHistory.length);
+                setCurrentTurnType(finishedTurnType);
+                setCurrentTurnOrder(finishedTurnOrder);
                 setCurrentTopicId(null);
                 setCurrentCategory('');
+                setQuestionTrail((prev) => {
+                    const nextItem = {
+                        id: `session-end-${finishedTurnOrder}`,
+                        type: getTrailTypeLabel(finishedTurnType, finishedTurnOrder, finishedTurnOrder),
+                        text: finishedMessage,
+                    };
+                    const lastItem = prev[prev.length - 1];
+                    if (
+                        lastItem &&
+                        toTrimmedString(lastItem.text) === nextItem.text &&
+                        toTrimmedString(lastItem.type) === nextItem.type
+                    ) {
+                        return prev;
+                    }
+                    return [...prev, nextItem];
+                });
                 setTranscriptDraft('');
+                setRecordedFileIds({ audioFileId: null, videoFileId: null });
                 setPhase(PHASE.READY);
                 if (hasFinishedTtsTarget) {
                     stopQuestionTtsPlayback();
@@ -1260,7 +1494,24 @@ const RealInterviewSession = () => {
                 setCurrentTurnOrder(nextInterviewHistory.length);
                 setCurrentTopicId(null);
                 setCurrentCategory('');
+                setQuestionTrail((prev) => {
+                    const nextItem = {
+                        id: `session-end-${nextInterviewHistory.length}`,
+                        type: getTrailTypeLabel('session_end', nextInterviewHistory.length, nextInterviewHistory.length),
+                        text: COPY.interviewFinishedQuestion,
+                    };
+                    const lastItem = prev[prev.length - 1];
+                    if (
+                        lastItem &&
+                        toTrimmedString(lastItem.text) === nextItem.text &&
+                        toTrimmedString(lastItem.type) === nextItem.type
+                    ) {
+                        return prev;
+                    }
+                    return [...prev, nextItem];
+                });
                 setTranscriptDraft('');
+                setRecordedFileIds({ audioFileId: null, videoFileId: null });
                 setPhase(PHASE.READY);
                 toast.error(COPY.nextQuestionMissing);
                 return;
@@ -1299,11 +1550,12 @@ const RealInterviewSession = () => {
                 ...prev,
                 {
                     id: `follow-up-${nextRound}`,
-                    type: `${COPY.followUpQuestionPrefix} ${nextRound - 1}`,
+                    type: getTrailTypeLabel(nextTurnType, nextTurnOrder, nextRound - 1),
                     text: nextQuestionText,
                 },
             ]);
             setTranscriptDraft('');
+            setRecordedFileIds({ audioFileId: null, videoFileId: null });
             setSeconds(0);
             setAutoStopNotice('');
             setPhase(PHASE.READY);
@@ -1320,6 +1572,7 @@ const RealInterviewSession = () => {
         playQuestionTtsText,
         realQuestionType,
         realSessionId,
+        recordedFileIds,
         seconds,
         stopQuestionTtsPlayback,
         transcriptDraft,
@@ -1397,11 +1650,16 @@ const RealInterviewSession = () => {
             mediaRecorderRef.current.onstop = null;
             mediaRecorderRef.current.stop();
         }
+        if (videoRecorderRef.current && videoRecorderRef.current.state !== 'inactive') {
+            videoRecorderRef.current.onstop = null;
+            videoRecorderRef.current.stop();
+        }
+        stopVideoCaptureStream();
         stopRecordingStream();
         stopStream();
         safeRemoveSessionItem(REAL_SESSION_STORAGE_KEY);
         navigate(-1);
-    }, [navigate, stopQuestionTtsPlayback, stopRecordingStream, stopStream, stopTimer]);
+    }, [navigate, stopQuestionTtsPlayback, stopRecordingStream, stopStream, stopTimer, stopVideoCaptureStream]);
 
     const handleExitCancel = useCallback(() => {
         setIsExitDialogOpen(false);
@@ -1456,9 +1714,11 @@ const RealInterviewSession = () => {
                 setQuestionTrail([
                     {
                         id: `turn-${normalizeTurnOrder(currentQuestionFromStorage.turn_order, currentTurnOrderFallback)}`,
-                        type: isTopicTurnType(currentQuestionFromStorage.turn_type)
-                            ? ORIGIN_QUESTION_TYPE
-                            : `${COPY.followUpQuestionPrefix} ${Math.max(initialRound - 1, 1)}`,
+                        type: getTrailTypeLabel(
+                            currentQuestionFromStorage.turn_type,
+                            currentQuestionFromStorage.turn_order,
+                            Math.max(initialRound - 1, 1)
+                        ),
                         text: currentQuestionFromStorage.question,
                     },
                 ]);
@@ -1508,15 +1768,16 @@ const RealInterviewSession = () => {
                     setQuestionTrail([
                         {
                             id: `turn-${turnOrder}`,
-                            type: turnType === 'main'
-                                ? ORIGIN_QUESTION_TYPE
-                                : `${COPY.followUpQuestionPrefix} ${Math.max(turnOrder - 1, 1)}`,
+                            type: getTrailTypeLabel(turnType, turnOrder, Math.max(turnOrder - 1, 1)),
                             text: resolvedQuestion.text,
                         },
                     ]);
                 }
 
                 if (isFinished) {
+                    const finishedMessage = resolvedQuestion?.text || COPY.interviewFinishedQuestion;
+                    const finishedTurnType = normalizeTurnType(resolvedQuestion?.turnType, 'session_end');
+                    const finishedTurnOrder = normalizeTurnOrder(resolvedQuestion?.turnOrder, initialRound);
                     const finishedSession = {
                         ...normalizedSession,
                         current_question: null,
@@ -1526,11 +1787,27 @@ const RealInterviewSession = () => {
                     persistRealSession(finishedSession);
 
                     setIsInterviewFinished(true);
-                    setCurrentQuestion(COPY.interviewFinishedQuestion);
-                    setCurrentTurnType('follow_up');
-                    setCurrentTurnOrder(initialRound);
+                    setCurrentQuestion(finishedMessage);
+                    setCurrentTurnType(finishedTurnType);
+                    setCurrentTurnOrder(finishedTurnOrder);
                     setCurrentTopicId(null);
                     setCurrentCategory('');
+                    setQuestionTrail((prev) => {
+                        const nextItem = {
+                            id: `session-end-${finishedTurnOrder}`,
+                            type: getTrailTypeLabel(finishedTurnType, finishedTurnOrder, finishedTurnOrder),
+                            text: finishedMessage,
+                        };
+                        const lastItem = prev[prev.length - 1];
+                        if (
+                            lastItem &&
+                            toTrimmedString(lastItem.text) === nextItem.text &&
+                            toTrimmedString(lastItem.type) === nextItem.type
+                        ) {
+                            return prev;
+                        }
+                        return [...prev, nextItem];
+                    });
                     setIsInterviewStarted(true);
                     setIsStartGateOpen(false);
                 }
@@ -1565,10 +1842,23 @@ const RealInterviewSession = () => {
                 mediaRecorderRef.current.onstop = null;
                 mediaRecorderRef.current.stop();
             }
+            if (videoRecorderRef.current && videoRecorderRef.current.state !== 'inactive') {
+                videoRecorderRef.current.onstop = null;
+                videoRecorderRef.current.stop();
+            }
+            stopVideoCaptureStream();
             stopRecordingStream();
             stopStream();
         };
-    }, [initializeCamera, isInterviewStarted, stopQuestionTtsPlayback, stopRecordingStream, stopStream, stopTimer]);
+    }, [
+        initializeCamera,
+        isInterviewStarted,
+        stopQuestionTtsPlayback,
+        stopRecordingStream,
+        stopStream,
+        stopTimer,
+        stopVideoCaptureStream,
+    ]);
 
     useEffect(() => {
         if (!isStartGateOpen || isInterviewStarted || isInterviewFinished) {
@@ -1583,6 +1873,16 @@ const RealInterviewSession = () => {
         if (!streamRef.current) return;
         attachStreamToVideo(streamRef.current);
     }, [attachStreamToVideo, cameraState]);
+
+    useEffect(() => {
+        const normalizedQuestion = toTrimmedString(currentQuestion);
+        if (!realSessionId || !normalizedQuestion) {
+            setHasQuestionTtsCompleted(true);
+            return;
+        }
+
+        setHasQuestionTtsCompleted(false);
+    }, [currentQuestion, realSessionId]);
 
     useEffect(() => {
         if (phase === PHASE.REVIEW) {
@@ -1768,7 +2068,7 @@ const RealInterviewSession = () => {
                         </div>
                     )}
 
-                    {(isProcessing || permissionHint || autoStopNotice || badCaseNotice || analysisNotice || isTimeWarning) && (
+                    {(isProcessing || permissionHint || autoStopNotice || badCaseNotice || analysisNotice || isTimeWarning || shouldShowTtsCompletionNotice) && (
                         <div className="absolute left-3.5 right-3.5 top-[226px] z-[3] flex flex-col gap-2">
                             {isProcessing && (
                                 <div className={`${BUBBLE_BASE} flex items-center gap-2.5 rounded-xl px-3 py-2.5`}>
@@ -1801,6 +2101,11 @@ const RealInterviewSession = () => {
                                     <p className="m-0 text-xs font-medium text-white/95">{toRenderableText(analysisNotice)}</p>
                                 </div>
                             )}
+                            {shouldShowTtsCompletionNotice && (
+                                <div className={`${BUBBLE_BASE} border-[#ff6b8a]/90 flex items-center gap-2.5 rounded-xl px-3 py-2.5`}>
+                                    <p className="m-0 text-xs font-medium text-white/95">{COPY.questionTtsCompletionRequired}</p>
+                                </div>
+                            )}
                         </div>
                     )}
 
@@ -1817,7 +2122,7 @@ const RealInterviewSession = () => {
                                 <Button
                                     className="min-h-[50px] flex-1 rounded-[14px]"
                                     onClick={submitTranscript}
-                                    disabled={!transcriptDraft.trim()}
+                                    disabled={isReviewSubmitDisabled}
                                 >
                                     {COPY.submitAndNext}
                                 </Button>

--- a/src/app/pages/RealLearningRecordDetail.jsx
+++ b/src/app/pages/RealLearningRecordDetail.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AppHeader } from '@/app/components/AppHeader';
 import { Card } from '@/app/components/ui/card';
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { useAnswerDetail } from '@/app/hooks/useAnswerDetail';
+import { getFileReadPresignedUrl } from '@/api/fileApi';
 
 const TEXT_PAGE_TITLE = '실전 학습 기록 상세';
 const TEXT_HEADER_DESC = '실전 면접 결과와 AI 피드백을 확인해보세요';
@@ -36,6 +37,13 @@ const TEXT_MISSING = '누락 키워드';
 const TEXT_NONE = '없음';
 const TEXT_FEEDBACK_EMPTY = '피드백 정보가 없습니다.';
 const TEXT_RADAR_LABEL = '평가';
+const TEXT_INTERVIEW_VIDEO_TITLE = '질문별 답변 영상';
+const TEXT_INTERVIEW_VIDEO_EMPTY = '표시할 답변 영상이 없습니다.';
+const TEXT_TURN_LABEL = '주제';
+const TEXT_VIDEO_LABEL = '답변 영상';
+const TEXT_VIDEO_EXPIRES_LABEL = '영상 링크 만료 시 새로고침 해주세요.';
+const TEXT_VIDEO_MISSING_CARD = '영상이 없습니다.';
+const TEXT_VIDEO_LOADING = '영상 불러오는 중...';
 
 const FEEDBACK_SPLIT_DELIMITER = '●';
 const FEEDBACK_BULLET = '•';
@@ -102,6 +110,73 @@ const toCoveragePercent = (coverageRatio) => {
   return Math.round(normalized * 100);
 };
 
+const toTurnOrder = (value, fallbackOrder) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === 'string' && /^-?\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10);
+  }
+  return fallbackOrder;
+};
+
+const toFileId = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return parsed > 0 ? parsed : null;
+  }
+  return null;
+};
+
+const buildTurnVideoKey = (turnOrder, index) => `${turnOrder}-${index}`;
+
+const parseAmzDateMs = (value) => {
+  const normalized = toTrimmedString(value);
+  const match = normalized.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/
+  );
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, second] = match;
+  const timestamp = Date.UTC(
+    Number.parseInt(year, 10),
+    Number.parseInt(month, 10) - 1,
+    Number.parseInt(day, 10),
+    Number.parseInt(hour, 10),
+    Number.parseInt(minute, 10),
+    Number.parseInt(second, 10)
+  );
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const isExpiredS3PresignedUrl = (resourceUrl) => {
+  const normalizedUrl = toTrimmedString(resourceUrl);
+  if (!normalizedUrl) return true;
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(normalizedUrl);
+  } catch {
+    return false;
+  }
+
+  const amzDateRaw =
+    parsedUrl.searchParams.get('X-Amz-Date') ??
+    parsedUrl.searchParams.get('x-amz-date');
+  const expiresRaw =
+    parsedUrl.searchParams.get('X-Amz-Expires') ??
+    parsedUrl.searchParams.get('x-amz-expires');
+
+  const issuedAtMs = parseAmzDateMs(amzDateRaw);
+  if (issuedAtMs === null) return false;
+
+  const expiresSeconds = Number.parseInt(toTrimmedString(expiresRaw), 10);
+  if (!Number.isFinite(expiresSeconds) || expiresSeconds < 0) return false;
+
+  return Date.now() >= issuedAtMs + expiresSeconds * 1000;
+};
+
 const hasRealFeedbackShape = (candidate) => {
   if (!candidate || typeof candidate !== 'object') return false;
   return Boolean(
@@ -143,6 +218,12 @@ const RealLearningRecordDetail = () => {
   const navigate = useNavigate();
   const { answerId } = useParams();
   const { data, isLoading, error } = useAnswerDetail(answerId);
+  const [resolvedVideoSources, setResolvedVideoSources] = useState({});
+  const [videoLoadFailedMap, setVideoLoadFailedMap] = useState({});
+  const [videoReadyMap, setVideoReadyMap] = useState({});
+  const videoReadUrlCacheRef = useRef(new Map());
+  const inFlightVideoReadUrlRef = useRef(new Map());
+  const refreshingTurnVideoRef = useRef(new Set());
 
   const answerDetail = useMemo(() => {
     const resolved = data?.data ?? data;
@@ -194,11 +275,165 @@ const RealLearningRecordDetail = () => {
   );
   const hasKeywordSummary = coveredKeywords.length > 0 || missingKeywords.length > 0;
   const hasRadarData = radarData.length > 0;
+  const interviewHistory = useMemo(() => {
+    const rows = Array.isArray(feedbackData?.interview_history)
+      ? feedbackData.interview_history
+      : [];
+
+    return rows
+      .map((item, idx) => {
+        const videoPlayUrl = toTrimmedString(
+          item?.video_play_url ??
+            item?.videoPlayUrl ??
+            item?.video_url ??
+            item?.videoUrl ??
+            item?.play_url ??
+            item?.playUrl
+        );
+
+        return {
+          turnOrder: toTurnOrder(item?.turn_order ?? item?.turnOrder, idx),
+          turnType: toTrimmedString(item?.turn_type ?? item?.turnType),
+          question: toTrimmedString(item?.question),
+          answerText: toTrimmedString(item?.answer_text ?? item?.answerText),
+          category: toTrimmedString(item?.category),
+          videoPlayUrl,
+          videoPlayUrlExpired: isExpiredS3PresignedUrl(videoPlayUrl),
+          videoExpiresAt: toTrimmedString(
+            item?.video_url_expires_at ??
+              item?.videoUrlExpiresAt ??
+              item?.video_expires_at ??
+              item?.videoExpiresAt
+          ),
+          videoFileId: toFileId(item?.video_file_id ?? item?.videoFileId),
+        };
+      })
+      .sort((a, b) => a.turnOrder - b.turnOrder);
+  }, [feedbackData]);
+
+  const getTurnVideoReadUrl = useCallback(async (fileId, { forceRefresh = false } = {}) => {
+    const normalizedFileId = toFileId(fileId);
+    if (!normalizedFileId) return '';
+    const fileIdKey = String(normalizedFileId);
+
+    if (forceRefresh) {
+      videoReadUrlCacheRef.current.delete(fileIdKey);
+      inFlightVideoReadUrlRef.current.delete(fileIdKey);
+    } else {
+      const cachedUrl = toTrimmedString(videoReadUrlCacheRef.current.get(fileIdKey));
+      if (cachedUrl) return cachedUrl;
+    }
+
+    let readPromise = inFlightVideoReadUrlRef.current.get(fileIdKey);
+    if (!readPromise) {
+      readPromise = getFileReadPresignedUrl(normalizedFileId)
+        .then((readResult) => {
+          const readPayload = readResult?.data ?? readResult ?? {};
+          return toTrimmedString(readPayload.presignedUrl ?? readPayload.presigned_url);
+        })
+        .finally(() => {
+          inFlightVideoReadUrlRef.current.delete(fileIdKey);
+        });
+      inFlightVideoReadUrlRef.current.set(fileIdKey, readPromise);
+    }
+
+    const resolvedUrl = toTrimmedString(await readPromise);
+    if (resolvedUrl) {
+      videoReadUrlCacheRef.current.set(fileIdKey, resolvedUrl);
+    }
+    return resolvedUrl;
+  }, []);
+
+  const handleTurnVideoLoadError = useCallback(async (turn, turnIndex) => {
+    const turnKey = buildTurnVideoKey(turn?.turnOrder, turnIndex);
+
+    if (!turn?.videoFileId) {
+      setVideoLoadFailedMap((prev) => ({ ...prev, [turnKey]: true }));
+      return;
+    }
+    if (refreshingTurnVideoRef.current.has(turnKey)) {
+      return;
+    }
+
+    refreshingTurnVideoRef.current.add(turnKey);
+    try {
+      const refreshedUrl = await getTurnVideoReadUrl(turn.videoFileId, { forceRefresh: true });
+      if (!refreshedUrl) {
+        throw new Error('empty_video_url');
+      }
+
+      setResolvedVideoSources((prev) => ({
+        ...prev,
+        [turnKey]: refreshedUrl,
+      }));
+      setVideoLoadFailedMap((prev) => {
+        if (!prev[turnKey]) return prev;
+        const next = { ...prev };
+        delete next[turnKey];
+        return next;
+      });
+    } catch {
+      setVideoLoadFailedMap((prev) => ({ ...prev, [turnKey]: true }));
+    } finally {
+      refreshingTurnVideoRef.current.delete(turnKey);
+    }
+  }, [getTurnVideoReadUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadTurnVideos = async () => {
+      const targets = interviewHistory
+        .map((turn, idx) => ({ turn, idx }))
+        .filter(
+          ({ turn }) =>
+            (!turn.videoPlayUrl || turn.videoPlayUrlExpired) &&
+            Boolean(turn.videoFileId)
+        );
+
+      if (targets.length === 0) {
+        if (!cancelled) setResolvedVideoSources({});
+        return;
+      }
+
+      const nextVideoSources = {};
+
+      for (let idx = 0; idx < targets.length; idx += 1) {
+        const turn = targets[idx]?.turn;
+        const originalIndex = targets[idx]?.idx ?? idx;
+        if (!turn) continue;
+
+        try {
+          const fallbackUrl = toTrimmedString(await getTurnVideoReadUrl(turn.videoFileId));
+          if (!fallbackUrl) continue;
+          nextVideoSources[buildTurnVideoKey(turn.turnOrder, originalIndex)] = fallbackUrl;
+        } catch {
+          // fallback URL 조회 실패 시 해당 턴은 텍스트만 표시
+        }
+      }
+
+      if (cancelled) return;
+      setResolvedVideoSources(nextVideoSources);
+    };
+
+    void loadTurnVideos();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getTurnVideoReadUrl, interviewHistory]);
+
+  useEffect(() => {
+    setVideoLoadFailedMap({});
+  }, [interviewHistory, resolvedVideoSources]);
+
+  useEffect(() => {
+    setVideoReadyMap({});
+  }, [interviewHistory, resolvedVideoSources]);
 
   const questionText = toTrimmedString(
     answerDetail?.question?.content ?? answerDetail?.question?.title
   );
-  const answerText = toTrimmedString(answerDetail?.content ?? answerDetail?.answer_text);
 
   if (isLoading) {
     return (
@@ -273,22 +508,6 @@ const RealLearningRecordDetail = () => {
       </div>
 
       <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-        {questionText && (
-          <Card className="p-5 bg-white shadow-sm">
-            <p className="text-sm text-muted-foreground mb-2">{TEXT_QUESTION_LABEL}</p>
-            <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{questionText}</p>
-          </Card>
-        )}
-
-        {answerText && (
-          <Card className="p-5">
-            <p className="text-sm text-muted-foreground mb-2">{TEXT_MY_ANSWER_LABEL}</p>
-            <div className="h-44 overflow-y-auto overscroll-contain pr-1">
-              <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{answerText}</p>
-            </div>
-          </Card>
-        )}
-
         <Card className="p-5 bg-white shadow-lg">
           <div className="flex items-center gap-2 mb-4">
             <Sparkles className="w-5 h-5 text-pink-600" />
@@ -305,6 +524,98 @@ const RealLearningRecordDetail = () => {
             </ResponsiveContainer>
           ) : (
             <p className="text-sm text-muted-foreground">{TEXT_FEEDBACK_EMPTY}</p>
+          )}
+        </Card>
+
+        {questionText && (
+          <Card className="p-5 bg-white shadow-sm">
+            <p className="text-sm text-muted-foreground mb-2">{TEXT_QUESTION_LABEL}</p>
+            <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{questionText}</p>
+          </Card>
+        )}
+
+        <Card className="p-5 bg-white shadow-sm space-y-4">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-pink-600" />
+            <h3>{TEXT_INTERVIEW_VIDEO_TITLE}</h3>
+          </div>
+          {interviewHistory.length > 0 ? (
+            <div className="space-y-4">
+              {interviewHistory.map((turn, idx) => {
+                const turnKey = buildTurnVideoKey(turn.turnOrder, idx);
+                const resolvedVideoUrl = toTrimmedString(
+                  resolvedVideoSources[turnKey] ?? turn.videoPlayUrl
+                );
+                const hasVideoLoadFailed = Boolean(videoLoadFailedMap[turnKey]);
+                const canRenderVideoPlayer = Boolean(resolvedVideoUrl) && !hasVideoLoadFailed;
+                const displayTopicOrder = Math.max(turn.turnOrder + 1, 1);
+
+                return (
+                  <div key={turnKey} className="rounded-xl border border-rose-100 bg-rose-50/50 p-4 space-y-3">
+                    <p className="text-sm font-semibold text-rose-700">
+                      {TEXT_TURN_LABEL} {displayTopicOrder}
+                      {turn.category ? ` · ${turn.category}` : ''}
+                    </p>
+                    {turn.question && (
+                      <div className="space-y-1">
+                        <p className="text-xs text-muted-foreground">{TEXT_QUESTION_LABEL}</p>
+                        <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{turn.question}</p>
+                      </div>
+                    )}
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{TEXT_VIDEO_LABEL}</p>
+                      {canRenderVideoPlayer ? (
+                        <div className="relative">
+                          <video
+                            controls
+                            preload="metadata"
+                            playsInline
+                            className="w-full aspect-video rounded-lg border border-gray-200 bg-black"
+                            src={resolvedVideoUrl}
+                            onError={() => {
+                              void handleTurnVideoLoadError(turn, idx);
+                            }}
+                            onLoadedData={() => {
+                              setVideoReadyMap((prev) => ({ ...prev, [turnKey]: true }));
+                              setVideoLoadFailedMap((prev) => {
+                                if (!prev[turnKey]) return prev;
+                                const next = { ...prev };
+                                delete next[turnKey];
+                                return next;
+                              });
+                            }}
+                          />
+                          {!videoReadyMap[turnKey] && (
+                            <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-black/65">
+                              <p className="text-xs text-white/90">{TEXT_VIDEO_LOADING}</p>
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-5 text-center">
+                          <p className="text-sm font-medium text-gray-600">{TEXT_VIDEO_MISSING_CARD}</p>
+                        </div>
+                      )}
+                      {canRenderVideoPlayer && (
+                        <p className="text-xs text-muted-foreground">
+                          {turn.videoExpiresAt
+                            ? `${TEXT_VIDEO_EXPIRES_LABEL} (${turn.videoExpiresAt})`
+                            : TEXT_VIDEO_EXPIRES_LABEL}
+                        </p>
+                      )}
+                    </div>
+                    {turn.answerText && (
+                      <div className="space-y-1">
+                        <p className="text-xs text-muted-foreground">{TEXT_MY_ANSWER_LABEL}</p>
+                        <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{turn.answerText}</p>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">{TEXT_INTERVIEW_VIDEO_EMPTY}</p>
           )}
         </Card>
 


### PR DESCRIPTION
## 요약
  - 실전 면접 답변 제출 플로우를 오디오/비디오 파일 기반으로 보강했습니다.
  - 질문 TTS 재생이 끝나기 전에는 `답변 제출하고 다음 질문 받기` 버튼이 비활성화되도록 변경했습니다.
  - 실전 학습 기록 상세에서 질문별 영상 노출 안정성을 개선했습니다. (만료된 presigned URL 재발급)
  - 질문별 답변 카드에 `내 답변(텍스트)`를 표시하고, `종합 역량 점수` 카드를 최상단으로 재배치했습니다.

  ## 변경 파일
  - `src/api/fileApi.js`
  - `src/api/interviewApi.js`
  - `src/api/ttsApi.js`
  - `src/app/hooks/useAudioSttPipeline.js`
  - `src/app/hooks/useQuestionTtsPlayer.js`
  - `src/app/pages/RealInterviewSession.jsx`
  - `src/app/pages/RealLearningRecordDetail.jsx`

  ## 구현 의도
  - 영상 URL이 `video_play_url`에 있어도 presigned URL 만료로 재생 실패하는 케이스를 프론트에서
  복구 가능하게 처리했습니다.
  - 녹화 업로드를 오디오/비디오 분리 및 멀티파트 업로드로 확장해 실전 모드 데이터 정합성을 높였
  습니다.
  - TTS 재생 완료 이벤트를 명확히 감지해 면접 UX 요구사항(질문 청취 후 제출)을 강제했습니다.
  - 영상 카드에 `metadata preload`, 고정 비율(`aspect-video`), 로딩 오버레이를 적용해 “영상 없
  음”처럼 보이는 문제를 완화했습니다.

  ## 목적
  - 실전 모드 면접 흐름의 신뢰성과 일관성 향상
  - 학습 기록 상세에서 영상 재생 실패율 감소
  - 사용자 혼동(영상 미노출/만료 URL/버튼 활성 시점) 최소화

  ## 관련 커밋
  - #170 