### PR TITLE
branch conflict로 인하여 과거 PR 삭제로 재 생성(#173)

### DIFF
--- a/src/app/components/ui/sonner.jsx
+++ b/src/app/components/ui/sonner.jsx
@@ -1,12 +1,18 @@
 import { useTheme } from "next-themes";
 import { Toaster as Sonner } from "sonner";
 
-const Toaster = ({ ...props }) => {
+const Toaster = ({
+    position = "top-center",
+    swipeDirections = ["top", "left", "right"],
+    ...props
+}) => {
     const { theme = "system" } = useTheme();
 
     return (
         <Sonner
             theme={theme}
+            position={position}
+            swipeDirections={swipeDirections}
             className="toaster group"
             style={
                 {

--- a/src/app/hooks/useQuestionTtsPlayer.js
+++ b/src/app/hooks/useQuestionTtsPlayer.js
@@ -25,6 +25,7 @@ export function useQuestionTtsPlayer({
 
     const [isLoading, setIsLoading] = useState(false);
     const [isPlaying, setIsPlaying] = useState(false);
+    const [remainingSeconds, setRemainingSeconds] = useState(null);
 
     const isAbortError = useCallback((error) => {
         const name = typeof error?.name === 'string' ? error.name : '';
@@ -40,6 +41,8 @@ export function useQuestionTtsPlayer({
 
         if (audioRef.current) {
             audioRef.current.onended = null;
+            audioRef.current.onloadedmetadata = null;
+            audioRef.current.ontimeupdate = null;
             audioRef.current.onpause = null;
             audioRef.current.pause();
             audioRef.current = null;
@@ -52,6 +55,24 @@ export function useQuestionTtsPlayer({
 
         setIsLoading(false);
         setIsPlaying(false);
+        setRemainingSeconds(null);
+    }, []);
+
+    const updateRemainingSeconds = useCallback((audioElement) => {
+        if (!audioElement) {
+            setRemainingSeconds(null);
+            return;
+        }
+
+        const duration = Number.isFinite(audioElement.duration) ? audioElement.duration : 0;
+        const currentTime = Number.isFinite(audioElement.currentTime) ? audioElement.currentTime : 0;
+
+        if (duration <= 0) {
+            setRemainingSeconds(null);
+            return;
+        }
+
+        setRemainingSeconds(Math.max(0, Math.ceil(duration - currentTime)));
     }, []);
 
     const playText = useCallback(async (text, { silent = false, allowFinishedText = false } = {}) => {
@@ -106,9 +127,20 @@ export function useQuestionTtsPlayer({
             const audio = new Audio(objectUrl);
             audio.preload = 'auto';
             audioRef.current = audio;
+            audio.onloadedmetadata = () => {
+                if (requestSequenceRef.current === requestSequence) {
+                    updateRemainingSeconds(audio);
+                }
+            };
+            audio.ontimeupdate = () => {
+                if (requestSequenceRef.current === requestSequence) {
+                    updateRemainingSeconds(audio);
+                }
+            };
             audio.onended = () => {
                 if (requestSequenceRef.current === requestSequence) {
                     setIsPlaying(false);
+                    setRemainingSeconds(0);
                     onPlaybackEnded?.({
                         text: normalizedText,
                         sessionId: normalizedSessionId,
@@ -133,6 +165,7 @@ export function useQuestionTtsPlayer({
                 return false;
             }
             setIsPlaying(true);
+            updateRemainingSeconds(audio);
             return true;
         } catch (error) {
             if (isAbortError(error)) {
@@ -167,6 +200,7 @@ export function useQuestionTtsPlayer({
         sessionId,
         stop,
         userId,
+        updateRemainingSeconds,
     ]);
 
     const play = useCallback(async ({ silent = false } = {}) => {
@@ -220,6 +254,7 @@ export function useQuestionTtsPlayer({
     return {
         isLoading,
         isPlaying,
+        remainingSeconds,
         play,
         playText,
         stop,

--- a/src/app/pages/LearningRecordDetail.jsx
+++ b/src/app/pages/LearningRecordDetail.jsx
@@ -9,6 +9,7 @@ import { useAnswerDetail } from '@/app/hooks/useAnswerDetail'
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories'
 import { useQuestionTypes } from '@/app/hooks/useQuestionTypes'
 import { getQuestionCategoryLabel, getQuestionTypeLabel } from '@/app/constants/questionCategoryMeta'
+import { sortMetricsByDisplayOrder } from '@/app/utils/metricOrder'
 
 const TEXT_PAGE_TITLE = '학습 기록 상세'
 const TEXT_HEADER_DESC = '제출한 답변과 AI 피드백을 확인해보세요'
@@ -109,7 +110,11 @@ const LearningRecordDetail = () => {
     : Array.isArray(aiFeedback?.radarChart)
       ? aiFeedback.radarChart
       : []
-  const radarData = metrics.map((metric) => ({
+  const sortedMetrics = sortMetricsByDisplayOrder(
+    metrics,
+    (metric) => metric?.subject ?? metric?.metricName ?? metric?.name ?? metric?.label
+  )
+  const radarData = sortedMetrics.map((metric) => ({
     ...metric,
     subject: metric?.subject ?? metric?.metricName ?? metric?.name ?? metric?.label ?? '평가',
     value: normalizeRadarValue(metric),
@@ -131,7 +136,7 @@ const LearningRecordDetail = () => {
     ? getQuestionTypeLabel(question.type, QUESTION_TYPE_LABELS)
     : null
   const questionCategory = question?.category ? (
-    <Badge variant="secondary" className="bg-rose-100 text-rose-700">
+    <Badge variant="secondary" className="bg-primary-100 text-primary-700">
       {getQuestionCategoryLabel(question.category, CATEGORY_LABELS)}
     </Badge>
   ) : null
@@ -142,7 +147,7 @@ const LearningRecordDetail = () => {
         <AppHeader title={TEXT_PAGE_TITLE} onBack={() => navigate('/profile')} showNotifications={false} />
         <div className="p-6 max-w-lg mx-auto">
           <Card className="p-6 flex items-center gap-3">
-            <Loader2 className="w-5 h-5 animate-spin text-pink-600" />
+            <Loader2 className="w-5 h-5 animate-spin text-primary-500" />
             <p className="text-sm text-muted-foreground">{TEXT_LOADING}</p>
           </Card>
         </div>
@@ -152,29 +157,29 @@ const LearningRecordDetail = () => {
 
   if (error || !hasAnswerDetail) {
     return (
-      <div className="min-h-screen bg-background">
-        <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+      <div className="min-h-screen bg-gradient-to-b from-secondary-50 via-white to-secondary-50">
+        <div className="border-b border-primary-100/80 bg-gradient-to-r from-primary-50 via-white to-secondary-50 text-gray-900">
           <AppHeader
             title={TEXT_PAGE_TITLE}
             onBack={() => navigate('/profile')}
             showNotifications={false}
-            tone="dark"
+            tone="light"
             className="!static"
           />
           <div className="text-center pb-6 pt-1 px-6">
-            <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+            <p className="text-gray-600 text-sm">{TEXT_HEADER_DESC}</p>
           </div>
         </div>
 
-        <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+        <div className="p-6 max-w-lg mx-auto space-y-4 -mt-3">
+          <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
             <div className="flex items-start gap-3">
-              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                <AlertCircle className="w-5 h-5 text-rose-600" />
+              <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-5 h-5 text-amber-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-rose-800">{error?.message || TEXT_NOT_FOUND}</p>
-                <p className="text-xs text-rose-700 mt-1">{TEXT_RETRY_HELP}</p>
+                <p className="text-sm text-amber-800">{error?.message || TEXT_NOT_FOUND}</p>
+                <p className="text-xs text-amber-700 mt-1">{TEXT_RETRY_HELP}</p>
               </div>
             </div>
           </Card>
@@ -193,28 +198,28 @@ const LearningRecordDetail = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+    <div className="min-h-screen bg-gradient-to-b from-secondary-50 via-white to-secondary-50">
+      <div className="border-b border-primary-100/80 bg-gradient-to-r from-primary-50 via-white to-secondary-50 text-gray-900">
         <AppHeader
           title={TEXT_PAGE_TITLE}
           onBack={() => navigate('/profile')}
           showNotifications={false}
-          tone="dark"
+          tone="light"
           className="!static"
         />
 
         <div className="text-center pb-6 pt-1 px-6">
-          <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+          <p className="text-gray-600 text-sm">{TEXT_HEADER_DESC}</p>
         </div>
       </div>
 
-      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-        <Card className="p-5 bg-white shadow-lg">
+      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-3">
+        <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm">
           <div className="flex items-center justify-between mb-3">
             <p className="text-sm text-muted-foreground">{TEXT_QUESTION_LABEL}</p>
             <div className="flex items-center gap-2">
               {questionTypeLabel && (
-                <Badge variant="outline" className="text-pink-700 border-pink-200">
+                <Badge variant="outline" className="text-primary-700 border-primary-200 bg-white">
                   {questionTypeLabel}
                 </Badge>
               )}
@@ -225,7 +230,7 @@ const LearningRecordDetail = () => {
           <p className="text-xs text-muted-foreground text-right mt-3">{formatDateTime(detail?.createdAt)}</p>
         </Card>
 
-        <Card className="p-5">
+        <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm">
           <p className="text-sm text-muted-foreground mb-2">{TEXT_MY_ANSWER_LABEL}</p>
           <div className="h-44 overflow-y-auto overscroll-contain pr-1">
             <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">
@@ -235,9 +240,9 @@ const LearningRecordDetail = () => {
         </Card>
 
         {hasRadarChart && (
-          <Card className="p-5 bg-white shadow-lg">
+          <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm">
             <div className="flex items-center gap-2 mb-4">
-              <Sparkles className="w-5 h-5 text-pink-600" />
+              <Sparkles className="w-5 h-5 text-primary-500" />
               <h3>{TEXT_RADAR_TITLE}</h3>
             </div>
             <ResponsiveContainer width="100%" height={250}>
@@ -245,41 +250,41 @@ const LearningRecordDetail = () => {
                 <PolarGrid />
                 <PolarAngleAxis dataKey="subject" />
                 <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} axisLine={false} />
-                <Radar name="평가" dataKey="value" stroke="#ec4899" fill="#ec4899" fillOpacity={0.6} />
+                <Radar name="평가" dataKey="value" stroke="#ff8fa3" fill="#ffccd5" fillOpacity={0.8} />
               </RadarChart>
             </ResponsiveContainer>
           </Card>
         )}
 
         {hasRadarChart && (
-          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+          <Card className="p-5 rounded-2xl border border-emerald-100 bg-emerald-50/70 shadow-sm">
             <div className="flex items-start gap-3">
-              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                <ThumbsUp className="w-5 h-5 text-pink-600" />
+              <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+                <ThumbsUp className="w-5 h-5 text-emerald-600" />
               </div>
               <div className="flex-1">
-                <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
-                {renderFeedbackText(strengthsText, 'text-sm text-rose-800')}
+                <h3 className="mb-2 text-emerald-900">{TEXT_STRENGTHS_TITLE}</h3>
+                {renderFeedbackText(strengthsText, 'text-sm text-gray-700')}
               </div>
             </div>
           </Card>
         )}
 
-        <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+        <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
           <div className="flex items-start gap-3">
-            <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
-              <AlertCircle className="w-5 h-5 text-pink-600" />
+            <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+              <AlertCircle className="w-5 h-5 text-amber-600" />
             </div>
             <div className="flex-1">
-              <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
-              {renderFeedbackText(mergedImprovementsText, 'text-sm text-pink-800')}
+              <h3 className="mb-2 text-amber-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+              {renderFeedbackText(mergedImprovementsText, 'text-sm text-gray-700')}
             </div>
           </div>
         </Card>
 
         <Button
           onClick={() => navigate('/profile')}
-          className="w-full rounded-xl h-12 gap-2"
+          className="w-full rounded-xl h-12 gap-2 shadow-sm"
           variant="default"
         >
           <Home className="w-5 h-5" />

--- a/src/app/pages/PracticeAnswerEdit.jsx
+++ b/src/app/pages/PracticeAnswerEdit.jsx
@@ -26,6 +26,7 @@ const TEXT_CHARACTER_SUFFIX = '자';
 const TEXT_LIMIT_TITLE = '답변 길이 초과';
 const TEXT_LIMIT_DESC = '답변은 1500자 이내로 작성해주세요.';
 const TEXT_LIMIT_OK = '확인';
+const TEXT_RETRY_INTERVIEW = '음성으로 다시 답변하기';
 const MAX_ANSWER_LENGTH = 1500;
 
 const PracticeAnswerEdit = () => {
@@ -62,6 +63,10 @@ const PracticeAnswerEdit = () => {
         setShowConfirm(true);
     };
 
+    const handleRetryInterview = () => {
+        navigate(`/practice/answer-voice/${questionId}`);
+    };
+
     const confirmSubmit = () => {
         setShowConfirm(false);
         submitAnswer({
@@ -89,26 +94,6 @@ const PracticeAnswerEdit = () => {
                 title="답변 확인"
                 onBack={() => navigate(`/practice/answer/${questionId}`)}
                 showNotifications={false}
-                rightContent={
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleToggleEdit}
-                        className="rounded-full gap-2"
-                    >
-                        {isEditing ? (
-                            <>
-                                <Eye className="w-4 h-4" />
-                                완료
-                            </>
-                        ) : (
-                            <>
-                                <Edit3 className="w-4 h-4" />
-                                편집
-                            </>
-                        )}
-                    </Button>
-                }
             />
 
             <div className="p-6 max-w-lg mx-auto space-y-4">
@@ -118,7 +103,27 @@ const PracticeAnswerEdit = () => {
                 </Card>
 
                 <Card className="p-4">
-                    <p className="text-sm text-muted-foreground mb-3">나의 답변</p>
+                    <div className="mb-3 flex items-center justify-between gap-2">
+                        <p className="text-sm text-muted-foreground">나의 답변</p>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleToggleEdit}
+                            className="rounded-full gap-2"
+                        >
+                            {isEditing ? (
+                                <>
+                                    <Eye className="w-4 h-4" />
+                                    완료
+                                </>
+                            ) : (
+                                <>
+                                    <Edit3 className="w-4 h-4" />
+                                    편집
+                                </>
+                            )}
+                        </Button>
+                    </div>
 
                     {isEditing ? (
                         <>
@@ -150,13 +155,23 @@ const PracticeAnswerEdit = () => {
                     )}
                 </Card>
 
-                <Button
-                    onClick={handleSubmit}
-                    disabled={!answer.trim() || isSubmitting || (answer || '').length > MAX_ANSWER_LENGTH}
-                    className="w-full rounded-xl h-12"
-                >
-                    {isSubmitting ? TEXT_SUBMITTING : '답변 제출'}
-                </Button>
+                <div className="flex gap-2">
+                    <Button
+                        variant="outline"
+                        onClick={handleRetryInterview}
+                        disabled={isSubmitting}
+                        className="flex-1 rounded-xl h-12"
+                    >
+                        {TEXT_RETRY_INTERVIEW}
+                    </Button>
+                    <Button
+                        onClick={handleSubmit}
+                        disabled={!answer.trim() || isSubmitting || (answer || '').length > MAX_ANSWER_LENGTH}
+                        className="flex-1 rounded-xl h-12"
+                    >
+                        {isSubmitting ? TEXT_SUBMITTING : '답변 제출'}
+                    </Button>
+                </div>
             </div>
 
             <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>

--- a/src/app/pages/PracticeAnswerVoice.jsx
+++ b/src/app/pages/PracticeAnswerVoice.jsx
@@ -49,6 +49,10 @@ const PracticeAnswerVoice = () => {
     resetAudioBlob,
   } = useAudioRecorder();
   const { uploadAudioBlob } = useAudioSttPipeline();
+  const remainingSeconds = Math.max(MAX_RECORDING_SECONDS - seconds, 0);
+  const isTimeWarning =
+    remainingSeconds <= 60 &&
+    (recorderState === 'recording' || recorderState === 'paused');
 
   const prefillAnswerText =
     typeof state?.prefillAnswerText === 'string' ? state.prefillAnswerText : '';
@@ -232,8 +236,8 @@ const PracticeAnswerVoice = () => {
 
       <div className="flex-1 flex flex-col items-center justify-center px-6 py-12">
         <div className="bg-white rounded-2xl p-6 mb-8 w-full max-w-lg shadow-sm border border-white/80">
-          <p className="text-center text-[var(--gray-600)] text-sm mb-2">질문</p>
-          <h2 className="text-center text-lg font-semibold text-[var(--gray-900)]">{question.title}</h2>
+          <p className="text-center text-[var(--gray-500)] text-sm mb-2">질문</p>
+          <h2 className="text-center text-lg font-semibold text-[var(--gray-700)]">{question.title}</h2>
         </div>
 
         {/* Audio Visualizer - 처음엔 원 1개, 소리 감지 시 바깥 원이 생기는 모션 */}
@@ -320,12 +324,30 @@ const PracticeAnswerVoice = () => {
 
         {/* Timer */}
         <div className="text-center mb-8">
-          <div className="text-5xl font-mono font-semibold text-[var(--gray-800)] mb-2">
+          <Motion.div
+            className={`text-5xl font-mono font-semibold mb-2 ${
+              isTimeWarning ? 'text-[var(--primary-500)]' : 'text-[var(--gray-600)]'
+            }`}
+            animate={
+              isTimeWarning
+                ? { scale: [1, 1.04, 1], opacity: [1, 0.85, 1] }
+                : { scale: 1, opacity: 1 }
+            }
+            transition={
+              isTimeWarning
+                ? { duration: 0.9, repeat: Infinity, ease: 'easeInOut' }
+                : { duration: 0.2 }
+            }
+          >
             {formatTime(seconds)}
-          </div>
-          <p className="text-[var(--gray-600)] text-sm">{getStatusMessage()}</p>
-          {recorderState === 'recording' && (
-            <p className="text-[var(--gray-500)] text-xs mt-1">
+          </Motion.div>
+          <p className="text-[var(--gray-500)] text-sm">{getStatusMessage()}</p>
+          {isTimeWarning ? (
+            <p className="text-[var(--primary-500)] text-xs mt-1 font-semibold animate-pulse">
+              종료까지 {formatTime(remainingSeconds)} 남음
+            </p>
+          ) : recorderState === 'recording' && (
+            <p className="text-[var(--gray-400)] text-xs mt-1">
               최대 {Math.floor(MAX_RECORDING_SECONDS / 60)}분까지 녹음 가능
             </p>
           )}
@@ -337,7 +359,7 @@ const PracticeAnswerVoice = () => {
           disabled={isUploading}
           className={`w-48 h-14 rounded-full text-lg font-semibold ${
             recorderState === 'recording' || recorderState === 'paused'
-              ? 'bg-red-500 hover:bg-red-600 text-white'
+              ? 'bg-[var(--primary-400)] hover:bg-[var(--primary-500)] text-white border border-[var(--primary-300)] shadow-sm'
               : 'bg-white text-[var(--primary-600)] hover:bg-[var(--primary-50)] border border-[var(--primary-200)] shadow-sm'
           } disabled:opacity-50`}
         >

--- a/src/app/pages/PracticeResultAI.jsx
+++ b/src/app/pages/PracticeResultAI.jsx
@@ -15,6 +15,7 @@ import {
 import { usePracticeQuestionLoader } from '@/app/hooks/usePracticeQuestionLoader';
 import { usePracticeQuestion } from '@/context/practiceQuestionContext.jsx';
 import { SESSION_STORAGE_KEYS } from '@/app/constants/storageKeys';
+import { sortMetricsByDisplayOrder } from '@/app/utils/metricOrder';
 
 const TEXT_LOADING = '질문을 불러오는 중...';
 const TEXT_NOT_FOUND = '질문을 찾을 수 없습니다';
@@ -65,9 +66,11 @@ const PracticeResultAI = () => {
     const feedbackData = useMemo(() => feedbackResponse?.data ?? null, [feedbackResponse]);
 
     const metrics = useMemo(() => {
-        return Array.isArray(feedbackData?.metrics)
+        const normalizedMetrics = Array.isArray(feedbackData?.metrics)
             ? feedbackData.metrics.filter((metric) => metric && typeof metric === 'object')
             : [];
+
+        return sortMetricsByDisplayOrder(normalizedMetrics, (metric) => metric?.name);
     }, [feedbackData]);
 
     const radarData = useMemo(() => {
@@ -136,7 +139,7 @@ const PracticeResultAI = () => {
     if (!question) return <div>{TEXT_NOT_FOUND}</div>;
 
     return (
-        <div className="min-h-screen bg-background">
+        <div className="min-h-screen bg-gradient-to-b from-secondary-50 via-white to-secondary-50">
             <AppHeader
                 title={TEXT_AI_FEEDBACK_TITLE}
                 onBack={() => navigate('/practice')}
@@ -144,28 +147,25 @@ const PracticeResultAI = () => {
                 tone="light"
             />
 
-            <div
-                className="text-center pb-6 px-6 pt-2"
-                style={{
-                    background: 'linear-gradient(165deg, var(--primary-50) 0%, var(--primary-100) 50%, var(--primary-50) 100%)',
-                }}
-            >
+            <div className="border-b border-primary-100/80 text-center pb-7 px-6 pt-3 bg-gradient-to-br from-primary-50 via-white to-secondary-50">
                 <div className="mb-2 flex justify-center">
-                    <Target className="w-14 h-14 text-primary-500" />
+                    <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/90 border border-primary-100 shadow-sm">
+                        <Target className="w-8 h-8 text-primary-400" />
+                    </div>
                 </div>
                 <h2 className="text-2xl mb-1 font-semibold text-[var(--gray-900)]">{TEXT_COMPLETE_TITLE}</h2>
                 <p className="text-[var(--gray-600)] text-sm">{TEXT_COMPLETE_DESC}</p>
             </div>
 
-            <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-                <Card className="p-6 bg-white shadow-lg">
+            <div className="p-6 max-w-lg mx-auto space-y-4 -mt-3">
+                <Card className="p-6 bg-white rounded-2xl border border-gray-100 shadow-sm">
                     {isBadCase ? (
                         <div className="text-center space-y-2">
-                            <p className="text-sm text-rose-900 font-medium">
+                            <p className="text-sm text-gray-900 font-medium">
                                 {failedFeedbackMessage || badCaseFeedback?.message || TEXT_BAD_CASE_FALLBACK}
                             </p>
                             {(badCaseFeedback?.guidance || overallFeedback?.improvements) && (
-                                <p className="text-xs text-rose-700">
+                                <p className="text-xs text-gray-600">
                                     {badCaseFeedback?.guidance || overallFeedback?.improvements}
                                 </p>
                             )}
@@ -185,9 +185,9 @@ const PracticeResultAI = () => {
                                     <Radar
                                         name={TEXT_RADAR_LABEL}
                                         dataKey="value"
-                                        stroke="#ec4899"
-                                        fill="#ec4899"
-                                        fillOpacity={0.6}
+                                        stroke="#ff8fa3"
+                                        fill="#ffccd5"
+                                        fillOpacity={0.8}
                                     />
                                 </RadarChart>
                             </ResponsiveContainer>
@@ -195,26 +195,26 @@ const PracticeResultAI = () => {
                     )}
                 </Card>
 
-                <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+                <Card className="p-5 rounded-2xl border border-emerald-100 bg-emerald-50/70 shadow-sm">
                     <div className="flex items-start gap-3">
-                        <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                            <ThumbsUp className="w-5 h-5 text-pink-600" />
+                        <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+                            <ThumbsUp className="w-5 h-5 text-emerald-600" />
                         </div>
                         <div className="flex-1">
-                            <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
-                            {renderFeedbackText(strengthsText, 'text-sm text-rose-800')}
+                            <h3 className="mb-2 text-emerald-900">{TEXT_STRENGTHS_TITLE}</h3>
+                            {renderFeedbackText(strengthsText, 'text-sm text-gray-700')}
                         </div>
                     </div>
                 </Card>
 
-                <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+                <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
                     <div className="flex items-start gap-3">
-                        <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
-                            <AlertCircle className="w-5 h-5 text-pink-600" />
+                        <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+                            <AlertCircle className="w-5 h-5 text-amber-600" />
                         </div>
                         <div className="flex-1">
-                            <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
-                            {renderFeedbackText(improvementsText, 'text-sm text-pink-800')}
+                            <h3 className="mb-2 text-amber-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+                            {renderFeedbackText(improvementsText, 'text-sm text-gray-700')}
                         </div>
                     </div>
                 </Card>
@@ -224,7 +224,7 @@ const PracticeResultAI = () => {
                         clearSelectedQuestion();
                         navigate('/');
                     }}
-                    className="w-full rounded-md h-12 gap-2"
+                    className="w-full rounded-xl h-12 gap-2 shadow-sm"
                 >
                     <Home className="w-5 h-5" />
                     {TEXT_HOME_BUTTON}

--- a/src/app/pages/RealInterview.jsx
+++ b/src/app/pages/RealInterview.jsx
@@ -102,14 +102,14 @@ const RealInterview = () => {
             title: 'CS 기초',
             description: '운영체제, 네트워크, 데이터베이스 등 핵심 전공 지식',
             questionType: QUESTION_TYPES.CS,
-            gradient: 'from-pink-500 to-rose-500',
+            gradient: 'from-primary-50 via-primary-100 to-secondary-100',
             onClick: () => handleStartRealInterview(QUESTION_TYPES.CS),
         },
         {
             title: '시스템 디자인',
             description: '대규모 아키텍처 및 분산 시스템 설계 연습',
             questionType: QUESTION_TYPES.SYSTEM_DESIGN,
-            gradient: 'from-rose-500 to-pink-600',
+            gradient: 'from-secondary-50 via-primary-100 to-primary-50',
             onClick: () => handleStartRealInterview(QUESTION_TYPES.SYSTEM_DESIGN),
         },
         ...(SHOW_PORTFOLIO_INTERVIEW
@@ -118,7 +118,7 @@ const RealInterview = () => {
                     title: '개별 포트폴리오',
                     description: '내 프로젝트 기반의 1:1 맞춤형 기술 면접',
                     questionType: QUESTION_TYPES.PORTFOLIO,
-                    gradient: 'from-pink-600 to-rose-600',
+                    gradient: 'from-primary-100 via-secondary-100 to-primary-200',
                     onClick: () => handleComingSoon('개별 포트폴리오'),
                 },
             ]
@@ -136,19 +136,19 @@ const RealInterview = () => {
                             key={index}
                             onClick={item.onClick}
                             disabled={isCreatingSession}
-                            className={`flex-1 relative overflow-hidden rounded-2xl p-5 flex flex-col justify-center text-left text-white transition-all active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed bg-gradient-to-br ${item.gradient} shadow-lg shadow-pink-200/50 min-h-[100px]`}
+                            className={`flex-1 relative overflow-hidden rounded-2xl p-5 flex flex-col justify-center text-left transition-all active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed bg-gradient-to-br ${item.gradient} border border-primary-200/80 shadow-[0_8px_22px_rgba(255,143,163,0.14)] min-h-[100px]`}
                         >
                             <div className="relative z-10">
-                                <h2 className="text-xl font-bold mb-1">{item.title}</h2>
-                                <p className="text-white/80 text-xs leading-relaxed max-w-[200px]">
+                                <h2 className="text-xl font-bold mb-1 text-gray-900">{item.title}</h2>
+                                <p className="text-gray-700 text-xs leading-relaxed max-w-[200px]">
                                     {item.description}
                                 </p>
                             </div>
 
-                            <div className="absolute -right-8 -bottom-8 w-24 h-24 bg-white/10 rounded-full blur-2xl" />
+                            <div className="absolute -right-8 -bottom-8 w-24 h-24 bg-primary-200/45 rounded-full blur-2xl" />
 
                             {item.title === '개별 포트폴리오' && (
-                                <div className="absolute top-2 right-4 text-[10px] font-medium bg-white/20 px-2 py-0.5 rounded-full backdrop-blur-sm">
+                                <div className="absolute top-2 right-4 text-[10px] font-medium text-primary-700 bg-white/75 border border-primary-200 px-2 py-0.5 rounded-full backdrop-blur-sm">
                                     Coming Soon
                                 </div>
                             )}

--- a/src/app/pages/RealInterviewResultAI.jsx
+++ b/src/app/pages/RealInterviewResultAI.jsx
@@ -171,7 +171,7 @@ const RealInterviewResultAI = () => {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-gradient-to-b from-secondary-50 via-white to-secondary-50">
       <AppHeader
         title={TEXT_PAGE_TITLE}
         onBack={() => navigate('/real-interview')}
@@ -179,35 +179,31 @@ const RealInterviewResultAI = () => {
         tone="light"
       />
 
-      <div
-        className="text-center pb-6 px-6 pt-2"
-        style={{
-          background:
-            'linear-gradient(165deg, var(--primary-50) 0%, var(--primary-100) 50%, var(--primary-50) 100%)',
-        }}
-      >
+      <div className="border-b border-primary-100/80 text-center pb-7 px-6 pt-3 bg-gradient-to-br from-primary-50 via-white to-secondary-50">
         <div className="mb-2 flex justify-center">
-          <Target className="w-14 h-14 text-primary-500" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/90 border border-primary-100 shadow-sm">
+            <Target className="w-8 h-8 text-primary-400" />
+          </div>
         </div>
         <h2 className="text-2xl mb-1 font-semibold text-[var(--gray-900)]">{TEXT_COMPLETE_TITLE}</h2>
         <p className="text-[var(--gray-600)] text-sm">{TEXT_COMPLETE_DESC}</p>
         <div className="mt-3 flex items-center justify-center gap-2">
-          <Badge variant="outline" className="border-pink-200 text-pink-700 bg-white/80">
+          <Badge variant="outline" className="border-primary-200 text-primary-700 bg-white/80">
             {interviewEntries.length}
             {TEXT_QUESTION_COUNT_SUFFIX}
           </Badge>
         </div>
       </div>
 
-      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
+      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-3">
         {!hasResult && (
-          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
-            <p className="text-sm text-rose-800">{TEXT_MISSING_RESULT}</p>
+          <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
+            <p className="text-sm text-amber-800">{TEXT_MISSING_RESULT}</p>
           </Card>
         )}
 
         {hasResult && (
-          <Card className="p-6 bg-white shadow-lg">
+          <Card className="p-6 bg-white rounded-2xl border border-gray-100 shadow-sm">
             <h3 className="text-base mb-3">{TEXT_METRICS_TITLE}</h3>
             {hasRadarData ? (
               <ResponsiveContainer width="100%" height={250}>
@@ -218,9 +214,9 @@ const RealInterviewResultAI = () => {
                   <Radar
                     name={TEXT_RADAR_LABEL}
                     dataKey="value"
-                    stroke="#ec4899"
-                    fill="#ec4899"
-                    fillOpacity={0.6}
+                    stroke="#ff8fa3"
+                    fill="#ffccd5"
+                    fillOpacity={0.8}
                   />
                 </RadarChart>
               </ResponsiveContainer>
@@ -231,7 +227,7 @@ const RealInterviewResultAI = () => {
         )}
 
         {hasResult && hasKeywordSummary && (
-          <Card className="p-5 bg-white shadow-sm space-y-3">
+          <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm space-y-3">
             <h3>{TEXT_COVERAGE}</h3>
             <p className="text-sm text-gray-700">
               {coveragePercent === null ? TEXT_FEEDBACK_EMPTY : `${coveragePercent}%`}
@@ -244,7 +240,7 @@ const RealInterviewResultAI = () => {
                 </p>
               </div>
               <div>
-                <p className="text-xs text-rose-700 mb-1">{TEXT_MISSING}</p>
+                <p className="text-xs text-amber-700 mb-1">{TEXT_MISSING}</p>
                 <p className="text-sm text-gray-700">
                   {missingKeywords.length > 0 ? missingKeywords.join(', ') : TEXT_NONE}
                 </p>
@@ -254,18 +250,18 @@ const RealInterviewResultAI = () => {
         )}
 
         {topicsFeedback.length > 0 && (
-          <Card className="p-5 bg-white shadow-sm space-y-3">
+          <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm space-y-3">
             <div className="flex items-center gap-2">
-              <ListChecks className="w-5 h-5 text-pink-600" />
+              <ListChecks className="w-5 h-5 text-primary-500" />
               <h3>{TEXT_TOPIC_FEEDBACK_TITLE}</h3>
             </div>
             <div className="space-y-3">
               {topicsFeedback.map((topic, idx) => (
                 <div
                   key={`${topic?.topic_id ?? 'topic'}-${idx}`}
-                  className="rounded-xl border border-rose-100 bg-rose-50/60 p-4 space-y-3"
+                  className="rounded-xl border border-primary-100 bg-primary-50/60 p-4 space-y-3"
                 >
-                  <p className="text-sm text-rose-700 font-semibold">
+                  <p className="text-sm text-primary-700 font-semibold">
                     {TEXT_TOPIC_LABEL} {topic?.topic_id ?? idx + 1}
                   </p>
                   <p className="text-[15px] leading-relaxed text-gray-900">
@@ -277,7 +273,7 @@ const RealInterviewResultAI = () => {
                     {renderFeedbackText(topic?.strengths, 'text-sm text-gray-700')}
                   </div>
                   <div>
-                    <p className="text-sm font-semibold text-pink-700 mb-1.5">{TEXT_TOPIC_IMPROVEMENTS}</p>
+                    <p className="text-sm font-semibold text-amber-700 mb-1.5">{TEXT_TOPIC_IMPROVEMENTS}</p>
                     {renderFeedbackText(topic?.improvements, 'text-sm text-gray-700')}
                   </div>
                 </div>
@@ -287,28 +283,28 @@ const RealInterviewResultAI = () => {
         )}
 
         {hasResult && (
-          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+          <Card className="p-5 rounded-2xl border border-emerald-100 bg-emerald-50/70 shadow-sm">
             <div className="flex items-start gap-3">
-              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                <ThumbsUp className="w-5 h-5 text-pink-600" />
+              <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+                <ThumbsUp className="w-5 h-5 text-emerald-600" />
               </div>
               <div className="flex-1">
-                <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
-                {renderFeedbackText(overallFeedback?.strengths, 'text-sm text-rose-800')}
+                <h3 className="mb-2 text-emerald-900">{TEXT_STRENGTHS_TITLE}</h3>
+                {renderFeedbackText(overallFeedback?.strengths, 'text-sm text-gray-700')}
               </div>
             </div>
           </Card>
         )}
 
         {hasResult && (
-          <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+          <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
             <div className="flex items-start gap-3">
-              <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
-                <AlertCircle className="w-5 h-5 text-pink-600" />
+              <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-5 h-5 text-amber-600" />
               </div>
               <div className="flex-1">
-                <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
-                {renderFeedbackText(overallFeedback?.improvements, 'text-sm text-pink-800')}
+                <h3 className="mb-2 text-amber-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+                {renderFeedbackText(overallFeedback?.improvements, 'text-sm text-gray-700')}
               </div>
             </div>
           </Card>
@@ -316,7 +312,7 @@ const RealInterviewResultAI = () => {
 
         <Button
           onClick={() => navigate('/')}
-          className="w-full rounded-md h-12 gap-2"
+          className="w-full rounded-xl h-12 gap-2 shadow-sm"
         >
           <Home className="w-5 h-5" />
           {TEXT_HOME_BUTTON}

--- a/src/app/pages/RealInterviewSession.jsx
+++ b/src/app/pages/RealInterviewSession.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+    CircleAlert,
     Camera,
     Circle,
     Clock3,
@@ -47,7 +48,7 @@ const COPY = {
     remainingPrefix: '남은',
     followUpQuestionPrefix: '꼬리 질문',
     processingAnswer: '답변을 정리하고 있습니다.',
-    processingFollowUp: '면접관의 다음 질문을 준비하고 있습니다.',
+    processingFollowUp: '답변 제출 및 다음 질문 생성 중',
     cameraInitializing: '카메라 초기화 중입니다.',
     cameraUnsupported: '현재 브라우저에서는 웹캠을 사용할 수 없습니다.',
     cameraPermissionRequired: '카메라 권한이 필요합니다. 브라우저 권한을 허용해주세요.',
@@ -73,6 +74,8 @@ const COPY = {
     questionTtsLoading: '생성 중...',
     questionTtsFailed: '질문 음성 재생에 실패했습니다.',
     questionTtsCompletionRequired: '질문 음성 재생이 끝나야 답변을 제출할 수 있습니다.',
+    questionTtsRemaining: '질문 재생 중',
+    questionTtsPending: '질문 음성 재생 대기 중',
     badCaseDetected: '답변이 기준을 충족하지 못해 다시 녹화가 필요합니다.',
     badCaseFeedbackFallback: '답변을 보완해 다시 시도해주세요.',
     badCaseRetryPrompt: '피드백을 반영해 다시 답변해주세요.',
@@ -82,7 +85,6 @@ const COPY = {
     reviewToggleOpen: '내 답변 열기',
     reviewTitle: '내 답변 확인',
     reviewDescription: '답변 텍스트를 확인한 뒤 다음 질문으로 진행하세요.',
-    reviewPanelClosed: '답변 확인 패널이 닫혀 있습니다. 필요하면 다시 열어 확인하세요.',
     timeWarning: '답변 시간이 곧 종료됩니다. 핵심 결론을 정리해주세요.',
     trailButtonLabel: '질문 내역',
     trailOpen: '보기',
@@ -648,6 +650,7 @@ const RealInterviewSession = () => {
     const [permissionHint, setPermissionHint] = useState('');
     const [isTrailOpen, setIsTrailOpen] = useState(false);
     const [isReviewPanelOpen, setIsReviewPanelOpen] = useState(true);
+    const [hasPendingReviewNotice, setHasPendingReviewNotice] = useState(false);
     const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
     const [autoStopNotice, setAutoStopNotice] = useState('');
     const [badCaseNotice, setBadCaseNotice] = useState('');
@@ -676,12 +679,20 @@ const RealInterviewSession = () => {
     const isRecording = phase === PHASE.RECORDING;
     const isProcessing =
         phase === PHASE.UPLOADING || phase === PHASE.STT || phase === PHASE.FOLLOW_UP;
+    const isStartBlockedByQuestionTts =
+        isInterviewStarted &&
+        isSessionReady &&
+        !isInterviewFinished &&
+        cameraState === CAMERA_STATE.READY &&
+        phase === PHASE.READY &&
+        !hasQuestionTtsCompleted;
     const canStartRecording =
         isInterviewStarted &&
         isSessionReady &&
         !isInterviewFinished &&
         cameraState === CAMERA_STATE.READY &&
-        phase === PHASE.READY;
+        phase === PHASE.READY &&
+        hasQuestionTtsCompleted;
     const isStartGatePermissionReady =
         startGateCameraPermission === START_GATE_PERMISSION_STATE.GRANTED &&
         startGateMicPermission === START_GATE_PERMISSION_STATE.GRANTED;
@@ -934,6 +945,7 @@ const RealInterviewSession = () => {
     const {
         isLoading: isQuestionTtsLoading,
         isPlaying: isQuestionPlaying,
+        remainingSeconds: questionTtsRemainingSeconds,
         playText: playQuestionTtsText,
         toggle: toggleQuestionTtsPlayback,
         stop: stopQuestionTtsPlayback,
@@ -949,10 +961,8 @@ const RealInterviewSession = () => {
     });
     const isReviewSubmitDisabled =
         !transcriptDraft.trim() ||
-        !hasQuestionTtsCompleted ||
         isQuestionTtsLoading ||
         isQuestionPlaying;
-    const shouldShowTtsCompletionNotice = phase === PHASE.REVIEW && !hasQuestionTtsCompleted;
 
     const stopTimer = useCallback(() => {
         if (timerRef.current) {
@@ -1067,6 +1077,7 @@ const RealInterviewSession = () => {
         if (!Array.isArray(audioChunks) || audioChunks.length === 0) {
             setTranscriptDraft('');
             setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setHasPendingReviewNotice(false);
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
             toast.error(COPY.recordingAudioMissing);
@@ -1075,6 +1086,7 @@ const RealInterviewSession = () => {
         if (!Array.isArray(videoChunks) || videoChunks.length === 0) {
             setTranscriptDraft('');
             setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setHasPendingReviewNotice(false);
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
             toast.error(COPY.recordingVideoMissing);
@@ -1083,6 +1095,7 @@ const RealInterviewSession = () => {
         if (!realSessionId) {
             setTranscriptDraft('');
             setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setHasPendingReviewNotice(false);
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
             toast.error(COPY.sessionNotFound);
@@ -1113,6 +1126,7 @@ const RealInterviewSession = () => {
         if (!audioBlob.size || !videoBlob.size) {
             setTranscriptDraft('');
             setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setHasPendingReviewNotice(false);
             setIsReviewPanelOpen(true);
             setPhase(PHASE.REVIEW);
             toast.error(COPY.recordingFileMissing);
@@ -1146,13 +1160,15 @@ const RealInterviewSession = () => {
 
             setTranscriptDraft(sttText);
             setBadCaseNotice('');
+            setHasPendingReviewNotice(true);
         } catch (error) {
             setTranscriptDraft('');
             setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setHasPendingReviewNotice(false);
             toast.error(error?.message || COPY.micConnectionFailed);
         } finally {
             setSeconds(0);
-            setIsReviewPanelOpen(true);
+            setIsReviewPanelOpen(false);
             setPhase(PHASE.REVIEW);
         }
     }, [realSessionId, realUserId, transcribeAudioUrl, uploadAudioBlob, uploadVideoBlobMultipart]);
@@ -1258,6 +1274,7 @@ const RealInterviewSession = () => {
             setAnalysisNotice('');
             setTranscriptDraft('');
             setRecordedFileIds({ audioFileId: null, videoFileId: null });
+            setHasPendingReviewNotice(false);
             setPhase(PHASE.RECORDING);
             startTimer();
             audioRecorder.start(250);
@@ -1316,6 +1333,7 @@ const RealInterviewSession = () => {
     const resetToReady = useCallback(() => {
         setTranscriptDraft('');
         setRecordedFileIds({ audioFileId: null, videoFileId: null });
+        setHasPendingReviewNotice(false);
         setSeconds(0);
         setAutoStopNotice('');
         setBadCaseNotice('');
@@ -1326,6 +1344,10 @@ const RealInterviewSession = () => {
     const submitTranscript = useCallback(async () => {
         const answerText = transcriptDraft.trim();
         if (!answerText) return;
+        if (!hasQuestionTtsCompleted) {
+            toast.error(COPY.questionTtsCompletionRequired);
+            return;
+        }
         if (!realSessionId) {
             toast.error(COPY.sessionNotFound);
             return;
@@ -1574,6 +1596,7 @@ const RealInterviewSession = () => {
         realSessionId,
         recordedFileIds,
         seconds,
+        hasQuestionTtsCompleted,
         stopQuestionTtsPlayback,
         transcriptDraft,
     ]);
@@ -1612,6 +1635,18 @@ const RealInterviewSession = () => {
         if (phase === PHASE.FOLLOW_UP) return COPY.processingFollowUp;
         return '';
     }, [phase]);
+    const questionTtsRemainingLabel = useMemo(() => {
+        if (!isStartBlockedByQuestionTts) return '';
+        if (isQuestionTtsLoading) return COPY.questionTtsLoading;
+        if (typeof questionTtsRemainingSeconds === 'number') {
+            return `${COPY.questionTtsRemaining} ${formatTime(questionTtsRemainingSeconds)}`;
+        }
+        return COPY.questionTtsPending;
+    }, [
+        isQuestionTtsLoading,
+        isStartBlockedByQuestionTts,
+        questionTtsRemainingSeconds,
+    ]);
 
     const handleBackClick = useCallback(() => {
         setIsExitDialogOpen(true);
@@ -1885,10 +1920,16 @@ const RealInterviewSession = () => {
     }, [currentQuestion, realSessionId]);
 
     useEffect(() => {
-        if (phase === PHASE.REVIEW) {
-            setIsReviewPanelOpen(true);
+        if (phase !== PHASE.REVIEW) {
+            setHasPendingReviewNotice(false);
         }
     }, [phase]);
+
+    useEffect(() => {
+        if (phase === PHASE.REVIEW && isReviewPanelOpen) {
+            setHasPendingReviewNotice(false);
+        }
+    }, [isReviewPanelOpen, phase]);
 
     useEffect(() => {
         if (phase === PHASE.RECORDING && seconds >= MAX_RECORDING_SECONDS) {
@@ -1908,6 +1949,10 @@ const RealInterviewSession = () => {
         await toggleQuestionTtsPlayback();
     }, [isInterviewStarted, realSessionId, toggleQuestionTtsPlayback]);
 
+    const handleReviewPanelToggle = useCallback(() => {
+        setIsReviewPanelOpen((prev) => !prev);
+    }, []);
+
     return (
         <div className="min-h-screen flex flex-col bg-[#0e0a0f] text-white">
             <main className="h-screen">
@@ -1917,7 +1962,7 @@ const RealInterviewSession = () => {
                         showNotifications={false}
                         showSettings={false}
                         tone="dark"
-                        className="left-0 right-0"
+                        className="!absolute !top-0 left-0 right-0 !bg-transparent"
                         onBack={handleBackClick}
                     />
 
@@ -2041,10 +2086,16 @@ const RealInterviewSession = () => {
                     {phase === PHASE.REVIEW && (
                         <button
                             type="button"
-                            className={`${BUBBLE_BASE} absolute right-3.5 bottom-[calc(106px+env(safe-area-inset-bottom,0px))] z-[4] rounded-full px-3 py-2 text-xs font-medium text-white`}
-                            onClick={() => setIsReviewPanelOpen((prev) => !prev)}
+                            className={`${BUBBLE_BASE} absolute right-3.5 bottom-[calc(106px+env(safe-area-inset-bottom,0px))] z-[4] inline-flex items-center gap-1 rounded-full px-3 py-2 text-xs font-medium text-white`}
+                            onClick={handleReviewPanelToggle}
                         >
                             {isReviewPanelOpen ? COPY.reviewToggleClose : COPY.reviewToggleOpen}
+                            {!isReviewPanelOpen && hasPendingReviewNotice && (
+                                <>
+                                    <CircleAlert size={13} className="text-[#ff5f7f]" />
+                                    <span className="sr-only">새 내 답변 확인 필요</span>
+                                </>
+                            )}
                         </button>
                     )}
 
@@ -2062,14 +2113,8 @@ const RealInterviewSession = () => {
                         </div>
                     )}
 
-                    {phase === PHASE.REVIEW && !isReviewPanelOpen && (
-                        <div className={`${BUBBLE_BASE} absolute left-3.5 right-3.5 bottom-[calc(150px+env(safe-area-inset-bottom,0px))] z-[4] rounded-xl px-[11px] py-[9px] text-xs text-white/95`}>
-                            {COPY.reviewPanelClosed}
-                        </div>
-                    )}
-
-                    {(isProcessing || permissionHint || autoStopNotice || badCaseNotice || analysisNotice || isTimeWarning || shouldShowTtsCompletionNotice) && (
-                        <div className="absolute left-3.5 right-3.5 top-[226px] z-[3] flex flex-col gap-2">
+                    {(isProcessing || permissionHint || autoStopNotice || badCaseNotice || analysisNotice || isTimeWarning) && (
+                        <div className="absolute left-3.5 right-3.5 bottom-[calc(94px+env(safe-area-inset-bottom,0px))] z-[7] flex flex-col gap-2">
                             {isProcessing && (
                                 <div className={`${BUBBLE_BASE} flex items-center gap-2.5 rounded-xl px-3 py-2.5`}>
                                     <div className="h-[13px] w-[13px] rounded-full border-2 border-white/50 border-t-[#ff8fa3] animate-spin" />
@@ -2099,11 +2144,6 @@ const RealInterviewSession = () => {
                             {analysisNotice && (
                                 <div className={`${BUBBLE_BASE} ${analysisState === 'error' ? 'border-[#ff6b8a]/90' : ''} flex items-center gap-2.5 rounded-xl px-3 py-2.5`}>
                                     <p className="m-0 text-xs font-medium text-white/95">{toRenderableText(analysisNotice)}</p>
-                                </div>
-                            )}
-                            {shouldShowTtsCompletionNotice && (
-                                <div className={`${BUBBLE_BASE} border-[#ff6b8a]/90 flex items-center gap-2.5 rounded-xl px-3 py-2.5`}>
-                                    <p className="m-0 text-xs font-medium text-white/95">{COPY.questionTtsCompletionRequired}</p>
                                 </div>
                             )}
                         </div>
@@ -2154,7 +2194,18 @@ const RealInterviewSession = () => {
                                 onClick={isRecording ? stopRecordingAndSubmit : startRecording}
                                 disabled={!isRecording && !canStartRecording}
                             >
-                                {isRecording ? COPY.answerStopAndReview : COPY.answerStart}
+                                {isRecording ? (
+                                    COPY.answerStopAndReview
+                                ) : (
+                                    <span className="flex flex-col items-center gap-0.5 leading-tight">
+                                        <span>{COPY.answerStart}</span>
+                                        {isStartBlockedByQuestionTts && (
+                                            <span className="text-[11px] font-medium text-white/80">
+                                                {questionTtsRemainingLabel}
+                                            </span>
+                                        )}
+                                    </span>
+                                )}
                             </Button>
                         )}
                     </footer>

--- a/src/app/pages/RealLearningRecordDetail.jsx
+++ b/src/app/pages/RealLearningRecordDetail.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { AppHeader } from '@/app/components/AppHeader';
 import { Card } from '@/app/components/ui/card';
 import { Button } from '@/app/components/ui/button';
-import { AlertCircle, Home, ListChecks, Loader2, Sparkles, ThumbsUp } from 'lucide-react';
+import { AlertCircle, ChevronLeft, ChevronRight, Home, ListChecks, Loader2, Sparkles, ThumbsUp } from 'lucide-react';
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -13,6 +13,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { useAnswerDetail } from '@/app/hooks/useAnswerDetail';
+import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
+import { getQuestionCategoryLabel } from '@/app/constants/questionCategoryMeta';
 import { getFileReadPresignedUrl } from '@/api/fileApi';
 
 const TEXT_PAGE_TITLE = '실전 학습 기록 상세';
@@ -44,12 +46,15 @@ const TEXT_VIDEO_LABEL = '답변 영상';
 const TEXT_VIDEO_EXPIRES_LABEL = '영상 링크 만료 시 새로고침 해주세요.';
 const TEXT_VIDEO_MISSING_CARD = '영상이 없습니다.';
 const TEXT_VIDEO_LOADING = '영상 불러오는 중...';
+const TEXT_PREV_TOPIC = '이전 주제';
+const TEXT_NEXT_TOPIC = '다음 주제';
 
 const FEEDBACK_SPLIT_DELIMITER = '●';
 const FEEDBACK_BULLET = '•';
 const FEEDBACK_DASH = '-';
 const METRIC_SCORE_MAX = 5;
 const RADAR_DOMAIN_MAX = 100;
+const SWIPE_THRESHOLD_PX = 48;
 
 const toTrimmedString = (value) => {
   if (typeof value !== 'string') return '';
@@ -218,12 +223,16 @@ const RealLearningRecordDetail = () => {
   const navigate = useNavigate();
   const { answerId } = useParams();
   const { data, isLoading, error } = useAnswerDetail(answerId);
+  const { data: categoryData } = useQuestionCategories();
+  const CATEGORY_LABELS = useMemo(() => categoryData?.flat ?? {}, [categoryData]);
   const [resolvedVideoSources, setResolvedVideoSources] = useState({});
   const [videoLoadFailedMap, setVideoLoadFailedMap] = useState({});
   const [videoReadyMap, setVideoReadyMap] = useState({});
+  const [activeTurnIndex, setActiveTurnIndex] = useState(0);
   const videoReadUrlCacheRef = useRef(new Map());
   const inFlightVideoReadUrlRef = useRef(new Map());
   const refreshingTurnVideoRef = useRef(new Set());
+  const swipeStartXRef = useRef(null);
 
   const answerDetail = useMemo(() => {
     const resolved = data?.data ?? data;
@@ -282,6 +291,7 @@ const RealLearningRecordDetail = () => {
 
     return rows
       .map((item, idx) => {
+        const categoryKey = toTrimmedString(item?.category);
         const videoPlayUrl = toTrimmedString(
           item?.video_play_url ??
             item?.videoPlayUrl ??
@@ -296,7 +306,8 @@ const RealLearningRecordDetail = () => {
           turnType: toTrimmedString(item?.turn_type ?? item?.turnType),
           question: toTrimmedString(item?.question),
           answerText: toTrimmedString(item?.answer_text ?? item?.answerText),
-          category: toTrimmedString(item?.category),
+          category: categoryKey,
+          categoryLabel: getQuestionCategoryLabel(categoryKey, CATEGORY_LABELS),
           videoPlayUrl,
           videoPlayUrlExpired: isExpiredS3PresignedUrl(videoPlayUrl),
           videoExpiresAt: toTrimmedString(
@@ -309,7 +320,7 @@ const RealLearningRecordDetail = () => {
         };
       })
       .sort((a, b) => a.turnOrder - b.turnOrder);
-  }, [feedbackData]);
+  }, [feedbackData, CATEGORY_LABELS]);
 
   const getTurnVideoReadUrl = useCallback(async (fileId, { forceRefresh = false } = {}) => {
     const normalizedFileId = toFileId(fileId);
@@ -431,6 +442,42 @@ const RealLearningRecordDetail = () => {
     setVideoReadyMap({});
   }, [interviewHistory, resolvedVideoSources]);
 
+  useEffect(() => {
+    setActiveTurnIndex((prev) => {
+      if (interviewHistory.length === 0) return 0;
+      return Math.min(prev, interviewHistory.length - 1);
+    });
+  }, [interviewHistory.length]);
+
+  const handlePrevTurn = useCallback(() => {
+    setActiveTurnIndex((prev) => Math.max(prev - 1, 0));
+  }, []);
+
+  const handleNextTurn = useCallback(() => {
+    setActiveTurnIndex((prev) => Math.min(prev + 1, interviewHistory.length - 1));
+  }, [interviewHistory.length]);
+
+  const handleCarouselTouchStart = useCallback((event) => {
+    swipeStartXRef.current = event.changedTouches?.[0]?.clientX ?? null;
+  }, []);
+
+  const handleCarouselTouchEnd = useCallback((event) => {
+    const startX = swipeStartXRef.current;
+    const endX = event.changedTouches?.[0]?.clientX;
+    swipeStartXRef.current = null;
+
+    if (typeof startX !== 'number' || typeof endX !== 'number') return;
+
+    const deltaX = endX - startX;
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD_PX) return;
+
+    if (deltaX < 0) {
+      handleNextTurn();
+      return;
+    }
+    handlePrevTurn();
+  }, [handleNextTurn, handlePrevTurn]);
+
   const questionText = toTrimmedString(
     answerDetail?.question?.content ?? answerDetail?.question?.title
   );
@@ -441,7 +488,7 @@ const RealLearningRecordDetail = () => {
         <AppHeader title={TEXT_PAGE_TITLE} onBack={() => navigate('/profile')} showNotifications={false} />
         <div className="p-6 max-w-lg mx-auto">
           <Card className="p-6 flex items-center gap-3">
-            <Loader2 className="w-5 h-5 animate-spin text-pink-600" />
+            <Loader2 className="w-5 h-5 animate-spin text-primary-500" />
             <p className="text-sm text-muted-foreground">{TEXT_LOADING}</p>
           </Card>
         </div>
@@ -451,29 +498,29 @@ const RealLearningRecordDetail = () => {
 
   if (error || !hasAnswerDetail) {
     return (
-      <div className="min-h-screen bg-background">
-        <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+      <div className="min-h-screen bg-gradient-to-b from-secondary-50 via-white to-secondary-50">
+        <div className="border-b border-primary-100/80 bg-gradient-to-r from-primary-50 via-white to-secondary-50 text-gray-900">
           <AppHeader
             title={TEXT_PAGE_TITLE}
             onBack={() => navigate('/profile')}
             showNotifications={false}
-            tone="dark"
+            tone="light"
             className="!static"
           />
           <div className="text-center pb-6 pt-1 px-6">
-            <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+            <p className="text-gray-600 text-sm">{TEXT_HEADER_DESC}</p>
           </div>
         </div>
 
-        <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-          <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+        <div className="p-6 max-w-lg mx-auto space-y-4 -mt-3">
+          <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
             <div className="flex items-start gap-3">
-              <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-                <AlertCircle className="w-5 h-5 text-rose-600" />
+              <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-5 h-5 text-amber-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-rose-800">{error?.message || TEXT_NOT_FOUND}</p>
-                <p className="text-xs text-rose-700 mt-1">{TEXT_RETRY_HELP}</p>
+                <p className="text-sm text-amber-800">{error?.message || TEXT_NOT_FOUND}</p>
+                <p className="text-xs text-amber-700 mt-1">{TEXT_RETRY_HELP}</p>
               </div>
             </div>
           </Card>
@@ -492,25 +539,25 @@ const RealLearningRecordDetail = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="bg-gradient-to-r from-pink-500 to-rose-500 text-white">
+    <div className="min-h-screen bg-gradient-to-b from-secondary-50 via-white to-secondary-50">
+      <div className="border-b border-primary-100/80 bg-gradient-to-r from-primary-50 via-white to-secondary-50 text-gray-900">
         <AppHeader
           title={TEXT_PAGE_TITLE}
           onBack={() => navigate('/profile')}
           showNotifications={false}
-          tone="dark"
+          tone="light"
           className="!static"
         />
 
         <div className="text-center pb-6 pt-1 px-6">
-          <p className="text-white/80 text-sm">{TEXT_HEADER_DESC}</p>
+          <p className="text-gray-600 text-sm">{TEXT_HEADER_DESC}</p>
         </div>
       </div>
 
-      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-4">
-        <Card className="p-5 bg-white shadow-lg">
+      <div className="p-6 max-w-lg mx-auto space-y-4 -mt-3">
+        <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm">
           <div className="flex items-center gap-2 mb-4">
-            <Sparkles className="w-5 h-5 text-pink-600" />
+            <Sparkles className="w-5 h-5 text-primary-500" />
             <h3>{TEXT_METRICS_TITLE}</h3>
           </div>
           {hasRadarData ? (
@@ -519,7 +566,13 @@ const RealLearningRecordDetail = () => {
                 <PolarGrid />
                 <PolarAngleAxis dataKey="subject" />
                 <PolarRadiusAxis angle={90} domain={[0, RADAR_DOMAIN_MAX]} tick={false} axisLine={false} />
-                <Radar name={TEXT_RADAR_LABEL} dataKey="value" stroke="#ec4899" fill="#ec4899" fillOpacity={0.6} />
+                <Radar
+                  name={TEXT_RADAR_LABEL}
+                  dataKey="value"
+                  stroke="#ff8fa3"
+                  fill="#ffccd5"
+                  fillOpacity={0.8}
+                />
               </RadarChart>
             </ResponsiveContainer>
           ) : (
@@ -528,99 +581,139 @@ const RealLearningRecordDetail = () => {
         </Card>
 
         {questionText && (
-          <Card className="p-5 bg-white shadow-sm">
+          <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm">
             <p className="text-sm text-muted-foreground mb-2">{TEXT_QUESTION_LABEL}</p>
             <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{questionText}</p>
           </Card>
         )}
 
-        <Card className="p-5 bg-white shadow-sm space-y-4">
+        <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm space-y-4">
           <div className="flex items-center gap-2">
-            <Sparkles className="w-5 h-5 text-pink-600" />
+            <Sparkles className="w-5 h-5 text-primary-500" />
             <h3>{TEXT_INTERVIEW_VIDEO_TITLE}</h3>
           </div>
           {interviewHistory.length > 0 ? (
-            <div className="space-y-4">
-              {interviewHistory.map((turn, idx) => {
-                const turnKey = buildTurnVideoKey(turn.turnOrder, idx);
-                const resolvedVideoUrl = toTrimmedString(
-                  resolvedVideoSources[turnKey] ?? turn.videoPlayUrl
-                );
-                const hasVideoLoadFailed = Boolean(videoLoadFailedMap[turnKey]);
-                const canRenderVideoPlayer = Boolean(resolvedVideoUrl) && !hasVideoLoadFailed;
-                const displayTopicOrder = Math.max(turn.turnOrder + 1, 1);
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-muted-foreground">
+                  {activeTurnIndex + 1} / {interviewHistory.length}
+                </p>
+                {interviewHistory.length > 1 && (
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={handlePrevTurn}
+                      disabled={activeTurnIndex === 0}
+                      className="h-8 w-8 inline-flex items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+                      aria-label={TEXT_PREV_TOPIC}
+                    >
+                      <ChevronLeft className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleNextTurn}
+                      disabled={activeTurnIndex >= interviewHistory.length - 1}
+                      className="h-8 w-8 inline-flex items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+                      aria-label={TEXT_NEXT_TOPIC}
+                    >
+                      <ChevronRight className="w-4 h-4" />
+                    </button>
+                  </div>
+                )}
+              </div>
+              <div
+                className="overflow-hidden"
+                onTouchStart={handleCarouselTouchStart}
+                onTouchEnd={handleCarouselTouchEnd}
+              >
+                <div
+                  className="flex transition-transform duration-300 ease-out"
+                  style={{ transform: `translateX(-${activeTurnIndex * 100}%)` }}
+                >
+                  {interviewHistory.map((turn, idx) => {
+                    const turnKey = buildTurnVideoKey(turn.turnOrder, idx);
+                    const resolvedVideoUrl = toTrimmedString(
+                      resolvedVideoSources[turnKey] ?? turn.videoPlayUrl
+                    );
+                    const hasVideoLoadFailed = Boolean(videoLoadFailedMap[turnKey]);
+                    const canRenderVideoPlayer = Boolean(resolvedVideoUrl) && !hasVideoLoadFailed;
+                    const displayTopicOrder = Math.max(turn.turnOrder + 1, 1);
 
-                return (
-                  <div key={turnKey} className="rounded-xl border border-rose-100 bg-rose-50/50 p-4 space-y-3">
-                    <p className="text-sm font-semibold text-rose-700">
-                      {TEXT_TURN_LABEL} {displayTopicOrder}
-                      {turn.category ? ` · ${turn.category}` : ''}
-                    </p>
-                    {turn.question && (
-                      <div className="space-y-1">
-                        <p className="text-xs text-muted-foreground">{TEXT_QUESTION_LABEL}</p>
-                        <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{turn.question}</p>
-                      </div>
-                    )}
-                    <div className="space-y-1">
-                      <p className="text-xs text-muted-foreground">{TEXT_VIDEO_LABEL}</p>
-                      {canRenderVideoPlayer ? (
-                        <div className="relative">
-                          <video
-                            controls
-                            preload="metadata"
-                            playsInline
-                            className="w-full aspect-video rounded-lg border border-gray-200 bg-black"
-                            src={resolvedVideoUrl}
-                            onError={() => {
-                              void handleTurnVideoLoadError(turn, idx);
-                            }}
-                            onLoadedData={() => {
-                              setVideoReadyMap((prev) => ({ ...prev, [turnKey]: true }));
-                              setVideoLoadFailedMap((prev) => {
-                                if (!prev[turnKey]) return prev;
-                                const next = { ...prev };
-                                delete next[turnKey];
-                                return next;
-                              });
-                            }}
-                          />
-                          {!videoReadyMap[turnKey] && (
-                            <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-black/65">
-                              <p className="text-xs text-white/90">{TEXT_VIDEO_LOADING}</p>
+                    return (
+                      <div key={turnKey} className="w-full shrink-0 px-px">
+                        <div className="rounded-xl border border-primary-100 bg-primary-50/50 p-4 space-y-3">
+                          <p className="text-sm font-semibold text-primary-700">
+                            {TEXT_TURN_LABEL} {displayTopicOrder}
+                            {turn.categoryLabel ? ` · ${turn.categoryLabel}` : ''}
+                          </p>
+                          {turn.question && (
+                            <div className="space-y-1">
+                              <p className="text-xs text-muted-foreground">{TEXT_QUESTION_LABEL}</p>
+                              <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{turn.question}</p>
+                            </div>
+                          )}
+                          <div className="space-y-1">
+                            <p className="text-xs text-muted-foreground">{TEXT_VIDEO_LABEL}</p>
+                            {canRenderVideoPlayer ? (
+                              <div className="relative">
+                                <video
+                                  controls
+                                  preload="metadata"
+                                  playsInline
+                                  className="w-full aspect-video rounded-lg border border-gray-200 bg-black"
+                                  src={resolvedVideoUrl}
+                                  onError={() => {
+                                    void handleTurnVideoLoadError(turn, idx);
+                                  }}
+                                  onLoadedData={() => {
+                                    setVideoReadyMap((prev) => ({ ...prev, [turnKey]: true }));
+                                    setVideoLoadFailedMap((prev) => {
+                                      if (!prev[turnKey]) return prev;
+                                      const next = { ...prev };
+                                      delete next[turnKey];
+                                      return next;
+                                    });
+                                  }}
+                                />
+                                {!videoReadyMap[turnKey] && (
+                                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-black/65">
+                                    <p className="text-xs text-white/90">{TEXT_VIDEO_LOADING}</p>
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-5 text-center">
+                                <p className="text-sm font-medium text-gray-600">{TEXT_VIDEO_MISSING_CARD}</p>
+                              </div>
+                            )}
+                            {canRenderVideoPlayer && (
+                              <p className="text-xs text-muted-foreground">
+                                {turn.videoExpiresAt
+                                  ? `${TEXT_VIDEO_EXPIRES_LABEL} (${turn.videoExpiresAt})`
+                                  : TEXT_VIDEO_EXPIRES_LABEL}
+                              </p>
+                            )}
+                          </div>
+                          {turn.answerText && (
+                            <div className="space-y-1">
+                              <p className="text-xs text-muted-foreground">{TEXT_MY_ANSWER_LABEL}</p>
+                              <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{turn.answerText}</p>
                             </div>
                           )}
                         </div>
-                      ) : (
-                        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-5 text-center">
-                          <p className="text-sm font-medium text-gray-600">{TEXT_VIDEO_MISSING_CARD}</p>
-                        </div>
-                      )}
-                      {canRenderVideoPlayer && (
-                        <p className="text-xs text-muted-foreground">
-                          {turn.videoExpiresAt
-                            ? `${TEXT_VIDEO_EXPIRES_LABEL} (${turn.videoExpiresAt})`
-                            : TEXT_VIDEO_EXPIRES_LABEL}
-                        </p>
-                      )}
-                    </div>
-                    {turn.answerText && (
-                      <div className="space-y-1">
-                        <p className="text-xs text-muted-foreground">{TEXT_MY_ANSWER_LABEL}</p>
-                        <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">{turn.answerText}</p>
                       </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+                    );
+                  })}
+                </div>
+                </div>
+              </div>
           ) : (
             <p className="text-sm text-muted-foreground">{TEXT_INTERVIEW_VIDEO_EMPTY}</p>
           )}
         </Card>
 
         {hasKeywordSummary && (
-          <Card className="p-5 bg-white shadow-sm space-y-3">
+          <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm space-y-3">
             <h3>{TEXT_COVERAGE}</h3>
             <p className="text-sm text-gray-700">
               {coveragePercent === null ? TEXT_FEEDBACK_EMPTY : `${coveragePercent}%`}
@@ -633,7 +726,7 @@ const RealLearningRecordDetail = () => {
                 </p>
               </div>
               <div>
-                <p className="text-xs text-rose-700 mb-1">{TEXT_MISSING}</p>
+                <p className="text-xs text-amber-700 mb-1">{TEXT_MISSING}</p>
                 <p className="text-sm text-gray-700">
                   {missingKeywords.length > 0 ? missingKeywords.join(', ') : TEXT_NONE}
                 </p>
@@ -643,18 +736,18 @@ const RealLearningRecordDetail = () => {
         )}
 
         {topicsFeedback.length > 0 && (
-          <Card className="p-5 bg-white shadow-sm space-y-3">
+          <Card className="p-5 bg-white rounded-2xl border border-gray-100 shadow-sm space-y-3">
             <div className="flex items-center gap-2">
-              <ListChecks className="w-5 h-5 text-pink-600" />
+              <ListChecks className="w-5 h-5 text-primary-500" />
               <h3>{TEXT_TOPIC_FEEDBACK_TITLE}</h3>
             </div>
             <div className="space-y-3">
               {topicsFeedback.map((topic, idx) => (
                 <div
                   key={`${topic?.topic_id ?? 'topic'}-${idx}`}
-                  className="rounded-xl border border-rose-100 bg-rose-50/60 p-4 space-y-3"
+                  className="rounded-xl border border-primary-100 bg-primary-50/60 p-4 space-y-3"
                 >
-                  <p className="text-sm text-rose-700 font-semibold">
+                  <p className="text-sm text-primary-700 font-semibold">
                     {TEXT_TOPIC_LABEL} {topic?.topic_id ?? idx + 1}
                   </p>
                   <p className="text-[15px] leading-relaxed text-gray-900">
@@ -666,7 +759,7 @@ const RealLearningRecordDetail = () => {
                     {renderFeedbackText(topic?.strengths, 'text-sm text-gray-700')}
                   </div>
                   <div>
-                    <p className="text-sm font-semibold text-pink-700 mb-1.5">{TEXT_TOPIC_IMPROVEMENTS}</p>
+                    <p className="text-sm font-semibold text-amber-700 mb-1.5">{TEXT_TOPIC_IMPROVEMENTS}</p>
                     {renderFeedbackText(topic?.improvements, 'text-sm text-gray-700')}
                   </div>
                 </div>
@@ -675,33 +768,33 @@ const RealLearningRecordDetail = () => {
           </Card>
         )}
 
-        <Card className="p-5 border-2 border-rose-200 bg-rose-50">
+        <Card className="p-5 rounded-2xl border border-emerald-100 bg-emerald-50/70 shadow-sm">
           <div className="flex items-start gap-3">
-            <div className="w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center flex-shrink-0">
-              <ThumbsUp className="w-5 h-5 text-pink-600" />
+            <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+              <ThumbsUp className="w-5 h-5 text-emerald-600" />
             </div>
             <div className="flex-1">
-              <h3 className="mb-2 text-rose-900">{TEXT_STRENGTHS_TITLE}</h3>
-              {renderFeedbackText(overallFeedback?.strengths, 'text-sm text-rose-800')}
+              <h3 className="mb-2 text-emerald-900">{TEXT_STRENGTHS_TITLE}</h3>
+              {renderFeedbackText(overallFeedback?.strengths, 'text-sm text-gray-700')}
             </div>
           </div>
         </Card>
 
-        <Card className="p-5 border-2 border-pink-200 bg-pink-50">
+        <Card className="p-5 rounded-2xl border border-amber-100 bg-amber-50/70 shadow-sm">
           <div className="flex items-start gap-3">
-            <div className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0">
-              <AlertCircle className="w-5 h-5 text-pink-600" />
+            <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+              <AlertCircle className="w-5 h-5 text-amber-600" />
             </div>
             <div className="flex-1">
-              <h3 className="mb-2 text-pink-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
-              {renderFeedbackText(overallFeedback?.improvements, 'text-sm text-pink-800')}
+              <h3 className="mb-2 text-amber-900">{TEXT_IMPROVEMENTS_TITLE}</h3>
+              {renderFeedbackText(overallFeedback?.improvements, 'text-sm text-gray-700')}
             </div>
           </div>
         </Card>
 
         <Button
           onClick={() => navigate('/profile')}
-          className="w-full rounded-xl h-12 gap-2"
+          className="w-full rounded-xl h-12 gap-2 shadow-sm"
           variant="default"
         >
           <Home className="w-5 h-5" />

--- a/src/app/utils/metricOrder.js
+++ b/src/app/utils/metricOrder.js
@@ -1,0 +1,63 @@
+const METRIC_DISPLAY_ORDER = ['논리력', '완성도', '전달력', '정확도', '구체성']
+
+const METRIC_ALIAS_TO_KR = {
+  logic: '논리력',
+  logicality: '논리력',
+  completeness: '완성도',
+  communication: '전달력',
+  delivery: '전달력',
+  accuracy: '정확도',
+  specificity: '구체성',
+}
+
+const METRIC_ORDER_INDEX = METRIC_DISPLAY_ORDER.reduce((acc, name, index) => {
+  acc[name] = index
+  return acc
+}, {})
+
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  return trimmed || ''
+}
+
+const resolveCanonicalMetricName = (metricName) => {
+  const normalized = toTrimmedString(metricName)
+  if (!normalized) return ''
+  if (Object.prototype.hasOwnProperty.call(METRIC_ORDER_INDEX, normalized)) {
+    return normalized
+  }
+
+  const aliasMatched = METRIC_ALIAS_TO_KR[normalized.toLowerCase()]
+  return aliasMatched || normalized
+}
+
+export const getMetricOrderIndex = (metricName) => {
+  const canonicalName = resolveCanonicalMetricName(metricName)
+  if (!canonicalName) return Number.MAX_SAFE_INTEGER
+  if (!Object.prototype.hasOwnProperty.call(METRIC_ORDER_INDEX, canonicalName)) {
+    return Number.MAX_SAFE_INTEGER
+  }
+  return METRIC_ORDER_INDEX[canonicalName]
+}
+
+export const sortMetricsByDisplayOrder = (metrics, getMetricName) => {
+  if (!Array.isArray(metrics) || metrics.length <= 1) return Array.isArray(metrics) ? metrics : []
+
+  const readMetricName = typeof getMetricName === 'function'
+    ? getMetricName
+    : (metric) => metric?.name
+
+  return metrics
+    .map((metric, originalIndex) => ({
+      metric,
+      originalIndex,
+      orderIndex: getMetricOrderIndex(readMetricName(metric)),
+    }))
+    .sort((a, b) => {
+      if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex
+      return a.originalIndex - b.originalIndex
+    })
+    .map((item) => item.metric)
+}
+


### PR DESCRIPTION
### 요약

  - 실전면접에서 TTS 재생 완료 전 답변 시작 제한 및 남은 재생시간 표시를 추가했습니다.
  - STT 완료 후 내 답변 패널 자동 오픈을 제거하고, 미확인 상태를 아이콘으로 안내하도록 변경했습니다.
  - 실전면접 상태 안내/헤더 표시를 정리하고, 연습 음성답변/편집 UX를 개선했습니다.
  - 결과/학습기록 화면의 헤더/카드 톤을 파스텔 기반으로 통일하고 가독성을 높였습니다.
  - 레이더 차트 메트릭 표시 순서를 통일하는 유틸을 추가했습니다.
  - 토스트 위치/스와이프 동작을 개선했습니다.

###  변경 파일

  - src/app/components/ui/sonner.jsx
  - src/app/hooks/useQuestionTtsPlayer.js
  - src/app/pages/LearningRecordDetail.jsx
  - src/app/pages/PracticeAnswerEdit.jsx
  - src/app/pages/PracticeAnswerVoice.jsx
  - src/app/pages/PracticeResultAI.jsx
  - src/app/pages/RealInterview.jsx
  - src/app/pages/RealInterviewResultAI.jsx
  - src/app/pages/RealInterviewSession.jsx
  - src/app/pages/RealLearningRecordDetail.jsx
  - src/app/utils/metricOrder.js

###  구현 의도

  - 면접 플로우를 실제 진행 맥락에 맞게 통제해 사용자 혼선을 줄입니다.
  - “자동으로 뜨는 UI”보다 사용자가 직접 확인/제출을 제어하도록 바꿔 실수 가능성을 낮춥니다.
  - 결과/기록 화면의 컬러/정보 구조를 일관되게 맞춰 피로도를 줄이고 핵심 정보 전달력을 높입니다.
  - 평가 지표 순서를 고정해 화면/모드 간 비교 가능성을 확보합니다.

 ### 목적

  - 실전면접 사용성 개선(진입-답변-제출-다음질문 흐름 안정화)
  - 피드백/학습기록 가독성 개선
  - UI 일관성 강화 및 인지 부하 감소

### 관련 커밋
  - #172 