### PR TITLE
fix: 포트폴리오 프로젝트 작성/조회 UX와 업로드 흐름 개선

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,7 +11,7 @@ VITE_API_BASE_URL=https://dev.q-feed.com
 VITE_SHOW_REAL_INTERVIEW=true
 
 # Show "Portfolio Interview" entry point (true/false)
-VITE_SHOW_PORTFOLIO_INTERVIEW=false
+VITE_SHOW_PORTFOLIO_INTERVIEW=true
 
 # SHow "Notification icon" entry Point(true/false)
 VITE_SHOW_NOTIFICATIONS=true

--- a/src/api/portfolioApi.js
+++ b/src/api/portfolioApi.js
@@ -1,0 +1,44 @@
+import { api } from '@/utils/apiUtils'
+
+export async function fetchTechStacks({ q, cursor, size = 20, signal } = {}) {
+  const params = new URLSearchParams()
+  const normalizedQuery = typeof q === 'string' ? q.trim() : ''
+
+  if (normalizedQuery) {
+    params.set('q', normalizedQuery)
+  }
+
+  if (cursor !== undefined && cursor !== null && cursor !== '') {
+    params.set('cursor', String(cursor))
+  }
+
+  if (Number.isFinite(size) && size > 0) {
+    params.set('size', String(Math.min(size, 100)))
+  }
+
+  const queryString = params.toString()
+
+  return api.get(queryString ? `/api/tech-stacks?${queryString}` : '/api/tech-stacks', {
+    parseResponse: true,
+    signal,
+  })
+}
+
+export async function fetchMyPortfolio({ signal } = {}) {
+  return api.get('/api/portfolio/me', {
+    parseResponse: true,
+    signal,
+  })
+}
+
+export async function replaceMyPortfolio(payload) {
+  return api.put('/api/portfolio/me', payload, {
+    parseResponse: true,
+  })
+}
+
+export async function deleteMyPortfolio() {
+  return api.delete('/api/portfolio/me', {
+    parseResponse: true,
+  })
+}

--- a/src/app/components/PortfolioProjectFields.jsx
+++ b/src/app/components/PortfolioProjectFields.jsx
@@ -1,0 +1,305 @@
+import { useRef, useState } from 'react'
+import { Button } from '@/app/components/ui/button'
+import { Card } from '@/app/components/ui/card'
+import { Input } from '@/app/components/ui/input'
+import { Textarea } from '@/app/components/ui/textarea'
+import ProjectDescriptionGuideDialog from '@/app/components/ProjectDescriptionGuideDialog'
+import {
+  MAX_PROJECT_CONTENT_LENGTH,
+  MAX_PROJECT_NAME_LENGTH,
+  getImageFileName,
+} from '@/app/utils/portfolio'
+import { Check, Loader2, Search, Upload, X } from 'lucide-react'
+
+function PortfolioProjectFields({
+  formData,
+  imagePreviewUrl,
+  techStacks,
+  selectedTechStacks,
+  techStackSearch,
+  isTechStacksLoading,
+  isTechStacksSearching,
+  techStacksErrorMessage,
+  emptyTechStacksMessage,
+  hasNextTechStacks,
+  isFetchingNextTechStacks,
+  onFieldChange,
+  onTechStackSearchChange,
+  onTechStackToggle,
+  onLoadMoreTechStacks,
+  onFileUpload,
+  onFileRemove,
+}) {
+  const techStackFieldRef = useRef(null)
+  const [isTechStackDropdownOpen, setIsTechStackDropdownOpen] = useState(false)
+  const architectureFileName = getImageFileName(
+    formData.architectureImageFile || formData.architectureImageUrl
+  )
+  const hasTechStackSearch = techStackSearch.trim().length > 0
+  const shouldScrollTechStacks = techStacks.length > 5
+  const shouldShowTechStackDropdown =
+    isTechStackDropdownOpen && (
+      hasTechStackSearch || isTechStacksLoading || Boolean(techStacksErrorMessage)
+    )
+
+  const handleTechStackFieldBlur = (event) => {
+    const nextFocusedElement = event.relatedTarget
+
+    if (techStackFieldRef.current?.contains(nextFocusedElement)) {
+      return
+    }
+
+    setIsTechStackDropdownOpen(false)
+  }
+
+  const handleTechStackSearchInputChange = (event) => {
+    setIsTechStackDropdownOpen(true)
+    onTechStackSearchChange(event.target.value)
+  }
+
+  const handleTechStackSelect = (techStackId) => {
+    onTechStackToggle(techStackId)
+    setIsTechStackDropdownOpen(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <label className="mb-2 block text-sm text-muted-foreground">
+          프로젝트 이름 *
+        </label>
+        <Input
+          placeholder="프로젝트 이름을 작성해주세요."
+          value={formData.projectName}
+          onChange={(event) => {
+            const value = event.target.value
+            if (value.length <= MAX_PROJECT_NAME_LENGTH) {
+              onFieldChange('projectName', value)
+            }
+          }}
+          maxLength={MAX_PROJECT_NAME_LENGTH}
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          {formData.projectName.length}/{MAX_PROJECT_NAME_LENGTH}자
+        </p>
+      </section>
+
+      <section>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <label className="block text-sm text-muted-foreground">기술 스택 *</label>
+          <span className="text-xs text-muted-foreground">
+            {formData.techStackIds.length}개 선택
+          </span>
+        </div>
+
+        <div
+          ref={techStackFieldRef}
+          className="relative"
+          onBlur={handleTechStackFieldBlur}
+        >
+          <Search className="pointer-events-none absolute left-3 top-1/2 z-[1] h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          {isTechStacksSearching && (
+            <Loader2 className="pointer-events-none absolute right-3 top-1/2 z-[1] h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+          )}
+          <Input
+            className={isTechStacksSearching ? 'pl-9 pr-9' : 'pl-9'}
+            placeholder="기술 스택 검색"
+            value={techStackSearch}
+            onFocus={() => setIsTechStackDropdownOpen(true)}
+            onChange={handleTechStackSearchInputChange}
+          />
+
+          {shouldShowTechStackDropdown && (
+            <div className="absolute left-0 right-0 top-[calc(100%+8px)] z-20 overflow-hidden rounded-[14px] border border-[#EEEEEE] bg-white shadow-[0_10px_24px_rgba(0,0,0,0.08)]">
+              {techStacksErrorMessage ? (
+                <p className="px-4 py-3 text-sm text-destructive">
+                  {techStacksErrorMessage}
+                </p>
+              ) : isTechStacksLoading ? (
+                <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>기술 스택을 불러오는 중입니다.</span>
+                </div>
+              ) : techStacks.length === 0 ? (
+                <p className="px-4 py-3 text-sm text-muted-foreground">
+                  검색 결과가 없습니다.
+                </p>
+              ) : (
+                <div
+                  className={shouldScrollTechStacks
+                    ? 'max-h-[18rem] space-y-1 overflow-y-auto p-2 overscroll-contain'
+                    : 'space-y-1 p-2'}
+                >
+                  {techStacks.map((techStack) => {
+                    const isSelected = formData.techStackIds.includes(techStack.techStackId)
+
+                    return (
+                      <button
+                        key={techStack.techStackId}
+                        type="button"
+                        onClick={() => handleTechStackSelect(techStack.techStackId)}
+                        className={`flex w-full items-start justify-between rounded-[12px] px-3 py-3 text-left transition-colors ${
+                          isSelected
+                            ? 'bg-primary-50 text-primary-700'
+                            : 'bg-white hover:bg-[#FAF7F2]'
+                        }`}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium text-current">{techStack.name}</p>
+                          {techStack.description && (
+                            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                              {techStack.description}
+                            </p>
+                          )}
+                        </div>
+                        <div
+                          className={`ml-3 mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border ${
+                            isSelected
+                              ? 'border-primary-500 bg-primary-500 text-white'
+                              : 'border-[#D9D9D9] text-transparent'
+                          }`}
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+
+              {hasNextTechStacks && !techStacksErrorMessage && techStacks.length > 0 && (
+                <div className="border-t border-[#F3F3F3] p-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={onLoadMoreTechStacks}
+                    disabled={isFetchingNextTechStacks}
+                    className="h-10 w-full justify-center rounded-[10px] border border-[#F3F3F3] bg-white text-sm text-[#616161] hover:bg-[#FAF7F2]"
+                  >
+                    {isFetchingNextTechStacks ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        더 불러오는 중...
+                      </>
+                    ) : (
+                      '기술 스택 더 보기'
+                    )}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {selectedTechStacks.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {selectedTechStacks.map((techStack) => (
+              <button
+                key={techStack.techStackId}
+                type="button"
+                onClick={() => onTechStackToggle(techStack.techStackId)}
+                className="inline-flex items-center gap-1 rounded-full border border-primary-200 bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700 transition-colors hover:bg-primary-100"
+              >
+                <span>{techStack.name}</span>
+                <X className="h-3 w-3" />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {!hasTechStackSearch && selectedTechStacks.length === 0 && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {emptyTechStacksMessage}
+          </p>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <label className="block text-sm text-muted-foreground">
+            해결한 문제 / 성과 *
+          </label>
+          <ProjectDescriptionGuideDialog />
+        </div>
+        <Textarea
+          placeholder="무엇을 만들었고, 어떤 문제를 어떻게 해결해 어떤 결과를 냈는지 적어주세요."
+          value={formData.content}
+          onChange={(event) => {
+            const value = event.target.value
+            if (value.length <= MAX_PROJECT_CONTENT_LENGTH) {
+              onFieldChange('content', value)
+            }
+          }}
+          maxLength={MAX_PROJECT_CONTENT_LENGTH}
+          rows={10}
+          className="h-56 min-h-56 max-h-56 overflow-y-auto resize-none"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          {formData.content.length}/{MAX_PROJECT_CONTENT_LENGTH}자
+        </p>
+      </section>
+
+      <section>
+        <label className="mb-2 block text-sm text-muted-foreground">
+          시스템 아키텍처
+        </label>
+        <Card className="gap-3 p-4">
+          {architectureFileName ? (
+            <>
+              <div className="flex items-center justify-between gap-3">
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {architectureFileName}
+                </span>
+                <div className="flex gap-2">
+                  <label className="cursor-pointer">
+                    <Button variant="outline" size="sm" asChild>
+                      <span>
+                        <Upload className="mr-1 h-4 w-4" />
+                        첨부하기
+                      </span>
+                    </Button>
+                    <input
+                      type="file"
+                      accept=".jpg,.jpeg,.png,.gif"
+                      onChange={onFileUpload}
+                      className="hidden"
+                    />
+                  </label>
+                  <Button variant="outline" size="sm" onClick={onFileRemove}>
+                    <X className="mr-1 h-4 w-4" />
+                    삭제
+                  </Button>
+                </div>
+              </div>
+
+              {imagePreviewUrl && (
+                <img
+                  src={imagePreviewUrl}
+                  alt="시스템 아키텍처 미리보기"
+                  className="max-h-60 w-full rounded-xl border border-[#F3F3F3] object-contain"
+                />
+              )}
+            </>
+          ) : (
+            <label className="cursor-pointer">
+              <Button variant="outline" size="sm" asChild>
+                <span>
+                  <Upload className="mr-1 h-4 w-4" />
+                  첨부하기
+                </span>
+              </Button>
+              <input
+                type="file"
+                accept=".jpg,.jpeg,.png,.gif"
+                onChange={onFileUpload}
+                className="hidden"
+              />
+            </label>
+          )}
+        </Card>
+      </section>
+    </div>
+  )
+}
+
+export default PortfolioProjectFields

--- a/src/app/components/ProjectDescriptionGuideDialog.jsx
+++ b/src/app/components/ProjectDescriptionGuideDialog.jsx
@@ -1,0 +1,278 @@
+import { useRef, useState } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cn } from '@/app/components/ui/utils'
+import { Sparkles, X } from 'lucide-react'
+
+const GUIDE_PAGES = [
+  {
+    title: '좋은 설명은 질문을 더 정확하게 만듭니다',
+    content: (
+      <div className="space-y-3">
+        <section className="rounded-[20px] border border-[#F4E9DD] bg-white p-4 shadow-[0_2px_10px_rgba(0,0,0,0.03)]">
+          <p className="text-sm font-semibold tracking-[0.01em] text-primary-600">
+            AI 질문의 출발점
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#424242]">
+            프로젝트 설명은 단순 소개문이 아니라, AI 면접 질문의 기반이 되는 정보예요.
+            무엇을 만들었는지, 어떤 문제를 해결했는지, 어떤 방식으로 개선했는지,
+            결과가 무엇이었는지가 보여야 질문도 더 정확하고 깊어집니다.
+          </p>
+        </section>
+
+        <section className="rounded-[20px] border border-[#F4E9DD] bg-[#FFF7F4] p-4">
+          <p className="text-sm font-semibold tracking-[0.01em] text-[#C25A74]">
+            면접관이 빠르게 읽을 수 있어야 해요
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#424242]">
+            Jakob Nielsen과 John Morkes의 가독성 연구에 따르면 사람들은 화면의 긴 설명을 처음부터 끝까지 읽기보다 먼저 훑으면서
+            핵심을 찾는 경향이 있어요. 길게 쓰기보다, 구조가 보이게 쓰는 편이 훨씬 유리해요.
+          </p>
+        </section>
+
+        <section className="rounded-[20px] border border-[#F4E9DD] bg-white p-4 shadow-[0_2px_10px_rgba(0,0,0,0.03)]">
+          <p className="text-sm font-semibold tracking-[0.01em] text-[#7A5C3D]">
+            이렇게 정리해보세요
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {['무엇을 만들었는지', '문제', '해결 방법', '결과'].map((label) => (
+              <span
+                key={label}
+                className="rounded-full bg-[#F7F2EB] px-3 py-1 text-xs font-medium text-[#5F5A52]"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+          <div className="mt-3 rounded-2xl bg-[#FFF1F4] px-4 py-3 text-sm leading-6 text-[#5B4B50]">
+            권장 글자 수는 <span className="font-semibold text-[#D25574]">350~600자</span>
+            예요. 한 줄 소개로 시작한 뒤, <span className="font-semibold">문제 → 해결 방법 → 결과</span>
+            순서로 쓰면 읽는 사람이 훨씬 빠르게 이해할 수 있습니다.
+          </div>
+        </section>
+      </div>
+    ),
+  },
+  {
+    title: '실제 예시',
+    content: (
+      <div className="space-y-4">
+        <section className="rounded-[22px] border border-[#F4E9DD] bg-white p-4 shadow-[0_2px_10px_rgba(0,0,0,0.03)]">
+          <p className="text-sm font-semibold tracking-[0.01em] text-primary-600">
+            예시 본문
+          </p>
+          <p className="mt-3 text-sm leading-7 text-[#424242]">
+            팀 프로젝트로 개발한 실시간 코드 리뷰 협업 플랫폼입니다. 기존에는 리뷰 요청이
+            슬랙, 문서, 깃허브 코멘트로 흩어져 있어 피드백 누락이 자주 발생했고, 리뷰
+            대기 시간이 길어져 배포 일정이 밀리는 문제가 있었습니다. 저는 프론트엔드와
+            일부 백엔드 API 설계를 맡아 PR 상태, 리뷰 우선순위, 미응답 시간을 한 화면에서
+            볼 수 있는 대시보드를 구현했고, 웹소켓 알림과 자동 리마인드 기능을 추가했습니다.
+            또 리뷰 목록 조회 API를 캐시 가능한 구조로 바꾸고 첫 화면 번들 크기를 줄여 초기
+            로딩 시간을 3.8초에서 1.6초로 개선했습니다. 그 결과 주간 평균 리뷰 완료 시간이
+            32% 단축됐고, 누락된 리뷰 건수도 크게 줄어 팀 내부에서 실제 운영 도구로 계속
+            사용하게 됐습니다.
+          </p>
+        </section>
+
+        <section className="rounded-[22px] border border-[#F4E9DD] bg-[#FFF7F4] p-4">
+          <p className="text-sm font-semibold tracking-[0.01em] text-[#C25A74]">
+            포인트 요약
+          </p>
+          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div className="rounded-2xl bg-white px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#9A8F82]">
+                무엇을 만들었는지
+              </p>
+              <p className="mt-1 text-sm leading-6 text-[#424242]">
+                실시간 코드 리뷰 협업 플랫폼
+              </p>
+            </div>
+            <div className="rounded-2xl bg-white px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#9A8F82]">
+                문제
+              </p>
+              <p className="mt-1 text-sm leading-6 text-[#424242]">
+                리뷰 요청이 분산돼 피드백 누락과 일정 지연이 발생함
+              </p>
+            </div>
+            <div className="rounded-2xl bg-white px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#9A8F82]">
+                해결 방법
+              </p>
+              <p className="mt-1 text-sm leading-6 text-[#424242]">
+                대시보드, 웹소켓 알림, 자동 리마인드, 조회 성능 개선
+              </p>
+            </div>
+            <div className="rounded-2xl bg-white px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#9A8F82]">
+                결과
+              </p>
+              <p className="mt-1 text-sm leading-6 text-[#424242]">
+                초기 로딩 3.8초 → 1.6초, 리뷰 완료 시간 32% 단축
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    ),
+  },
+]
+
+const LAST_PAGE_INDEX = GUIDE_PAGES.length - 1
+const SWIPE_THRESHOLD = 56
+
+function ProjectDescriptionGuideDialog() {
+  const [open, setOpen] = useState(false)
+  const [currentPage, setCurrentPage] = useState(0)
+  const touchStartXRef = useRef(null)
+
+  const goToPage = (pageIndex) => {
+    const nextPage = Math.max(0, Math.min(pageIndex, LAST_PAGE_INDEX))
+    setCurrentPage(nextPage)
+  }
+
+  const handleOpenChange = (nextOpen) => {
+    setOpen(nextOpen)
+
+    if (nextOpen) {
+      setCurrentPage(0)
+    }
+  }
+
+  const handleTouchStart = (event) => {
+    touchStartXRef.current = event.changedTouches?.[0]?.clientX ?? null
+  }
+
+  const handleTouchEnd = (event) => {
+    const startX = touchStartXRef.current
+    touchStartXRef.current = null
+
+    if (startX == null) return
+
+    const endX = event.changedTouches?.[0]?.clientX ?? startX
+    const deltaX = endX - startX
+
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD) return
+
+    if (deltaX < 0) {
+      goToPage(currentPage + 1)
+      return
+    }
+
+    goToPage(currentPage - 1)
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+      <DialogPrimitive.Trigger asChild>
+        <button
+          type="button"
+          className="inline-flex h-8 items-center gap-1.5 rounded-full border border-primary-100 bg-primary-50 px-3 text-xs font-medium text-primary-700 transition-colors hover:border-primary-200 hover:bg-primary-100"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          작성 가이드 보기
+        </button>
+      </DialogPrimitive.Trigger>
+
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[220] bg-black/55 backdrop-blur-[2px]" />
+
+        <DialogPrimitive.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[221] flex h-[min(42rem,calc(100dvh-48px))] max-h-[calc(100dvh-48px)] w-[calc(100%-32px)] max-w-[29rem] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-[24px] border border-[#EFE5D9] bg-[#FFFDF8] shadow-[0_20px_60px_rgba(0,0,0,0.18)] outline-none',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-6 data-[state=closed]:slide-out-to-bottom-4 duration-300'
+          )}
+        >
+          <DialogPrimitive.Title className="sr-only">
+            프로젝트 설명 작성 가이드
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            프로젝트 설명을 문제, 해결 방법, 결과 구조로 정리하는 2페이지 가이드
+          </DialogPrimitive.Description>
+
+          <div className="border-b border-[#F3EDE3] bg-[linear-gradient(180deg,#FFF7F2_0%,#FFFDF8_100%)] px-5 pb-4 pt-5 sm:px-6 sm:pt-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <div className="inline-flex items-center gap-1.5 rounded-full border border-[#F9DCE5] bg-white/90 px-3 py-1 text-xs font-medium text-[#D25574]">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  작성 가이드
+                </div>
+                <p className="mt-3 text-[20px] font-semibold leading-snug text-[#212121]">
+                  면접관이 쉽게 읽을 수 있는 설명 구조
+                </p>
+                <p className="mt-1.5 text-sm leading-6 text-[#616161]">
+                  AI가 질문을 만들고, 면접관이 빠르게 이해할 수 있도록 핵심만 구조적으로
+                  정리해보세요.
+                </p>
+              </div>
+
+              <DialogPrimitive.Close asChild>
+                <button
+                  type="button"
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[#EFE8DC] bg-white text-[#757575] transition-colors hover:bg-[#FAF7F2]"
+                  aria-label="닫기"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </DialogPrimitive.Close>
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                {GUIDE_PAGES.map((page, pageIndex) => (
+                  <button
+                    key={page.title}
+                    type="button"
+                    onClick={() => goToPage(pageIndex)}
+                    className={cn(
+                      'h-2.5 rounded-full transition-all',
+                      pageIndex === currentPage
+                        ? 'w-6 bg-primary-500'
+                        : 'w-2.5 bg-[#E4DBCF] hover:bg-[#D5C8B6]'
+                    )}
+                    aria-label={`${pageIndex + 1}페이지로 이동`}
+                  />
+                ))}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => goToPage(currentPage === 0 ? 1 : 0)}
+                  className="rounded-full border border-[#EFE8DC] bg-white px-3 py-1.5 text-xs font-medium text-[#616161] transition-colors hover:bg-[#FAF7F2]"
+                >
+                  {currentPage === 0 ? '예시 보기' : '원칙 보기'}
+                </button>
+                <div className="rounded-full bg-white/90 px-2.5 py-1 text-xs font-medium text-[#757575]">
+                  {currentPage + 1}/{GUIDE_PAGES.length}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <div
+              className="flex h-full transition-transform duration-300 ease-out"
+              style={{ transform: `translateX(-${currentPage * 100}%)` }}
+            >
+              {GUIDE_PAGES.map((page) => (
+                <div
+                  key={page.title}
+                  className="min-h-0 h-full max-h-full w-full shrink-0 overflow-y-auto touch-pan-y overscroll-contain px-5 pb-6 pt-5 [-webkit-overflow-scrolling:touch] sm:px-6 sm:pb-6"
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                >
+                  <p className="text-lg font-semibold leading-snug text-[#212121]">
+                    {page.title}
+                  </p>
+                  <div className="mt-4">{page.content}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}
+
+export default ProjectDescriptionGuideDialog

--- a/src/app/components/ui/card.jsx
+++ b/src/app/components/ui/card.jsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }) {
         <div
             data-slot="card"
             className={cn(
-                "bg-white text-[#212121] flex flex-col gap-6 rounded-[16px] border border-[#F5F5F5] p-5 shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all",
+                "bg-white text-[#212121] flex min-w-0 flex-col gap-6 rounded-[16px] border border-[#F5F5F5] p-5 shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all",
                 className,
             )}
             {...props}

--- a/src/app/components/ui/input.jsx
+++ b/src/app/components/ui/input.jsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }) {
             type={type}
             data-slot="input"
             className={cn(
-                "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex h-[48px] w-full min-w-0 rounded-[12px] border border-[#EEEEEE] px-4 py-[14px] text-[15px] bg-[#FAFAFA] transition-all outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+                "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex h-[48px] w-full min-w-0 rounded-[12px] border border-[#EEEEEE] bg-white px-4 py-[14px] text-[15px] transition-all outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                 "focus-visible:border-[#FF8FA3] focus-visible:ring-[#FFE4E9] focus-visible:ring-[3px] focus-visible:shadow-none",
                 "aria-invalid:ring-[#FFEBEE] aria-invalid:border-[#F44336] dark:aria-invalid:ring-destructive/40",
                 className,

--- a/src/app/components/ui/textarea.jsx
+++ b/src/app/components/ui/textarea.jsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }) {
         <textarea
             data-slot="textarea"
             className={cn(
-                "resize-none border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-input-background px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+                "resize-none border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border border-[#EEEEEE] bg-white px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
                 className,
             )}
             {...props}

--- a/src/app/hooks/usePortfolio.js
+++ b/src/app/hooks/usePortfolio.js
@@ -1,0 +1,196 @@
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import {
+  deleteMyPortfolio,
+  fetchMyPortfolio,
+  fetchTechStacks,
+  replaceMyPortfolio,
+} from '@/api/portfolioApi'
+import { useDebounce } from '@/app/hooks/useDebounce'
+import { isPortfolioNotFoundError } from '@/app/utils/portfolio'
+
+export const PORTFOLIO_QUERY_KEY = ['portfolio', 'me']
+export const TECH_STACKS_QUERY_KEY = ['portfolio', 'tech-stacks']
+const TECH_STACKS_PAGE_SIZE = 20
+
+const EMPTY_PORTFOLIO = Object.freeze({
+  portfolioId: null,
+  projects: [],
+})
+
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  return trimmed || ''
+}
+
+const toNullableString = (value) => {
+  const trimmed = toTrimmedString(value)
+  return trimmed || null
+}
+
+function normalizeTechStack(techStack) {
+  const techStackId = Number(techStack?.techStackId)
+
+  return {
+    techStackId: Number.isInteger(techStackId) ? techStackId : 0,
+    name: toTrimmedString(techStack?.name),
+    description: toTrimmedString(techStack?.description),
+  }
+}
+
+function normalizeProjectTechStack(techStack) {
+  const techStackId = Number(techStack?.techStackId)
+
+  return {
+    techStackId: Number.isInteger(techStackId) ? techStackId : 0,
+    techStackName: toTrimmedString(techStack?.techStackName || techStack?.name),
+  }
+}
+
+function normalizeProject(project) {
+  const projectId = Number(project?.projectId)
+  const architectureImageFileId = Number(
+    project?.architectureImageFileId ??
+      project?.architecture_image_file_id ??
+      project?.architectureImageFile?.fileId ??
+      project?.architectureImageFile?.file_id
+  )
+
+  return {
+    projectId: Number.isInteger(projectId) ? projectId : 0,
+    projectName: toTrimmedString(project?.projectName),
+    content: toTrimmedString(project?.content),
+    architectureImageFileId:
+      Number.isInteger(architectureImageFileId) && architectureImageFileId > 0
+        ? architectureImageFileId
+        : null,
+    architectureImageUrl: toNullableString(
+      project?.architectureImageUrl ??
+        project?.architecture_image_url ??
+        project?.architectureImageFile?.fileUrl ??
+        project?.architectureImageFile?.file_url
+    ),
+    techStacks: Array.isArray(project?.techStacks)
+      ? project.techStacks
+          .map(normalizeProjectTechStack)
+          .filter((techStack) => techStack.techStackId > 0)
+      : [],
+  }
+}
+
+function normalizePortfolioResponse(response) {
+  const payload = response?.data ?? response ?? {}
+  const portfolioId = Number(payload?.portfolioId)
+
+  return {
+    portfolioId: Number.isInteger(portfolioId) ? portfolioId : null,
+    projects: Array.isArray(payload?.projects)
+      ? payload.projects.map(normalizeProject).filter((project) => project.projectId > 0)
+      : [],
+  }
+}
+
+function normalizeTechStacksResponse(response) {
+  const payload = response?.data ?? response ?? {}
+  const pagination = payload?.pagination ?? {}
+
+  return {
+    records: Array.isArray(payload?.techStacks)
+      ? payload.techStacks
+          .map(normalizeTechStack)
+          .filter((techStack) => techStack.techStackId > 0 && techStack.name)
+      : [],
+    pagination: {
+      nextCursor: pagination?.nextCursor ?? null,
+      hasNext: Boolean(pagination?.hasNext),
+      size: Number(pagination?.size) || TECH_STACKS_PAGE_SIZE,
+    },
+  }
+}
+
+export function usePortfolio() {
+  return useQuery({
+    queryKey: PORTFOLIO_QUERY_KEY,
+    queryFn: async ({ signal }) => {
+      try {
+        const response = await fetchMyPortfolio({ signal })
+        return normalizePortfolioResponse(response)
+      } catch (error) {
+        if (isPortfolioNotFoundError(error)) {
+          return EMPTY_PORTFOLIO
+        }
+        throw error
+      }
+    },
+  })
+}
+
+export function useTechStacks({ query = '', size = TECH_STACKS_PAGE_SIZE } = {}) {
+  const normalizedQuery = toTrimmedString(query)
+  const debouncedQuery = useDebounce(normalizedQuery, 300)
+  const hasQuery = debouncedQuery.length > 0
+  const normalizedSize =
+    Number.isFinite(size) && size > 0 ? Math.min(Math.floor(size), 100) : TECH_STACKS_PAGE_SIZE
+
+  const result = useInfiniteQuery({
+    queryKey: [...TECH_STACKS_QUERY_KEY, { query: debouncedQuery, size: normalizedSize }],
+    enabled: hasQuery,
+    queryFn: async ({ pageParam = null, signal }) => {
+      const response = await fetchTechStacks({
+        q: debouncedQuery || undefined,
+        cursor: pageParam,
+        size: normalizedSize,
+        signal,
+      })
+      return normalizeTechStacksResponse(response)
+    },
+    initialPageParam: null,
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasNext ? lastPage.pagination.nextCursor : undefined,
+  })
+
+  const techStacks = useMemo(() => {
+    const records = result.data?.pages?.flatMap((page) => page.records) ?? []
+    const dedupedTechStacks = []
+    const seenIds = new Set()
+
+    records.forEach((techStack) => {
+      if (seenIds.has(techStack.techStackId)) return
+      seenIds.add(techStack.techStackId)
+      dedupedTechStacks.push(techStack)
+    })
+
+    return dedupedTechStacks
+  }, [result.data])
+
+  return {
+    ...result,
+    techStacks,
+    debouncedQuery,
+    hasQuery,
+  }
+}
+
+export function useReplacePortfolio() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: replaceMyPortfolio,
+    onSuccess: async () => {
+      // Mutation response can omit fields used by the list view, so resync from source of truth.
+      await queryClient.invalidateQueries({ queryKey: PORTFOLIO_QUERY_KEY })
+    },
+  })
+}
+
+export function useDeletePortfolio() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: deleteMyPortfolio,
+    onSuccess: () => {
+      queryClient.setQueryData(PORTFOLIO_QUERY_KEY, EMPTY_PORTFOLIO)
+    },
+  })
+}

--- a/src/app/pages/PortfolioManagement.jsx
+++ b/src/app/pages/PortfolioManagement.jsx
@@ -1,98 +1,105 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Card } from '@/app/components/ui/card';
-import { Button } from '@/app/components/ui/button';
-import { AppHeader } from '@/app/components/AppHeader';
-import BottomNav from '@/app/components/BottomNav';
-import { Plus, ChevronRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom'
+import { Card } from '@/app/components/ui/card'
+import { Button } from '@/app/components/ui/button'
+import { AppHeader } from '@/app/components/AppHeader'
+import BottomNav from '@/app/components/BottomNav'
+import { MAX_PORTFOLIO_PROJECTS, getProjectTechStackNames } from '@/app/utils/portfolio'
+import { usePortfolio } from '@/app/hooks/usePortfolio'
+import { ChevronRight, Loader2, Plus, RefreshCw } from 'lucide-react'
 
 const PortfolioManagement = () => {
-  const navigate = useNavigate();
+  const navigate = useNavigate()
+  const {
+    data: portfolio,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = usePortfolio()
 
-  // Mock data for projects (최대 3개)
-  const [projects] = useState([
-    {
-      id: 1,
-      name: '프로젝트 1',
-      description: '프로젝트 축약 설명...',
-      createdAt: '2025.12.29',
-    },
-    {
-      id: 2,
-      name: '프로젝트 2',
-      description: '프로젝트 축약 설명...',
-      createdAt: '2025.12.29',
-    },
-    {
-      id: 3,
-      name: '프로젝트 3',
-      description: '프로젝트 축약 설명...',
-      createdAt: '2025.12.29',
-    },
-  ]);
-
-  const canAddMore = projects.length < 3;
+  const projects = portfolio?.projects ?? []
+  const canAddMore = projects.length < MAX_PORTFOLIO_PROJECTS
 
   return (
     <div className="min-h-screen bg-background pb-20">
       <AppHeader title="내 포트폴리오" onBack={() => navigate('/profile')} />
 
-      <div className="p-6 max-w-lg mx-auto space-y-6">
-        {/* 프로젝트 등록 안내 카드 */}
-        <Card className="p-5 bg-primary-50 border-primary-200">
-          <div className="flex items-center justify-between">
+      <div className="mx-auto max-w-lg space-y-6 p-6">
+        <Card className="border-primary-200 bg-primary-50 p-5">
+          <div className="flex items-center justify-between gap-4">
             <div className="flex-1">
               <h3 className="mb-1 text-primary-700">프로젝트 등록하기</h3>
               <p className="text-sm text-primary-600">
-                프로젝트는 3개까지 등록 가능합니다
+                {projects.length}/{MAX_PORTFOLIO_PROJECTS}개 등록됨
               </p>
             </div>
             <Button
               onClick={() => navigate('/portfolio/add')}
               disabled={!canAddMore}
-              className="bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
               size="sm"
             >
-              <Plus className="w-4 h-4 mr-1" />
+              <Plus className="mr-1 h-4 w-4" />
               등록
             </Button>
           </div>
         </Card>
 
-        {/* 프로젝트 리스트 */}
         <section>
-          {projects.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p>아직 등록된 프로젝트가 없습니다</p>
-            </div>
+          {isLoading ? (
+            <Card className="items-center p-8 text-center">
+              <Loader2 className="mb-3 h-5 w-5 animate-spin text-primary-500" />
+              <p className="text-sm text-muted-foreground">
+                포트폴리오를 불러오는 중입니다.
+              </p>
+            </Card>
+          ) : isError ? (
+            <Card className="items-center p-8 text-center">
+              <p className="mb-4 text-sm text-muted-foreground">
+                {error?.message || '포트폴리오를 불러오지 못했습니다.'}
+              </p>
+              <Button variant="outline" onClick={() => refetch()}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                다시 시도
+              </Button>
+            </Card>
+          ) : projects.length === 0 ? (
+            <Card className="items-center p-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                아직 등록된 프로젝트가 없습니다.
+              </p>
+            </Card>
           ) : (
             <div className="space-y-4">
-              {projects.map((project) => (
-                <Card
-                  key={project.id}
-                  className="p-5 hover:shadow-md transition-shadow cursor-pointer"
-                  onClick={() => navigate(`/portfolio/${project.id}`)}
-                >
-                  <div className="flex items-start justify-between mb-3">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2 mb-2">
-                        <div className="px-3 py-1 bg-primary-100 border border-primary-200 rounded text-xs text-primary-600 font-medium">
-                          {project.name}
+              {projects.map((project) => {
+                const techStackNames = getProjectTechStackNames(project)
+
+                return (
+                  <Card
+                    key={project.projectId}
+                    className="cursor-pointer p-5 transition-shadow hover:shadow-md"
+                    onClick={() => navigate(`/portfolio/${project.projectId}`)}
+                  >
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-2 inline-flex rounded bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700">
+                          {project.projectName}
                         </div>
+                        <p className="line-clamp-2 text-sm text-muted-foreground">
+                          {project.content}
+                        </p>
                       </div>
-                      <p className="text-sm text-muted-foreground line-clamp-2">
-                        {project.description}
-                      </p>
+                      <ChevronRight className="mt-1 h-5 w-5 flex-shrink-0 text-muted-foreground" />
                     </div>
-                    <ChevronRight className="w-5 h-5 text-muted-foreground flex-shrink-0 ml-2" />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {project.createdAt}
-                    </span>
-                  </div>
-                </Card>
-              ))}
+
+                    {techStackNames.length > 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        {techStackNames.join(' · ')}
+                      </p>
+                    )}
+                  </Card>
+                )
+              })}
             </div>
           )}
         </section>
@@ -100,7 +107,7 @@ const PortfolioManagement = () => {
 
       <BottomNav />
     </div>
-  );
-};
+  )
+}
 
-export default PortfolioManagement;
+export default PortfolioManagement

--- a/src/app/pages/ProjectAdd.jsx
+++ b/src/app/pages/ProjectAdd.jsx
@@ -1,12 +1,9 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Card } from '@/app/components/ui/card';
-import { Button } from '@/app/components/ui/button';
-import { Input } from '@/app/components/ui/input';
-import { Textarea } from '@/app/components/ui/textarea';
-import { AppHeader } from '@/app/components/AppHeader';
-import BottomNav from '@/app/components/BottomNav';
-import { Upload, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/app/components/ui/button'
+import { AppHeader } from '@/app/components/AppHeader'
+import BottomNav from '@/app/components/BottomNav'
+import PortfolioProjectFields from '@/app/components/PortfolioProjectFields'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,195 +12,285 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/app/components/ui/alert-dialog';
-import { toast } from 'sonner';
+} from '@/app/components/ui/alert-dialog'
+import {
+  MAX_PORTFOLIO_PROJECTS,
+  buildPortfolioProjectPayload,
+  getSelectedTechStacks,
+  mergeTechStackLookup,
+  resolvePortfolioErrorMessage,
+  toPortfolioProjectPayload,
+  uploadPortfolioImage,
+  validatePortfolioImage,
+} from '@/app/utils/portfolio'
+import { usePortfolio, useReplacePortfolio, useTechStacks } from '@/app/hooks/usePortfolio'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+
+const INITIAL_FORM_DATA = {
+  projectName: '',
+  content: '',
+  techStackIds: [],
+  architectureImageFileId: null,
+  architectureImageUrl: '',
+  architectureImageFile: null,
+}
 
 const ProjectAdd = () => {
-  const navigate = useNavigate();
-  const [showWarningDialog, setShowWarningDialog] = useState(false);
-  const [formData, setFormData] = useState({
-    name: '',
-    techStack: '',
-    architecture: null,
-    description: '',
-  });
+  const navigate = useNavigate()
+  const [showWarningDialog, setShowWarningDialog] = useState(false)
+  const [formData, setFormData] = useState(INITIAL_FORM_DATA)
+  const [techStackSearch, setTechStackSearch] = useState('')
+  const [techStackLookup, setTechStackLookup] = useState({})
+  const [imagePreviewUrl, setImagePreviewUrl] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const isFormValid =
-    formData.name.trim() &&
-    formData.techStack.trim() &&
-    formData.description.trim();
+  const {
+    data: portfolio,
+    isLoading: isPortfolioLoading,
+    isError: isPortfolioError,
+    error: portfolioError,
+    refetch: refetchPortfolio,
+  } = usePortfolio()
+  const {
+    techStacks = [],
+    isLoading: isTechStacksLoading,
+    isFetching: isTechStacksFetching,
+    isFetchingNextPage: isFetchingNextTechStacks,
+    error: techStacksError,
+    hasNextPage: hasNextTechStacks,
+    fetchNextPage: fetchNextTechStacks,
+    refetch: refetchTechStacks,
+    debouncedQuery: debouncedTechStackQuery,
+    hasQuery: hasTechStackQuery,
+  } = useTechStacks({ query: techStackSearch })
+  const replacePortfolioMutation = useReplacePortfolio()
 
-  const handleFileUpload = (e) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      // 파일 크기 체크 (5MB)
-      if (file.size > 5 * 1024 * 1024) {
-        toast.error('이미지는 5MB 이하만 가능합니다.');
-        return;
-      }
+  const projects = portfolio?.projects ?? []
+  const techStackSearchKeyword = techStackSearch.trim()
+  const isFormValid = Boolean(
+    formData.projectName.trim() &&
+      formData.content.trim() &&
+      formData.techStackIds.length > 0
+  )
 
-      // 파일 형식 체크
-      const validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
-      if (!validTypes.includes(file.type)) {
-        toast.error('jpg, jpeg, png, gif 형식만 업로드 가능합니다.');
-        return;
-      }
-
-      setFormData({ ...formData, architecture: file });
+  useEffect(() => {
+    if (!formData.architectureImageFile) {
+      setImagePreviewUrl(formData.architectureImageUrl || '')
+      return undefined
     }
-  };
+
+    const nextPreviewUrl = URL.createObjectURL(formData.architectureImageFile)
+    setImagePreviewUrl(nextPreviewUrl)
+
+    return () => {
+      URL.revokeObjectURL(nextPreviewUrl)
+    }
+  }, [formData.architectureImageFile, formData.architectureImageUrl])
+
+  useEffect(() => {
+    setTechStackLookup((current) => mergeTechStackLookup(current, techStacks))
+  }, [techStacks])
+
+  const isLoading = isPortfolioLoading
+  const isError = isPortfolioError
+  const errorMessage = portfolioError?.message
+  const techStacksEmptyMessage = techStackSearchKeyword
+    ? '검색된 기술 스택이 없습니다.'
+    : '기술 스택 이름을 입력해 검색하세요.'
+
+  const canSubmit = isFormValid && projects.length < MAX_PORTFOLIO_PROJECTS
+
+  const retry = () => {
+    refetchPortfolio()
+    if (hasTechStackQuery) {
+      refetchTechStacks()
+    }
+  }
+
+  const selectedTechStacks = useMemo(
+    () => getSelectedTechStacks(formData.techStackIds, techStackLookup),
+    [formData.techStackIds, techStackLookup]
+  )
+
+  const handleFieldChange = (field, value) => {
+    setFormData((current) => ({
+      ...current,
+      [field]: value,
+    }))
+  }
+
+  const handleTechStackToggle = (techStackId) => {
+    setFormData((current) => {
+      const exists = current.techStackIds.includes(techStackId)
+      return {
+        ...current,
+        techStackIds: exists
+          ? current.techStackIds.filter((value) => value !== techStackId)
+          : [...current.techStackIds, techStackId],
+      }
+    })
+  }
+
+  const handleFileUpload = (event) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+
+    if (!file) return
+
+    const validationMessage = validatePortfolioImage(file)
+    if (validationMessage) {
+      toast.error(validationMessage)
+      return
+    }
+
+    setFormData((current) => ({
+      ...current,
+      architectureImageFileId: null,
+      architectureImageFile: file,
+      architectureImageUrl: '',
+    }))
+  }
 
   const handleRemoveFile = () => {
-    setFormData({ ...formData, architecture: null });
-  };
+    setFormData((current) => ({
+      ...current,
+      architectureImageFileId: null,
+      architectureImageFile: null,
+      architectureImageUrl: '',
+    }))
+  }
 
   const handleSubmit = () => {
-    if (isFormValid) {
-      setShowWarningDialog(true);
-    }
-  };
+    if (!canSubmit) return
 
-  const handleConfirm = () => {
-    toast.success('프로젝트가 추가되었습니다');
-    navigate('/portfolio');
-  };
+    if (projects.length >= MAX_PORTFOLIO_PROJECTS) {
+      toast.error('프로젝트는 3개까지 등록할 수 있습니다.')
+      return
+    }
+
+    setShowWarningDialog(true)
+  }
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true)
+
+    try {
+      const uploadedArchitectureImage = formData.architectureImageFile
+        ? await uploadPortfolioImage(formData.architectureImageFile)
+        : null
+      const architectureImageFileId =
+        uploadedArchitectureImage?.fileId ?? formData.architectureImageFileId
+
+      const newProjectPayload = buildPortfolioProjectPayload({
+        projectName: formData.projectName,
+        content: formData.content,
+        architectureImageFileId,
+        techStackIds: selectedTechStacks.map((techStack) => techStack.techStackId),
+      })
+
+      const response = await replacePortfolioMutation.mutateAsync({
+        projects: [
+          ...projects.map(toPortfolioProjectPayload),
+          newProjectPayload,
+        ],
+      })
+
+      const responseProjects = response?.data?.projects ?? []
+      const savedProject = responseProjects[responseProjects.length - 1]
+
+      toast.success('프로젝트가 추가되었습니다.')
+      navigate(
+        savedProject?.projectId ? `/portfolio/${savedProject.projectId}` : '/portfolio',
+        { replace: true }
+      )
+    } catch (error) {
+      toast.error(resolvePortfolioErrorMessage(error, '프로젝트 추가에 실패했습니다.'))
+    } finally {
+      setIsSubmitting(false)
+      setShowWarningDialog(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="프로젝트 추가" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <Loader2 className="mb-3 h-5 w-5 animate-spin text-primary-500" />
+            <p className="text-sm text-muted-foreground">필수 데이터를 불러오는 중입니다.</p>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="프로젝트 추가" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <p className="mb-4 text-sm text-muted-foreground">
+              {errorMessage || '데이터를 불러오지 못했습니다.'}
+            </p>
+            <Button variant="outline" onClick={retry}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              다시 시도
+            </Button>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-background pb-20">
       <AppHeader title="프로젝트 추가" onBack={() => navigate('/portfolio')} />
 
-      <div className="p-6 max-w-lg mx-auto space-y-6">
-        {/* 프로젝트명 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            프로젝트 이름 *
-          </label>
-          <Input
-            placeholder="프로젝트 이름을 작성해주세요."
-            value={formData.name}
-            onChange={(e) => {
-              const value = e.target.value;
-              if (value.length <= 30) {
-                setFormData({ ...formData, name: value });
-              }
-            }}
-            maxLength={30}
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {formData.name.length}/30자
-          </p>
-        </section>
+      <div className="mx-auto max-w-lg space-y-6 p-6">
+        <PortfolioProjectFields
+          formData={formData}
+          imagePreviewUrl={imagePreviewUrl}
+          techStacks={techStacks}
+          selectedTechStacks={selectedTechStacks}
+          techStackSearch={techStackSearch}
+          isTechStacksLoading={hasTechStackQuery && isTechStacksLoading && techStacks.length === 0}
+          isTechStacksSearching={
+            techStackSearchKeyword !== debouncedTechStackQuery ||
+            (hasTechStackQuery && isTechStacksFetching)
+          }
+          techStacksErrorMessage={techStacksError?.message || ''}
+          emptyTechStacksMessage={techStacksEmptyMessage}
+          hasNextTechStacks={Boolean(hasNextTechStacks)}
+          isFetchingNextTechStacks={isFetchingNextTechStacks}
+          onFieldChange={handleFieldChange}
+          onTechStackSearchChange={setTechStackSearch}
+          onTechStackToggle={handleTechStackToggle}
+          onLoadMoreTechStacks={() => fetchNextTechStacks()}
+          onFileUpload={handleFileUpload}
+          onFileRemove={handleRemoveFile}
+        />
 
-        {/* 기술 스택 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            기술 스택 *
-          </label>
-          <Input
-            placeholder="기술 스택을 작성해주세요(콤마로 구분)"
-            value={formData.techStack}
-            onChange={(e) => {
-              const value = e.target.value;
-              if (value.length <= 100) {
-                setFormData({ ...formData, techStack: value });
-              }
-            }}
-            maxLength={100}
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {formData.techStack.length}/100자
-          </p>
-        </section>
-
-        {/* 시스템 아키텍처 이미지 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            시스템 아키텍처
-          </label>
-          <Card className="p-4">
-            {formData.architecture ? (
-              <div className="flex items-center justify-between">
-                <span className="text-sm truncate flex-1">
-                  {formData.architecture.name}
-                </span>
-                <div className="flex gap-2 ml-2">
-                  <label className="cursor-pointer">
-                    <Button variant="outline" size="sm" asChild>
-                      <span>
-                        <Upload className="w-4 h-4 mr-1" />
-                        첨부하기
-                      </span>
-                    </Button>
-                    <input
-                      type="file"
-                      accept=".jpg,.jpeg,.png,.gif"
-                      onChange={handleFileUpload}
-                      className="hidden"
-                    />
-                  </label>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleRemoveFile}
-                  >
-                    <X className="w-4 h-4 mr-1" />
-                    삭제
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <label className="cursor-pointer">
-                <Button variant="outline" size="sm" asChild>
-                  <span>
-                    <Upload className="w-4 h-4 mr-1" />
-                    첨부하기
-                  </span>
-                </Button>
-                <input
-                  type="file"
-                  accept=".jpg,.jpeg,.png,.gif"
-                  onChange={handleFileUpload}
-                  className="hidden"
-                />
-              </label>
-            )}
-          </Card>
-        </section>
-
-        {/* 프로젝트 설명 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            해결한 문제 / 성과 *
-          </label>
-          <Textarea
-            placeholder="프로젝트 간 겪은 문제와 해결 스토리를 적어주세요"
-            value={formData.description}
-            onChange={(e) => {
-              const value = e.target.value;
-              if (value.length <= 1000) {
-                setFormData({ ...formData, description: value });
-              }
-            }}
-            maxLength={1000}
-            rows={10}
-            className="resize-none"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {formData.description.length}/1000자
-          </p>
-        </section>
-
-        {/* 추가하기 버튼 */}
         <Button
           onClick={handleSubmit}
-          disabled={!isFormValid}
-          className="w-full bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white disabled:opacity-50"
+          disabled={!canSubmit || isSubmitting || replacePortfolioMutation.isPending}
+          className="w-full bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700 disabled:opacity-50"
         >
-          추가하기
+          {isSubmitting || replacePortfolioMutation.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              저장 중...
+            </>
+          ) : (
+            '추가하기'
+          )}
         </Button>
       </div>
 
-      {/* 제출 전 경고 모달 */}
       <AlertDialog open={showWarningDialog} onOpenChange={setShowWarningDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -213,8 +300,8 @@ const ProjectAdd = () => {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirm}>
-              제출하기
+            <AlertDialogAction onClick={handleConfirm} disabled={isSubmitting}>
+              {isSubmitting ? '제출 중...' : '제출하기'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -222,7 +309,7 @@ const ProjectAdd = () => {
 
       <BottomNav />
     </div>
-  );
-};
+  )
+}
 
-export default ProjectAdd;
+export default ProjectAdd

--- a/src/app/pages/ProjectDetail.jsx
+++ b/src/app/pages/ProjectDetail.jsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { Card } from '@/app/components/ui/card';
-import { Button } from '@/app/components/ui/button';
-import { AppHeader } from '@/app/components/AppHeader';
-import BottomNav from '@/app/components/BottomNav';
-import { Pencil, Trash2, FileImage } from 'lucide-react';
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Card } from '@/app/components/ui/card'
+import { Button } from '@/app/components/ui/button'
+import { AppHeader } from '@/app/components/AppHeader'
+import BottomNav from '@/app/components/BottomNav'
+import ProjectDescriptionGuideDialog from '@/app/components/ProjectDescriptionGuideDialog'
+import { fetchS3ResourceBlob } from '@/api/fileApi'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,33 +14,144 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/app/components/ui/alert-dialog';
-import { toast } from 'sonner';
+} from '@/app/components/ui/alert-dialog'
+import {
+  findPortfolioProjectById,
+  findPortfolioProjectIndex,
+  getImageFileName,
+  getProjectTechStackNames,
+  resolvePortfolioErrorMessage,
+  toPortfolioProjectPayload,
+} from '@/app/utils/portfolio'
+import {
+  useDeletePortfolio,
+  usePortfolio,
+  useReplacePortfolio,
+} from '@/app/hooks/usePortfolio'
+import { Download, Loader2, Pencil, RefreshCw, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
 
 const ProjectDetail = () => {
-  const navigate = useNavigate();
-  const { id } = useParams();
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [isDownloadingArchitecture, setIsDownloadingArchitecture] = useState(false)
 
-  // Mock data - 실제로는 API에서 가져와야 함
-  const project = {
-    id: id,
-    name: '프로젝트 이름',
-    techStack: '스프링부트, 리액트',
-    architecture: '시스템_아키텍처_이미지.jpg',
-    description: `해결한 문제 1
-• N+1 문제
+  const {
+    data: portfolio,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = usePortfolio()
+  const replacePortfolioMutation = useReplacePortfolio()
+  const deletePortfolioMutation = useDeletePortfolio()
 
-해결한 문제 2
-• DB 조회 성능 속도 개선
-  • redis 캐시 적용`,
-    createdAt: '2025.12.29',
-  };
+  const projects = portfolio?.projects ?? []
+  const project = findPortfolioProjectById(projects, id)
+  const projectIndex = findPortfolioProjectIndex(projects, id)
+  const techStackNames = getProjectTechStackNames(project)
+  const isDeleting =
+    replacePortfolioMutation.isPending || deletePortfolioMutation.isPending
 
-  const handleDelete = () => {
-    toast.success('삭제되었습니다');
-    navigate('/portfolio');
-  };
+  const handleArchitectureDownload = async () => {
+    if (!project?.architectureImageUrl || isDownloadingArchitecture) return
+
+    setIsDownloadingArchitecture(true)
+
+    try {
+      const blob = await fetchS3ResourceBlob(project.architectureImageUrl)
+      const downloadUrl = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = downloadUrl
+      link.download = getImageFileName(project.architectureImageUrl) || 'architecture-image'
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      URL.revokeObjectURL(downloadUrl)
+    } catch {
+      toast.error('시스템 아키텍처 이미지 다운로드에 실패했습니다.')
+    } finally {
+      setIsDownloadingArchitecture(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!project || projectIndex < 0) return
+
+    try {
+      if (projects.length <= 1) {
+        await deletePortfolioMutation.mutateAsync()
+      } else {
+        await replacePortfolioMutation.mutateAsync({
+          projects: projects
+            .filter((_, index) => index !== projectIndex)
+            .map(toPortfolioProjectPayload),
+        })
+      }
+
+      toast.success('삭제되었습니다.')
+      navigate('/portfolio', { replace: true })
+    } catch (deleteError) {
+      toast.error(resolvePortfolioErrorMessage(deleteError, '삭제에 실패했습니다.'))
+    } finally {
+      setShowDeleteDialog(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="내 프로젝트 확인" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <Loader2 className="mb-3 h-5 w-5 animate-spin text-primary-500" />
+            <p className="text-sm text-muted-foreground">프로젝트를 불러오는 중입니다.</p>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="내 프로젝트 확인" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <p className="mb-4 text-sm text-muted-foreground">
+              {error?.message || '프로젝트를 불러오지 못했습니다.'}
+            </p>
+            <Button variant="outline" onClick={() => refetch()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              다시 시도
+            </Button>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (!project) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="내 프로젝트 확인" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <p className="mb-4 text-sm text-muted-foreground">
+              요청한 프로젝트를 찾을 수 없습니다.
+            </p>
+            <Button variant="outline" onClick={() => navigate('/portfolio')}>
+              목록으로
+            </Button>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-background pb-20">
@@ -53,68 +165,106 @@ const ProjectDetail = () => {
             onClick={() => setShowDeleteDialog(true)}
             className="text-destructive hover:text-destructive"
           >
-            <Trash2 className="w-5 h-5" />
+            <Trash2 className="h-5 w-5" />
           </Button>
         }
       />
 
-      <div className="p-6 max-w-lg mx-auto space-y-6">
-        {/* 프로젝트명 */}
+      <div className="mx-auto max-w-lg space-y-6 p-6">
         <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
+          <label className="mb-2 block text-sm text-muted-foreground">
             프로젝트 이름
           </label>
           <Card className="p-4">
-            <p className="text-sm">{project.name}</p>
+            <p className="text-sm break-words [overflow-wrap:anywhere]">
+              {project.projectName}
+            </p>
           </Card>
         </section>
 
-        {/* 기술 스택 */}
         <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
+          <label className="mb-2 block text-sm text-muted-foreground">
             기술 스택
           </label>
           <Card className="p-4">
-            <p className="text-sm">{project.techStack}</p>
+            {techStackNames.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {techStackNames.map((techStackName) => (
+                  <span
+                    key={techStackName}
+                    className="inline-flex items-center rounded-full border border-primary-200 bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700"
+                  >
+                    {techStackName}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm break-words text-muted-foreground [overflow-wrap:anywhere]">
+                등록된 기술 스택이 없습니다.
+              </p>
+            )}
           </Card>
         </section>
 
-        {/* 시스템 아키텍처 이미지 */}
         <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            시스템 아키텍처
-          </label>
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <label className="block text-sm text-muted-foreground">
+              해결한 문제 / 성과
+            </label>
+            <ProjectDescriptionGuideDialog />
+          </div>
           <Card className="p-4">
-            <button className="flex items-center gap-2 text-sm text-primary hover:underline">
-              <FileImage className="w-4 h-4" />
-              <span className="underline">{project.architecture}</span>
-            </button>
-          </Card>
-        </section>
-
-        {/* 프로젝트 설명 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            해결한 문제 / 성과
-          </label>
-          <Card className="p-4">
-            <pre className="text-sm whitespace-pre-wrap font-sans">
-              {project.description}
+            <pre className="whitespace-pre-wrap break-words font-sans text-sm [overflow-wrap:anywhere]">
+              {project.content}
             </pre>
           </Card>
         </section>
 
-        {/* 수정 버튼 */}
+        <section>
+          <label className="mb-2 block text-sm text-muted-foreground">
+            시스템 아키텍처
+          </label>
+          <Card className="gap-4 p-4">
+            {project.architectureImageUrl ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleArchitectureDownload}
+                  disabled={isDownloadingArchitecture}
+                  className="w-fit"
+                >
+                  {isDownloadingArchitecture ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Download className="h-4 w-4" />
+                  )}
+                  이미지 다운로드
+                </Button>
+                <img
+                  src={project.architectureImageUrl}
+                  alt="시스템 아키텍처"
+                  className="max-h-72 w-full rounded-xl border border-[#F3F3F3] object-contain"
+                />
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                등록된 시스템 아키텍처 이미지가 없습니다.
+              </p>
+            )}
+          </Card>
+        </section>
+
         <Button
-          onClick={() => navigate(`/portfolio/edit/${id}`)}
-          className="w-full bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white"
+          onClick={() => navigate(`/portfolio/edit/${project.projectId}`)}
+          className="w-full bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700"
         >
-          <Pencil className="w-4 h-4 mr-2" />
+          <Pencil className="mr-2 h-4 w-4" />
           수정
         </Button>
       </div>
 
-      {/* 삭제 확인 다이얼로그 */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -122,14 +272,16 @@ const ProjectDetail = () => {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete}>확인</AlertDialogAction>
+            <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting ? '삭제 중...' : '확인'}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
 
       <BottomNav />
     </div>
-  );
-};
+  )
+}
 
-export default ProjectDetail;
+export default ProjectDetail

--- a/src/app/pages/ProjectEdit.jsx
+++ b/src/app/pages/ProjectEdit.jsx
@@ -1,12 +1,9 @@
-import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { Card } from '@/app/components/ui/card';
-import { Button } from '@/app/components/ui/button';
-import { Input } from '@/app/components/ui/input';
-import { Textarea } from '@/app/components/ui/textarea';
-import { AppHeader } from '@/app/components/AppHeader';
-import BottomNav from '@/app/components/BottomNav';
-import { Upload, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Button } from '@/app/components/ui/button'
+import { AppHeader } from '@/app/components/AppHeader'
+import BottomNav from '@/app/components/BottomNav'
+import PortfolioProjectFields from '@/app/components/PortfolioProjectFields'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -16,76 +13,293 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/app/components/ui/alert-dialog';
-import { toast } from 'sonner';
+} from '@/app/components/ui/alert-dialog'
+import {
+  buildPortfolioProjectPayload,
+  findPortfolioProjectById,
+  findPortfolioProjectIndex,
+  getSelectedTechStacks,
+  getProjectTechStackIds,
+  mergeTechStackLookup,
+  resolvePortfolioErrorMessage,
+  toPortfolioProjectPayload,
+  uploadPortfolioImage,
+  validatePortfolioImage,
+} from '@/app/utils/portfolio'
+import { usePortfolio, useReplacePortfolio, useTechStacks } from '@/app/hooks/usePortfolio'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+
+const createFormData = (project) => ({
+  projectName: project?.projectName || '',
+  content: project?.content || '',
+  techStackIds: getProjectTechStackIds(project),
+  architectureImageFileId: project?.architectureImageFileId ?? null,
+  architectureImageUrl: project?.architectureImageUrl || '',
+  architectureImageFile: null,
+})
+
+const EMPTY_PROJECTS = []
 
 const ProjectEdit = () => {
-  const navigate = useNavigate();
-  const { id } = useParams();
-  const [showExitDialog, setShowExitDialog] = useState(false);
-  const [isModified, setIsModified] = useState(false);
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const [showExitDialog, setShowExitDialog] = useState(false)
+  const [formData, setFormData] = useState(null)
+  const [techStackSearch, setTechStackSearch] = useState('')
+  const [techStackLookup, setTechStackLookup] = useState({})
+  const [imagePreviewUrl, setImagePreviewUrl] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // Mock initial data
-  const initialData = {
-    name: '프로젝트 1',
-    techStack: '스프링부트, 리액트',
-    architecture: { name: '시스템_아키텍처_이미지.jpg' },
-    description: `해결한 문제 1
-• N+1 문제
+  const {
+    data: portfolio,
+    isLoading: isPortfolioLoading,
+    isError: isPortfolioError,
+    error: portfolioError,
+    refetch: refetchPortfolio,
+  } = usePortfolio()
+  const {
+    techStacks = [],
+    isLoading: isTechStacksLoading,
+    isFetching: isTechStacksFetching,
+    isFetchingNextPage: isFetchingNextTechStacks,
+    error: techStacksError,
+    hasNextPage: hasNextTechStacks,
+    fetchNextPage: fetchNextTechStacks,
+    refetch: refetchTechStacks,
+    debouncedQuery: debouncedTechStackQuery,
+    hasQuery: hasTechStackQuery,
+  } = useTechStacks({ query: techStackSearch })
+  const replacePortfolioMutation = useReplacePortfolio()
 
-해결한 문제 2
-• DB 조회 성능 속도 개선
-  • redis 캐시 적용`,
-  };
+  const projects = portfolio?.projects ?? EMPTY_PROJECTS
+  const techStackSearchKeyword = techStackSearch.trim()
+  const project = useMemo(() => findPortfolioProjectById(projects, id), [id, projects])
+  const projectIndex = useMemo(() => findPortfolioProjectIndex(projects, id), [id, projects])
+  const initialFormData = useMemo(() => createFormData(project), [project])
 
-  const [formData, setFormData] = useState(initialData);
+  useEffect(() => {
+    if (!project) return
+    setFormData(createFormData(project))
+  }, [project])
 
-  const isFormValid =
-    formData.name.trim() &&
-    formData.techStack.trim() &&
-    formData.description.trim();
+  useEffect(() => {
+    setTechStackLookup((current) => mergeTechStackLookup(current, project?.techStacks))
+  }, [project])
 
-  const handleFileUpload = (e) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      if (file.size > 5 * 1024 * 1024) {
-        toast.error('이미지는 5MB 이하만 가능합니다.');
-        return;
-      }
-
-      const validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
-      if (!validTypes.includes(file.type)) {
-        toast.error('jpg, jpeg, png, gif 형식만 업로드 가능합니다.');
-        return;
-      }
-
-      setFormData({ ...formData, architecture: file });
-      setIsModified(true);
+  useEffect(() => {
+    if (!formData?.architectureImageFile) {
+      setImagePreviewUrl(formData?.architectureImageUrl || '')
+      return undefined
     }
-  };
+
+    const nextPreviewUrl = URL.createObjectURL(formData.architectureImageFile)
+    setImagePreviewUrl(nextPreviewUrl)
+
+    return () => {
+      URL.revokeObjectURL(nextPreviewUrl)
+    }
+  }, [formData?.architectureImageFile, formData?.architectureImageUrl])
+
+  useEffect(() => {
+    setTechStackLookup((current) => mergeTechStackLookup(current, techStacks))
+  }, [techStacks])
+
+  const isLoading = isPortfolioLoading
+  const isError = isPortfolioError
+  const errorMessage = portfolioError?.message
+  const techStacksEmptyMessage = techStackSearchKeyword
+    ? '검색된 기술 스택이 없습니다.'
+    : '기술 스택 이름을 입력해 검색하세요.'
+
+  const isFormValid = Boolean(
+    formData?.projectName?.trim() &&
+      formData?.content?.trim() &&
+      formData?.techStackIds?.length > 0
+  )
+  const isModified =
+    formData != null && JSON.stringify(formData) !== JSON.stringify(initialFormData)
+
+  const handleFieldChange = (field, value) => {
+    setFormData((current) => ({
+      ...current,
+      [field]: value,
+    }))
+  }
+
+  const handleTechStackToggle = (techStackId) => {
+    setFormData((current) => {
+      const exists = current.techStackIds.includes(techStackId)
+      return {
+        ...current,
+        techStackIds: exists
+          ? current.techStackIds.filter((value) => value !== techStackId)
+          : [...current.techStackIds, techStackId],
+      }
+    })
+  }
+
+  const handleFileUpload = (event) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+
+    if (!file) return
+
+    const validationMessage = validatePortfolioImage(file)
+    if (validationMessage) {
+      toast.error(validationMessage)
+      return
+    }
+
+    setFormData((current) => ({
+      ...current,
+      architectureImageFileId: null,
+      architectureImageFile: file,
+      architectureImageUrl: '',
+    }))
+  }
 
   const handleRemoveFile = () => {
-    setFormData({ ...formData, architecture: null });
-    setIsModified(true);
-  };
+    setFormData((current) => ({
+      ...current,
+      architectureImageFileId: null,
+      architectureImageFile: null,
+      architectureImageUrl: '',
+    }))
+  }
 
   const handleBack = () => {
     if (isModified) {
-      setShowExitDialog(true);
-    } else {
-      navigate(`/portfolio/${id}`);
+      setShowExitDialog(true)
+      return
     }
-  };
 
-  const handleSubmit = () => {
-    toast.success('수정되었습니다');
-    navigate(`/portfolio/${id}`);
-  };
+    navigate(`/portfolio/${id}`)
+  }
 
-  const handleChange = (field, value) => {
-    setFormData({ ...formData, [field]: value });
-    setIsModified(true);
-  };
+  const retry = () => {
+    refetchPortfolio()
+    if (hasTechStackQuery) {
+      refetchTechStacks()
+    }
+  }
+
+  const selectedTechStacks = useMemo(
+    () => getSelectedTechStacks(formData?.techStackIds ?? [], techStackLookup),
+    [formData?.techStackIds, techStackLookup]
+  )
+
+  const handleSubmit = async () => {
+    if (!isFormValid || !formData || projectIndex < 0) return
+
+    setIsSubmitting(true)
+
+    try {
+      const uploadedArchitectureImage = formData.architectureImageFile
+        ? await uploadPortfolioImage(formData.architectureImageFile)
+        : null
+      const architectureImageFileId =
+        uploadedArchitectureImage?.fileId ?? formData.architectureImageFileId
+
+      const updatedProjectPayload = buildPortfolioProjectPayload({
+        projectName: formData.projectName,
+        content: formData.content,
+        architectureImageFileId,
+        techStackIds: selectedTechStacks.map((techStack) => techStack.techStackId),
+      })
+
+      const nextProjects = projects.map((currentProject, index) =>
+        index === projectIndex
+          ? updatedProjectPayload
+          : toPortfolioProjectPayload(currentProject)
+      )
+
+      const response = await replacePortfolioMutation.mutateAsync({
+        projects: nextProjects,
+      })
+      const responseProjects = response?.data?.projects ?? []
+      const savedProject = responseProjects[projectIndex]
+
+      toast.success('수정되었습니다.')
+      navigate(
+        savedProject?.projectId ? `/portfolio/${savedProject.projectId}` : '/portfolio',
+        { replace: true }
+      )
+    } catch (error) {
+      toast.error(resolvePortfolioErrorMessage(error, '프로젝트 수정에 실패했습니다.'))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="프로젝트 수정" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <Loader2 className="mb-3 h-5 w-5 animate-spin text-primary-500" />
+            <p className="text-sm text-muted-foreground">프로젝트 정보를 불러오는 중입니다.</p>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="프로젝트 수정" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <p className="mb-4 text-sm text-muted-foreground">
+              {errorMessage || '데이터를 불러오지 못했습니다.'}
+            </p>
+            <Button variant="outline" onClick={retry}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              다시 시도
+            </Button>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (!project || projectIndex < 0) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="프로젝트 수정" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <p className="mb-4 text-sm text-muted-foreground">
+              수정할 프로젝트를 찾을 수 없습니다.
+            </p>
+            <Button variant="outline" onClick={() => navigate('/portfolio')}>
+              목록으로
+            </Button>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (!formData) {
+    return (
+      <div className="min-h-screen bg-background pb-20">
+        <AppHeader title="프로젝트 수정" onBack={() => navigate('/portfolio')} />
+        <div className="mx-auto max-w-lg p-6">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-[#F3F3F3] bg-white p-10 text-center shadow-[0_2px_8px_rgba(0,0,0,0.04)]">
+            <Loader2 className="mb-3 h-5 w-5 animate-spin text-primary-500" />
+            <p className="text-sm text-muted-foreground">프로젝트 정보를 준비하는 중입니다.</p>
+          </div>
+        </div>
+        <BottomNav />
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-background pb-20">
@@ -97,145 +311,47 @@ const ProjectEdit = () => {
             variant="ghost"
             size="sm"
             onClick={handleSubmit}
-            disabled={!isFormValid}
+            disabled={!isFormValid || isSubmitting || replacePortfolioMutation.isPending}
             className="text-primary-500 hover:text-primary-600 disabled:opacity-50"
           >
-            완료
+            {isSubmitting || replacePortfolioMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              '완료'
+            )}
           </Button>
         }
       />
 
-      <div className="p-6 max-w-lg mx-auto space-y-6">
-        {/* 프로젝트명 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            프로젝트 이름 *
-          </label>
-          <Input
-            placeholder="프로젝트 이름을 작성해주세요."
-            value={formData.name}
-            onChange={(e) => {
-              const value = e.target.value;
-              if (value.length <= 30) {
-                handleChange('name', value);
-              }
-            }}
-            maxLength={30}
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {formData.name.length}/30자
-          </p>
-        </section>
-
-        {/* 기술 스택 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            기술 스택 *
-          </label>
-          <Input
-            placeholder="기술 스택을 작성해주세요(콤마로 구분)"
-            value={formData.techStack}
-            onChange={(e) => {
-              const value = e.target.value;
-              if (value.length <= 100) {
-                handleChange('techStack', value);
-              }
-            }}
-            maxLength={100}
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {formData.techStack.length}/100자
-          </p>
-        </section>
-
-        {/* 시스템 아키텍처 이미지 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            시스템 아키텍처
-          </label>
-          <Card className="p-4">
-            {formData.architecture ? (
-              <div className="flex items-center justify-between">
-                <span className="text-sm truncate flex-1">
-                  {typeof formData.architecture === 'object'
-                    ? formData.architecture.name
-                    : formData.architecture}
-                </span>
-                <div className="flex gap-2 ml-2">
-                  <label className="cursor-pointer">
-                    <Button variant="outline" size="sm" asChild>
-                      <span>
-                        <Upload className="w-4 h-4 mr-1" />
-                        첨부하기
-                      </span>
-                    </Button>
-                    <input
-                      type="file"
-                      accept=".jpg,.jpeg,.png,.gif"
-                      onChange={handleFileUpload}
-                      className="hidden"
-                    />
-                  </label>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleRemoveFile}
-                  >
-                    <X className="w-4 h-4 mr-1" />
-                    삭제
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <label className="cursor-pointer">
-                <Button variant="outline" size="sm" asChild>
-                  <span>
-                    <Upload className="w-4 h-4 mr-1" />
-                    첨부하기
-                  </span>
-                </Button>
-                <input
-                  type="file"
-                  accept=".jpg,.jpeg,.png,.gif"
-                  onChange={handleFileUpload}
-                  className="hidden"
-                />
-              </label>
-            )}
-          </Card>
-        </section>
-
-        {/* 프로젝트 설명 */}
-        <section>
-          <label className="text-sm text-muted-foreground mb-2 block">
-            해결한 문제 / 성과 *
-          </label>
-          <Textarea
-            placeholder="프로젝트 간 겪은 문제와 해결 스토리를 적어주세요"
-            value={formData.description}
-            onChange={(e) => {
-              const value = e.target.value;
-              if (value.length <= 1000) {
-                handleChange('description', value);
-              }
-            }}
-            maxLength={1000}
-            rows={10}
-            className="resize-none"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {formData.description.length}/1000자
-          </p>
-        </section>
+      <div className="mx-auto max-w-lg space-y-6 p-6">
+        <PortfolioProjectFields
+          formData={formData}
+          imagePreviewUrl={imagePreviewUrl}
+          techStacks={techStacks}
+          selectedTechStacks={selectedTechStacks}
+          techStackSearch={techStackSearch}
+          isTechStacksLoading={hasTechStackQuery && isTechStacksLoading && techStacks.length === 0}
+          isTechStacksSearching={
+            techStackSearchKeyword !== debouncedTechStackQuery ||
+            (hasTechStackQuery && isTechStacksFetching)
+          }
+          techStacksErrorMessage={techStacksError?.message || ''}
+          emptyTechStacksMessage={techStacksEmptyMessage}
+          hasNextTechStacks={Boolean(hasNextTechStacks)}
+          isFetchingNextTechStacks={isFetchingNextTechStacks}
+          onFieldChange={handleFieldChange}
+          onTechStackSearchChange={setTechStackSearch}
+          onTechStackToggle={handleTechStackToggle}
+          onLoadMoreTechStacks={() => fetchNextTechStacks()}
+          onFileUpload={handleFileUpload}
+          onFileRemove={handleRemoveFile}
+        />
       </div>
 
-      {/* 이탈 확인 다이얼로그 */}
       <AlertDialog open={showExitDialog} onOpenChange={setShowExitDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>
-              수정된 내용이 저장되지 않습니다.
-            </AlertDialogTitle>
+            <AlertDialogTitle>수정된 내용이 저장되지 않습니다.</AlertDialogTitle>
             <AlertDialogDescription>나가시겠습니까?</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -249,7 +365,7 @@ const ProjectEdit = () => {
 
       <BottomNav />
     </div>
-  );
-};
+  )
+}
 
-export default ProjectEdit;
+export default ProjectEdit

--- a/src/app/utils/portfolio.js
+++ b/src/app/utils/portfolio.js
@@ -1,0 +1,244 @@
+import { confirmFileUpload, getPresignedUrl, uploadToS3 } from '@/api/fileApi'
+
+export const MAX_PORTFOLIO_PROJECTS = 3
+export const MAX_PROJECT_NAME_LENGTH = 100
+export const MAX_PROJECT_CONTENT_LENGTH = 1000
+export const MAX_PROJECT_IMAGE_SIZE = 5 * 1024 * 1024
+export const PORTFOLIO_IMAGE_UPLOAD_CATEGORY = 'ARCHITECTURE'
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif']
+
+const PORTFOLIO_ERROR_MESSAGE_MAP = {
+  PORT001: '프로젝트는 최대 3개까지 저장할 수 있습니다.',
+  PORT002: '포트폴리오를 찾을 수 없습니다.',
+  TS001: '존재하지 않는 기술 스택이 포함되어 있습니다.',
+}
+
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  return trimmed || ''
+}
+
+const toNullablePositiveInteger = (value) => {
+  const numeric = Number(value)
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null
+}
+
+const createUploadPrefix = (date = new Date()) => {
+  const year = String(date.getFullYear())
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+  return `${year}-${month}-${day}_${hours}:${minutes}:${seconds}`
+}
+
+const createUploadFileName = (file) => {
+  const originalName = typeof file?.name === 'string' ? file.name.trim() : ''
+  const extension = originalName.includes('.') ? originalName.split('.').pop() : 'png'
+  const randomToken =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`
+  return `${createUploadPrefix()}_ARCHITECTURE_${randomToken}.${extension}`
+}
+
+export function validatePortfolioImage(file) {
+  if (!file) return ''
+
+  if (file.size > MAX_PROJECT_IMAGE_SIZE) {
+    return '이미지는 5MB 이하만 가능합니다.'
+  }
+
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    return 'jpg, jpeg, png, gif 형식만 업로드 가능합니다.'
+  }
+
+  return ''
+}
+
+export function buildPortfolioProjectPayload({
+  projectName,
+  content,
+  architectureImageFileId,
+  techStackIds,
+}) {
+  return {
+    projectName: toTrimmedString(projectName),
+    content: toTrimmedString(content),
+    architectureImageFileId: toNullablePositiveInteger(architectureImageFileId),
+    techStackIds: Array.isArray(techStackIds)
+      ? techStackIds
+        .map((value) => Number(value))
+        .filter((value) => Number.isInteger(value) && value > 0)
+      : [],
+  }
+}
+
+export function toPortfolioProjectPayload(project) {
+  return buildPortfolioProjectPayload({
+    projectName: project?.projectName,
+    content: project?.content,
+    architectureImageFileId: project?.architectureImageFileId,
+    techStackIds:
+      project?.techStackIds ??
+      project?.techStacks?.map((techStack) => techStack?.techStackId) ??
+      [],
+  })
+}
+
+export function findPortfolioProjectIndex(projects, projectId) {
+  return Array.isArray(projects)
+    ? projects.findIndex((project) => String(project?.projectId) === String(projectId))
+    : -1
+}
+
+export function findPortfolioProjectById(projects, projectId) {
+  const projectIndex = findPortfolioProjectIndex(projects, projectId)
+  return projectIndex >= 0 ? projects[projectIndex] : null
+}
+
+export function getProjectTechStackIds(project) {
+  if (Array.isArray(project?.techStackIds)) {
+    return project.techStackIds
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value > 0)
+  }
+
+  if (!Array.isArray(project?.techStacks)) return []
+
+  return project.techStacks
+    .map((techStack) => Number(techStack?.techStackId))
+    .filter((value) => Number.isInteger(value) && value > 0)
+}
+
+export function getProjectTechStackNames(project) {
+  if (!Array.isArray(project?.techStacks)) return []
+
+  return project.techStacks
+    .map((techStack) => toTrimmedString(techStack?.techStackName || techStack?.name))
+    .filter(Boolean)
+}
+
+export function mergeTechStackLookup(currentLookup, techStacks) {
+  const baseLookup =
+    currentLookup && typeof currentLookup === 'object' && !Array.isArray(currentLookup)
+      ? currentLookup
+      : {}
+  const source = Array.isArray(techStacks) ? techStacks : []
+
+  if (source.length === 0) {
+    return baseLookup
+  }
+
+  let hasChanges = false
+  const nextLookup = { ...baseLookup }
+
+  source.forEach((techStack) => {
+    const techStackId = Number(techStack?.techStackId)
+    if (!Number.isInteger(techStackId) || techStackId <= 0) return
+
+    const previous = nextLookup[techStackId]
+    const nextEntry = {
+      techStackId,
+      name: toTrimmedString(techStack?.name || techStack?.techStackName || previous?.name),
+      description: toTrimmedString(techStack?.description || previous?.description),
+    }
+
+    if (
+      !previous ||
+      previous.name !== nextEntry.name ||
+      previous.description !== nextEntry.description
+    ) {
+      nextLookup[techStackId] = nextEntry
+      hasChanges = true
+    }
+  })
+
+  return hasChanges ? nextLookup : baseLookup
+}
+
+export function getSelectedTechStacks(techStackIds, techStackLookup) {
+  if (!Array.isArray(techStackIds) || !techStackLookup) return []
+
+  return techStackIds
+    .map((techStackId) => techStackLookup[techStackId])
+    .filter((techStack) => techStack?.techStackId > 0 && techStack?.name)
+}
+
+export function getImageFileName(source) {
+  if (!source) return ''
+
+  if (typeof source === 'object' && source?.name) {
+    return source.name
+  }
+
+  const normalized = toTrimmedString(source)
+  if (!normalized) return ''
+
+  try {
+    const url = new URL(normalized)
+    const lastSegment = url.pathname.split('/').filter(Boolean).pop()
+    return lastSegment || normalized
+  } catch {
+    return normalized.split('/').filter(Boolean).pop() || normalized
+  }
+}
+
+export function resolvePortfolioErrorMessage(error, fallbackMessage) {
+  const code = toTrimmedString(error?.code)
+  if (code && PORTFOLIO_ERROR_MESSAGE_MAP[code]) {
+    return PORTFOLIO_ERROR_MESSAGE_MAP[code]
+  }
+  return error?.message || fallbackMessage
+}
+
+export function isPortfolioNotFoundError(error) {
+  return error?.code === 'PORT002'
+}
+
+export async function uploadPortfolioImage(file) {
+  if (!file) {
+    return {
+      fileId: null,
+      fileUrl: '',
+    }
+  }
+
+  const validationMessage = validatePortfolioImage(file)
+  if (validationMessage) {
+    throw new Error(validationMessage)
+  }
+
+  const presignedResult = await getPresignedUrl({
+    fileName: createUploadFileName(file),
+    fileSize: file.size,
+    mimeType: file.type,
+    category: PORTFOLIO_IMAGE_UPLOAD_CATEGORY,
+    method: 'PUT',
+  })
+  const presignedPayload = presignedResult?.data ?? {}
+  const fileId = presignedPayload.fileId ?? presignedPayload.file_id
+  const presignedUrl = presignedPayload.presignedUrl ?? presignedPayload.presigned_url
+
+  if (!fileId || !presignedUrl) {
+    throw new Error('이미지 업로드 URL을 받지 못했습니다.')
+  }
+
+  await uploadToS3(presignedUrl, file, file.type)
+
+  const confirmResult = await confirmFileUpload(fileId)
+  const confirmPayload = confirmResult?.data ?? {}
+  const fileUrl = toTrimmedString(confirmPayload.fileUrl ?? confirmPayload.file_url)
+
+  if (!fileUrl) {
+    throw new Error('업로드된 이미지 URL을 확인할 수 없습니다.')
+  }
+
+  return {
+    fileId,
+    fileUrl,
+  }
+}

--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -12,17 +12,48 @@ export async function parseJsonSafe(response) {
 }
 
 export async function extractErrorMessage(response, defaultMessage = DEFAULT_ERROR_MESSAGE) {
+  const { message } = await extractErrorDetails(response, defaultMessage)
+  return message
+}
+
+export async function extractErrorDetails(response, defaultMessage = DEFAULT_ERROR_MESSAGE) {
   try {
     const data = await parseJsonSafe(response)
-    if (!data) return defaultMessage
-    if (typeof data === 'string') return data
-    if (data.message) return data.message
-    if (data.error) return data.error
-    if (data.errorMessage) return data.errorMessage
-    return defaultMessage
+    if (!data) {
+      return {
+        message: defaultMessage,
+        code: null,
+        data: null,
+      }
+    }
+    if (typeof data === 'string') {
+      return {
+        message: data,
+        code: null,
+        data,
+      }
+    }
+    return {
+      message: data.message || data.error || data.errorMessage || defaultMessage,
+      code: data.errorCode || data.code || null,
+      data,
+    }
   } catch {
-    return defaultMessage
+    return {
+      message: defaultMessage,
+      code: null,
+      data: null,
+    }
   }
+}
+
+function createApiError(message, { code = null, status = null, data = null } = {}) {
+  const error = new Error(message)
+  error.name = 'ApiError'
+  if (code) error.code = code
+  if (status != null) error.status = status
+  if (data != null) error.data = data
+  return error
 }
 
 export async function handleResponse(response, fallbackRedirect, defaultErrorMessage = DEFAULT_ERROR_MESSAGE) {
@@ -36,7 +67,12 @@ export async function handleResponse(response, fallbackRedirect, defaultErrorMes
   }
 
   if (!response.ok) {
-    throw new Error(await extractErrorMessage(response, defaultErrorMessage))
+    const { message, code, data } = await extractErrorDetails(response, defaultErrorMessage)
+    throw createApiError(message, {
+      code,
+      status: response.status,
+      data,
+    })
   }
 
   return await parseJsonSafe(response)


### PR DESCRIPTION
 ## 작업 내용

  포트폴리오 프로젝트 작성, 수정, 상세 조회 흐름 전반의 UX를 정리하고
  아키텍처 이미지 업로드 및 조회 동작을 서버 계약에 맞게 수정했습니다.

  ## 주요 변경 사항

  ### 1. 프로젝트 작성/수정 UX 개선
  - 기술 스택 검색을 입력창 기반 드롭다운 UX로 변경
  - 선택된 기술 스택은 검색창 하단 칩 형태로 노출
  - 검색 결과는 blur 또는 선택 시 닫히도록 정리
  - 검색 결과가 없을 경우 드롭다운 내에 빈 상태 문구 표시
  - 해결한 문제 / 성과 입력 필드는 일정 높이 이후 내부 스크롤로 전환
  - 프로젝트 이름 최대 길이를 100자로 확장
  - 입력 필드 배경색을 흰색으로 통일해 구분감 개선

  ### 2. 프로젝트 설명 작성 가이드 모달 추가
  - 해결한 문제 / 성과 섹션에 2페이지 가이드 모달 추가
  - 구조적 작성 원칙, 읽기 쉬운 설명 방식, 권장 글자 수 안내 제공
  - 실제 예시를 함께 제공해 바로 참고할 수 있도록 구성
  - 모바일 환경에서도 스와이프 및 내부 스크롤이 가능하도록 조정

  ### 3. 시스템 아키텍처 업로드 흐름 정비
  - 아키텍처 이미지를 S3 presigned URL 기반으로 업로드
  - 업로드 완료 후 `fileId`를 사용해 `architectureImageFileId`로 저장하도록 변경
  - 업로드 파일명 규칙을 `YYYY-MM-DD_HH:mm:ss_ARCHITECTURE_<uuid>` 형태로 정리
  - 서버의 파일 검증 조건(`UPLOADED`, `ARCHITECTURE`)에 맞는 흐름으로 정리

  ### 4. 조회/상세 화면 개선
  - 프로젝트 상세 화면에서 기술 스택을 칩 UI로 변경
  - 해결한 문제 / 성과 섹션을 시스템 아키텍처보다 먼저 배치
  - 긴 텍스트가 카드 가로 영역을 벗어나지 않도록 오버플로우 처리
  - 시스템 아키텍처 파일명 직접 노출 대신 다운로드 버튼 제공

  ### 5. 등록 후 조회 반영 문제 수정
  - 프로젝트 등록/수정 후 포트폴리오 조회 화면에서 최신 프로젝트 카드가 반영되지 않던 문제 수정
  - mutation 성공 후 캐시를 직접 덮는 대신 포트폴리오 조회 쿼리를 다시 동기화하도록 변경

  ## 참고 사항
  - `.env.development`의 `VITE_SHOW_PORTFOLIO_INTERVIEW` 값을 `true`로 변경했습니다.

## 관련 커밋
- #185 
