### PR TITLE
fix:[#187] 포트폴리오 기반 실전면접 진입 조건 및 관리 UX 개선

### DIFF
--- a/src/app/components/PortfolioProjectFields.jsx
+++ b/src/app/components/PortfolioProjectFields.jsx
@@ -251,6 +251,10 @@ function PortfolioProjectFields({
                   {architectureFileName}
                 </span>
                 <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={onFileRemove}>
+                    <X className="mr-1 h-4 w-4" />
+                    삭제
+                  </Button>
                   <label className="cursor-pointer">
                     <Button variant="outline" size="sm" asChild>
                       <span>
@@ -265,10 +269,6 @@ function PortfolioProjectFields({
                       className="hidden"
                     />
                   </label>
-                  <Button variant="outline" size="sm" onClick={onFileRemove}>
-                    <X className="mr-1 h-4 w-4" />
-                    삭제
-                  </Button>
                 </div>
               </div>
 
@@ -281,20 +281,22 @@ function PortfolioProjectFields({
               )}
             </>
           ) : (
-            <label className="cursor-pointer">
-              <Button variant="outline" size="sm" asChild>
-                <span>
-                  <Upload className="mr-1 h-4 w-4" />
-                  첨부하기
-                </span>
-              </Button>
-              <input
-                type="file"
-                accept=".jpg,.jpeg,.png,.gif"
-                onChange={onFileUpload}
-                className="hidden"
-              />
-            </label>
+            <div className="flex justify-end">
+              <label className="cursor-pointer">
+                <Button variant="outline" size="sm" asChild>
+                  <span>
+                    <Upload className="mr-1 h-4 w-4" />
+                    첨부하기
+                  </span>
+                </Button>
+                <input
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.gif"
+                  onChange={onFileUpload}
+                  className="hidden"
+                />
+              </label>
+            </div>
           )}
         </Card>
       </section>

--- a/src/app/pages/PortfolioManagement.jsx
+++ b/src/app/pages/PortfolioManagement.jsx
@@ -1,14 +1,41 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Card } from '@/app/components/ui/card'
 import { Button } from '@/app/components/ui/button'
 import { AppHeader } from '@/app/components/AppHeader'
 import BottomNav from '@/app/components/BottomNav'
-import { MAX_PORTFOLIO_PROJECTS, getProjectTechStackNames } from '@/app/utils/portfolio'
-import { usePortfolio } from '@/app/hooks/usePortfolio'
-import { ChevronRight, Loader2, Plus, RefreshCw } from 'lucide-react'
+import {
+  MAX_PORTFOLIO_PROJECTS,
+  getProjectTechStackNames,
+  resolvePortfolioErrorMessage,
+  toPortfolioProjectPayload,
+} from '@/app/utils/portfolio'
+import {
+  useDeletePortfolio,
+  usePortfolio,
+  useReplacePortfolio,
+} from '@/app/hooks/usePortfolio'
+import { Check, ChevronRight, FolderCode, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+const PROJECT_NAME_PREVIEW_MAX_LENGTH = 22
+const PROJECT_CONTENT_PREVIEW_MAX_LENGTH = 88
+const TECH_STACK_PREVIEW_MAX_LENGTH = 14
+const TECH_STACK_PREVIEW_MAX_COUNT = 3
+
+const truncateText = (value, maxLength) => {
+  if (typeof value !== 'string') return ''
+
+  const normalized = value.trim()
+  if (normalized.length <= maxLength) return normalized
+
+  return `${normalized.slice(0, maxLength)}...`
+}
 
 const PortfolioManagement = () => {
   const navigate = useNavigate()
+  const [isDeleteMode, setIsDeleteMode] = useState(false)
+  const [selectedProjectIds, setSelectedProjectIds] = useState([])
   const {
     data: portfolio,
     isLoading,
@@ -16,9 +43,66 @@ const PortfolioManagement = () => {
     error,
     refetch,
   } = usePortfolio()
+  const replacePortfolioMutation = useReplacePortfolio()
+  const deletePortfolioMutation = useDeletePortfolio()
 
   const projects = portfolio?.projects ?? []
   const canAddMore = projects.length < MAX_PORTFOLIO_PROJECTS
+  const isDeleting =
+    replacePortfolioMutation.isPending || deletePortfolioMutation.isPending
+  const selectedProjectCount = selectedProjectIds.length
+  const selectedProjectIdSet = new Set(selectedProjectIds)
+
+  const resetDeleteMode = () => {
+    setIsDeleteMode(false)
+    setSelectedProjectIds([])
+  }
+
+  const handleEnterDeleteMode = () => {
+    if (projects.length === 0 || isDeleting) return
+
+    setIsDeleteMode(true)
+    setSelectedProjectIds([])
+  }
+
+  const handleToggleProjectSelection = (projectId) => {
+    if (!isDeleteMode || isDeleting) return
+
+    const normalizedProjectId = String(projectId)
+
+    setSelectedProjectIds((currentIds) =>
+      currentIds.includes(normalizedProjectId)
+        ? currentIds.filter((id) => id !== normalizedProjectId)
+        : [...currentIds, normalizedProjectId]
+    )
+  }
+
+  const handleDeleteProject = async () => {
+    if (selectedProjectCount === 0 || isDeleting) return
+
+    const remainingProjects = projects.filter(
+      (project) => !selectedProjectIdSet.has(String(project.projectId))
+    )
+
+    try {
+      if (remainingProjects.length === 0) {
+        await deletePortfolioMutation.mutateAsync()
+      } else {
+        await replacePortfolioMutation.mutateAsync({
+          projects: remainingProjects.map(toPortfolioProjectPayload),
+        })
+      }
+
+      toast.success(
+        selectedProjectCount > 1
+          ? `${selectedProjectCount}개 프로젝트가 삭제되었습니다.`
+          : '삭제되었습니다.'
+      )
+      resetDeleteMode()
+    } catch (deleteError) {
+      toast.error(resolvePortfolioErrorMessage(deleteError, '삭제에 실패했습니다.'))
+    }
+  }
 
   return (
     <div className="min-h-screen bg-background pb-20">
@@ -26,22 +110,72 @@ const PortfolioManagement = () => {
 
       <div className="mx-auto max-w-lg space-y-6 p-6">
         <Card className="border-primary-200 bg-primary-50 p-5">
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex-1">
               <h3 className="mb-1 text-primary-700">프로젝트 등록하기</h3>
               <p className="text-sm text-primary-600">
                 {projects.length}/{MAX_PORTFOLIO_PROJECTS}개 등록됨
               </p>
+              {projects.length === 0 && (
+                <p className="mt-2 text-xs leading-5 text-primary-700/80">
+                  아직 등록된 프로젝트가 없습니다. 프로젝트를 추가하면 실전 면접 준비에 바로 활용할 수 있습니다.
+                </p>
+              )}
+              {isDeleteMode && projects.length > 0 && (
+                <p className="mt-2 text-xs leading-5 text-primary-700/80">
+                  삭제할 프로젝트를 선택해주세요. 여러 프로젝트를 동시에 선택할 수 있습니다.
+                </p>
+              )}
             </div>
-            <Button
-              onClick={() => navigate('/portfolio/add')}
-              disabled={!canAddMore}
-              className="bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
-              size="sm"
-            >
-              <Plus className="mr-1 h-4 w-4" />
-              등록
-            </Button>
+            <div className="flex w-full justify-end gap-2 sm:w-auto">
+              {isDeleteMode ? (
+                <>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={handleDeleteProject}
+                    disabled={selectedProjectCount === 0 || isDeleting}
+                    className="bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    {isDeleting ? '삭제 중...' : `선택 삭제${selectedProjectCount > 0 ? ` (${selectedProjectCount})` : ''}`}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={resetDeleteMode}
+                    disabled={isDeleting}
+                    className="w-fit"
+                  >
+                    취소
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    onClick={() => navigate('/portfolio/add')}
+                    disabled={!canAddMore || isDeleting}
+                    className="bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    size="sm"
+                  >
+                    <Plus className="mr-1 h-4 w-4" />
+                    등록
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleEnterDeleteMode}
+                    disabled={projects.length === 0 || isDeleting}
+                    className="w-fit"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    삭제
+                  </Button>
+                </>
+              )}
+            </div>
           </div>
         </Card>
 
@@ -73,30 +207,107 @@ const PortfolioManagement = () => {
             <div className="space-y-4">
               {projects.map((project) => {
                 const techStackNames = getProjectTechStackNames(project)
+                const previewTechStackNames = techStackNames.slice(0, TECH_STACK_PREVIEW_MAX_COUNT)
+                const hasMoreTechStacks = techStackNames.length > TECH_STACK_PREVIEW_MAX_COUNT
+                const isSelected = selectedProjectIdSet.has(String(project.projectId))
+                const previewProjectName = truncateText(
+                  project.projectName,
+                  PROJECT_NAME_PREVIEW_MAX_LENGTH
+                )
+                const previewContent = truncateText(
+                  project.content,
+                  PROJECT_CONTENT_PREVIEW_MAX_LENGTH
+                )
 
                 return (
                   <Card
                     key={project.projectId}
-                    className="cursor-pointer p-5 transition-shadow hover:shadow-md"
-                    onClick={() => navigate(`/portfolio/${project.projectId}`)}
-                  >
-                    <div className="mb-3 flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="mb-2 inline-flex rounded bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700">
-                          {project.projectName}
-                        </div>
-                        <p className="line-clamp-2 text-sm text-muted-foreground">
-                          {project.content}
-                        </p>
-                      </div>
-                      <ChevronRight className="mt-1 h-5 w-5 flex-shrink-0 text-muted-foreground" />
-                    </div>
+                    className={`relative gap-0 overflow-hidden rounded-[24px] p-0 transition-all ${
+                      isDeleteMode
+                        ? 'cursor-pointer'
+                        : 'cursor-pointer hover:-translate-y-0.5'
+                    } border-[#F1E7EA] bg-white shadow-[0_12px_28px_rgba(15,23,42,0.06)] hover:border-primary-200 hover:shadow-[0_18px_36px_rgba(15,23,42,0.08)]`}
+                    onClick={() => {
+                      if (isDeleteMode) {
+                        handleToggleProjectSelection(project.projectId)
+                        return
+                      }
 
-                    {techStackNames.length > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        {techStackNames.join(' · ')}
-                      </p>
-                    )}
+                      navigate(`/portfolio/${project.projectId}`)
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Enter' && event.key !== ' ') return
+
+                      event.preventDefault()
+
+                      if (isDeleteMode) {
+                        handleToggleProjectSelection(project.projectId)
+                        return
+                      }
+
+                      navigate(`/portfolio/${project.projectId}`)
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isDeleteMode ? isSelected : undefined}
+                  >
+                    <div className="absolute inset-x-5 top-0 h-px bg-[#F3E7EA]" />
+                    <div className="absolute -right-8 top-4 h-24 w-24 rounded-full bg-primary-100/60 blur-3xl" />
+                    <div className="relative flex items-center gap-4 p-5">
+                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-primary-100 bg-primary-50 text-primary-500">
+                        <FolderCode className="h-5 w-5" />
+                      </div>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-3 flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1">
+                            <h3 className="truncate text-[17px] font-semibold tracking-[-0.02em] text-[#212121]">
+                              {previewProjectName}
+                            </h3>
+                          </div>
+                          {!isDeleteMode && (
+                            <ChevronRight className="mt-1 h-5 w-5 flex-shrink-0 text-primary-300" />
+                          )}
+                        </div>
+
+                        <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">
+                          {previewContent}
+                        </p>
+
+                        {techStackNames.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {previewTechStackNames.map((techStackName) => (
+                              <span
+                                key={`${project.projectId}-${techStackName}`}
+                                className="inline-flex max-w-full rounded-full border border-[#F2E8EB] bg-[#FCFAFB] px-3 py-1 text-xs font-medium text-[#6B5E63]"
+                              >
+                                <span className="truncate">
+                                  {truncateText(techStackName, TECH_STACK_PREVIEW_MAX_LENGTH)}
+                                </span>
+                              </span>
+                            ))}
+                            {hasMoreTechStacks && (
+                              <span className="inline-flex rounded-full border border-[#F2E8EB] bg-[#FCFAFB] px-3 py-1 text-xs font-medium text-[#6B5E63]">
+                                ...
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      {isDeleteMode && (
+                        <span
+                          className={`flex h-5 w-5 shrink-0 self-center items-center justify-center rounded-full border transition-colors ${
+                            isSelected
+                              ? 'border-primary-500 bg-primary-500 text-white'
+                              : 'border-[#D6D6D6] bg-white text-transparent'
+                          }`}
+                          aria-hidden="true"
+                        >
+                          <Check className="h-3 w-3" />
+                        </span>
+                      )}
+                    </div>
                   </Card>
                 )
               })}

--- a/src/app/pages/ProfileMain.jsx
+++ b/src/app/pages/ProfileMain.jsx
@@ -368,11 +368,11 @@ const ProfileMain = () => {
             <h2 className="profile-name">{nickname || '사용자'}</h2>
             <Button
               onClick={() => navigate('/portfolio')}
-              variant="secondary"
+              variant="outline"
               size="sm"
-              className="bg-white/20 text-white border-white/30 hover:bg-white/30 text-xs"
+              className="mt-2 border-primary-200 bg-primary-50 text-primary-700 shadow-sm hover:border-primary-300 hover:bg-primary-100 hover:text-primary-800 text-xs"
             >
-              포트폴리오 관리
+              내 포트폴리오 관리
             </Button>
           </div>
           <div className="profile-card-actions">

--- a/src/app/pages/RealInterview.jsx
+++ b/src/app/pages/RealInterview.jsx
@@ -4,6 +4,8 @@ import { Loader2 } from 'lucide-react';
 import BottomNav from '@/app/components/BottomNav';
 import { toast } from 'sonner';
 import { AppHeader } from '@/app/components/AppHeader';
+import { Button } from '@/app/components/ui/button';
+import { usePortfolio } from '@/app/hooks/usePortfolio';
 import { createInterviewSession } from '@/api/interviewApi';
 import { SESSION_STORAGE_KEYS } from '@/app/constants/storageKeys';
 import { INTERVIEW_TYPES, QUESTION_TYPES } from '@/app/constants/interviewTaxonomy';
@@ -13,6 +15,9 @@ const SHOW_NOTIFICATIONS = import.meta.env.VITE_SHOW_NOTIFICATIONS === 'true';
 const REAL_SESSION_STORAGE_KEY = SESSION_STORAGE_KEYS.REAL_INTERVIEW_SESSION;
 const TEXT_SESSION_CREATE_FAILED = '면접 세션 생성에 실패했습니다.';
 const TEXT_SESSION_CREATING = '실전면접 준비 중';
+const TEXT_PORTFOLIO_REQUIRED = '실전 면접은 포트폴리오 프로젝트를 1개 이상 등록한 뒤 시작할 수 있습니다.';
+const TEXT_PORTFOLIO_LOADING = '포트폴리오 프로젝트를 확인하는 중입니다.';
+const TEXT_PORTFOLIO_FETCH_FAILED = '포트폴리오 상태를 확인하지 못했습니다. 잠시 후 다시 시도해주세요.';
 
 const safeSetSessionItem = (key, value) => {
     try {
@@ -62,6 +67,17 @@ const saveRealInterviewSession = ({ questionType, sessionData }) => {
 const RealInterview = () => {
     const navigate = useNavigate();
     const [isCreatingSession, setIsCreatingSession] = useState(false);
+    const {
+        data: portfolio,
+        isLoading: isPortfolioLoading,
+        isError: isPortfolioError,
+        error: portfolioError,
+        refetch: refetchPortfolio,
+    } = usePortfolio();
+    const portfolioProjectCount = portfolio?.projects?.length ?? 0;
+    const isPortfolioStartBlocked =
+        isPortfolioLoading || isPortfolioError || portfolioProjectCount === 0;
+    const canStartRealInterview = !isCreatingSession && !isPortfolioStartBlocked;
 
     const handleComingSoon = (title) => {
         toast.info(`${title} 서비스는 현재 준비 중입니다.`, {
@@ -71,6 +87,18 @@ const RealInterview = () => {
 
     const handleStartRealInterview = async (questionType) => {
         if (isCreatingSession) return;
+        if (isPortfolioLoading) {
+            toast.info(TEXT_PORTFOLIO_LOADING);
+            return;
+        }
+        if (isPortfolioError) {
+            toast.error(portfolioError?.message || TEXT_PORTFOLIO_FETCH_FAILED);
+            return;
+        }
+        if (portfolioProjectCount === 0) {
+            toast.info(TEXT_PORTFOLIO_REQUIRED);
+            return;
+        }
 
         setIsCreatingSession(true);
         try {
@@ -124,12 +152,52 @@ const RealInterview = () => {
             <AppHeader title="실전 면접" onBack={() => navigate('/')} showNotifications={SHOW_NOTIFICATIONS} />
 
             <div className="flex-1 flex flex-col p-4 gap-4 pb-24 min-h-0">
+                <section className="rounded-2xl border border-primary-200/80 bg-white/85 p-4 shadow-[0_8px_22px_rgba(255,143,163,0.08)] backdrop-blur-sm">
+                    {isPortfolioLoading ? (
+                        <div className="flex items-center gap-2 text-sm text-gray-700">
+                            <Loader2 size={16} className="animate-spin text-primary-500" />
+                            <span>{TEXT_PORTFOLIO_LOADING}</span>
+                        </div>
+                    ) : isPortfolioError ? (
+                        <div className="flex flex-col gap-3">
+                            <p className="text-sm text-gray-700">
+                                {portfolioError?.message || TEXT_PORTFOLIO_FETCH_FAILED}
+                            </p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => refetchPortfolio()}
+                                className="w-fit border-primary-200 bg-primary-50 text-primary-700 hover:bg-primary-100"
+                            >
+                                다시 확인
+                            </Button>
+                        </div>
+                    ) : portfolioProjectCount === 0 ? (
+                        <div className="flex flex-col gap-3">
+                            <p className="text-sm text-gray-700">{TEXT_PORTFOLIO_REQUIRED}</p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                onClick={() => navigate('/portfolio')}
+                                className="w-fit"
+                            >
+                                포트폴리오 관리
+                            </Button>
+                        </div>
+                    ) : (
+                        <p className="text-sm text-gray-700">
+                            현재 등록된 프로젝트 {portfolioProjectCount}개를 기반으로 실전 면접을 시작할 수 있습니다.
+                        </p>
+                    )}
+                </section>
+
                 {menuItems.map((item, index) => {
                     return (
                         <button
                             key={index}
                             onClick={item.onClick}
-                            disabled={isCreatingSession}
+                            disabled={!canStartRealInterview}
                             className={`flex-1 relative overflow-hidden rounded-2xl p-5 flex flex-col justify-center text-left transition-all active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed bg-gradient-to-br ${item.gradient} border border-primary-200/80 shadow-[0_8px_22px_rgba(255,143,163,0.14)] min-h-[100px]`}
                         >
                             <div className="relative z-10">
@@ -144,6 +212,12 @@ const RealInterview = () => {
                             {item.title === '개별 포트폴리오' && (
                                 <div className="absolute top-2 right-4 text-[10px] font-medium text-primary-700 bg-white/75 border border-primary-200 px-2 py-0.5 rounded-full backdrop-blur-sm">
                                     Coming Soon
+                                </div>
+                            )}
+
+                            {!isPortfolioLoading && !isPortfolioError && portfolioProjectCount === 0 && (
+                                <div className="absolute bottom-3 right-4 text-[10px] font-medium text-amber-700 bg-white/85 border border-amber-200 px-2 py-0.5 rounded-full backdrop-blur-sm">
+                                    프로젝트 등록 필요
                                 </div>
                             )}
                         </button>


### PR DESCRIPTION
### 요약

  - 포트폴리오 프로젝트가 없는 경우 실전면접 진입을 막고, 바로 포트폴리오로 이동할 수 있는 안내를 추가했습니다.
  - 프로필과 포트폴리오 관리 화면의 CTA 가시성과 조작 흐름을 정리했습니다.
  - 포트폴리오 목록에서 프로젝트를 더 쉽게 확인하고 선택 삭제할 수 있도록 관리 UX를 개선했습니다.

###  변경파일
  - RealInterview.jsx: 포트폴리오 보유 여부 확인 후 실전면접 진입 제어 및 안내 UI 추가
  - ProfileMain.jsx: 포트폴리오 관리 버튼 가시성 개선
  - PortfolioManagement.jsx: 프로젝트 카드 UI 개선 및 다중 선택 삭제 모드 추가
  - PortfolioProjectFields.jsx: 첨부하기 버튼 우측 정렬

 ### 목적
  - 포트폴리오 없이 실전면접을 시작하는 잘못된 사용자 흐름을 방지하기 위함입니다.
  - 포트폴리오 작성, 수정, 삭제 흐름을 더 직관적으로 만들기 위함입니다.
  - 프로젝트 목록에서 정보 확인성과 작업 효율을 함께 높이기 위함입니다.

 ### 구현의도
  - 실전면접은 포트폴리오 기반 기능이라는 점이 명확하므로, 진입 전에 프로젝트 존재 여부를 먼저 확인하도록 했습니다.
  - 삭제는 상세 페이지 진입 없이 목록에서 바로 처리할 수 있도록 선택 모드 기반으로 구성했습니다.
  - 카드 디자인은 과한 메타포보다 정보 가독성과 조작 일관성을 우선해 정리했습니다.
  - 버튼 배치는 시선 흐름과 주 사용 손을 고려해 우측 중심으로 맞췄습니다.

### 관련 커밋
 - #187 