### PR TITLE
Feat/#189 auth refresh guard

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,5 +1,14 @@
 import { authFetch, extractErrorMessage, API_BASE_URL } from '@/utils/apiUtils.js'
 
+// refresh 전용 에러 클래스: status 코드를 포함해 호출자가 401/기타를 구분할 수 있게 함
+export class RefreshTokenError extends Error {
+  constructor(message, status) {
+    super(message)
+    this.name = 'RefreshTokenError'
+    this.status = status
+  }
+}
+
 export function getOAuthAuthorizationUrl(provider = 'kakao') {
   return `${API_BASE_URL}/api/auth/oauth/authorization-url?provider=${provider}`
 }
@@ -34,12 +43,13 @@ export async function refreshTokens() {
   })
 
   if (!response.ok) {
-    throw new Error(await extractErrorMessage(response, '토큰 갱신에 실패했습니다.'))
+    const message = await extractErrorMessage(response, '토큰 갱신에 실패했습니다.')
+    throw new RefreshTokenError(message, response.status)
   }
 
   const authHeader = response.headers.get('Authorization')
   if (!authHeader?.startsWith('Bearer ')) {
-    throw new Error('토큰 갱신에 실패했습니다.')
+    throw new RefreshTokenError('토큰 갱신에 실패했습니다.', response.status)
   }
 
   return authHeader.slice(7)

--- a/src/app/pages/OAuthCallback.jsx
+++ b/src/app/pages/OAuthCallback.jsx
@@ -1,19 +1,32 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '@/context/AuthContext'
-import { exchangeOAuthCode, refreshTokens } from '@/api/authApi'
+import { exchangeOAuthCode } from '@/api/authApi'
 import { toast } from 'sonner'
 
 const OAuthCallback = () => {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const { login } = useAuth()
+  const { login, invalidateSession } = useAuth()
   const [error, setError] = useState(null)
   const processed = useRef(false)
+  // 언마운트 시 setTimeout 누수 방지
+  const redirectTimerRef = useRef(null)
+
+  // 에러 발생 시 2초 후 /login으로 이동. 언마운트되면 타이머를 정리해 stale navigation 방지.
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     if (processed.current) return
     processed.current = true
+
+    const scheduleLoginRedirect = () => {
+      redirectTimerRef.current = setTimeout(() => navigate('/login', { replace: true }), 2000)
+    }
 
     const handleCallback = async () => {
       const exchangeCode = searchParams.get('exchange_code')
@@ -22,9 +35,10 @@ const OAuthCallback = () => {
 
       if (errorParam) {
         const msg = errorMessage || '로그인에 실패했습니다.'
+        invalidateSession('oauth_error_param')
         setError(msg)
         toast.error(msg)
-        setTimeout(() => navigate('/login', { replace: true }), 2000)
+        scheduleLoginRedirect()
         return
       }
 
@@ -35,28 +49,23 @@ const OAuthCallback = () => {
           toast.success('로그인 성공!')
           navigate('/', { replace: true })
         } catch {
+          invalidateSession('oauth_exchange_failed')
           setError('인증 처리에 실패했습니다.')
           toast.error('인증 처리에 실패했습니다.')
-          setTimeout(() => navigate('/login', { replace: true }), 2000)
+          scheduleLoginRedirect()
         }
         return
       }
 
-      // exchange_code 없이 도달한 경우, HttpOnly 쿠키의 refresh token으로 시도
-      try {
-        const newToken = await refreshTokens()
-        login(newToken)
-        toast.success('로그인 성공!')
-        navigate('/', { replace: true })
-      } catch {
-        setError('인증 정보를 찾을 수 없습니다.')
-        toast.error('인증 정보를 찾을 수 없습니다.')
-        setTimeout(() => navigate('/login', { replace: true }), 2000)
-      }
+      // exchange_code 없이 도달한 경우 → 잘못된 접근, 깨끗한 상태로 재로그인 유도
+      invalidateSession('oauth_no_exchange_code')
+      setError('인증 정보를 찾을 수 없습니다.')
+      toast.error('인증 정보를 찾을 수 없습니다.')
+      scheduleLoginRedirect()
     }
 
     handleCallback()
-  }, [searchParams, login, navigate])
+  }, [searchParams, login, invalidateSession, navigate])
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-rose-50 via-white to-pink-50 flex items-center justify-center">

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react'
-import { setAccessTokenGetter } from '@/utils/apiUtils'
+import { setAccessTokenGetter, setUnauthorizedHandler } from '@/utils/apiUtils'
 import { refreshTokens, logout as apiLogout } from '@/api/authApi'
 import { queryClient } from '@/lib/queryClient'
 
@@ -44,10 +44,19 @@ export function AuthProvider({ children }) {
   const [accessToken, setAccessToken] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [user, setUser] = useState(null)
+
   const accessTokenRef = useRef(null)
+  const refreshTimerRef = useRef(null)
+  // BroadcastChannel: 다른 탭으로 세션 무효화 신호 전파
+  const authChannelRef = useRef(null)
+
+  // 중복 실행 방지용 플래그: true면 세션이 무효화된 상태
+  const isInvalidatingRef = useRef(false)
+  // single-flight: 동시에 refresh 요청 1개만 허용
+  const refreshInProgressRef = useRef(false)
+  const refreshPromiseRef = useRef(null)
 
   const isAuthenticated = !!accessToken
-
   const nickname = user?.nickname || user?.name || DEFAULT_NICKNAME
 
   useEffect(() => {
@@ -58,50 +67,127 @@ export function AuthProvider({ children }) {
     setAccessTokenGetter(() => accessTokenRef.current)
   }, [])
 
-  const refreshTimerRef = useRef(null)
+  // ─── 단일 세션 무효화 함수 ───────────────────────────────────────────────
+  // 어디서 호출해도 한 번만 실행. 타이머·토큰·캐시를 모두 정리한다.
+  // 완료 후 BroadcastChannel로 다른 탭에 전파 (송신 탭 자신에게는 발화 안 됨).
+  const invalidateSession = useCallback((reason) => {
+    if (isInvalidatingRef.current) return
+    isInvalidatingRef.current = true
 
-  const scheduleRefresh = useCallback((token) => {
     if (refreshTimerRef.current) {
       clearTimeout(refreshTimerRef.current)
       refreshTimerRef.current = null
     }
 
-    const delay = getTokenRefreshDelay(token)
-    if (delay == null) return
+    accessTokenRef.current = null
+    setAccessToken(null)
+    setUser(null)
+    queryClient.clear()
 
-    refreshTimerRef.current = setTimeout(async () => {
-      if (!accessTokenRef.current) return
-
-      try {
-        const newToken = await refreshTokens()
-        setAccessToken(newToken)
-        setUser(getUserFromToken(newToken))
-        scheduleRefresh(newToken)
-      } catch {
-        setAccessToken(null)
-        setUser(null)
-      }
-    }, delay)
+    authChannelRef.current?.postMessage({ type: 'SESSION_INVALIDATED', reason })
   }, [])
 
+  // ─── single-flight refresh ────────────────────────────────────────────────
+  // 동시에 여러 컴포넌트가 refresh를 요청해도 실제 네트워크 요청은 1개만 발생
+  const performRefresh = useCallback(() => {
+    // 이미 세션이 무효화된 상태면 시도 자체를 차단
+    if (isInvalidatingRef.current) {
+      return Promise.reject(new Error('Session already invalidated'))
+    }
+
+    if (refreshInProgressRef.current && refreshPromiseRef.current) {
+      return refreshPromiseRef.current
+    }
+
+    refreshInProgressRef.current = true
+    const promise = refreshTokens().finally(() => {
+      refreshInProgressRef.current = false
+      refreshPromiseRef.current = null
+    })
+    refreshPromiseRef.current = promise
+    return promise
+  }, [])
+
+  // ─── 다음 refresh 스케줄링 ────────────────────────────────────────────────
+  const scheduleRefresh = useCallback(
+    (token) => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current)
+        refreshTimerRef.current = null
+      }
+
+      const delay = getTokenRefreshDelay(token)
+      if (delay == null) return
+
+      refreshTimerRef.current = setTimeout(async () => {
+        // 타이머가 발화될 시점에 이미 로그아웃/무효화 상태면 skip
+        if (!accessTokenRef.current || isInvalidatingRef.current) return
+
+        try {
+          const newToken = await performRefresh()
+          accessTokenRef.current = newToken
+          setAccessToken(newToken)
+          setUser(getUserFromToken(newToken))
+          scheduleRefresh(newToken)
+        } catch {
+          // refresh 실패 = 세션 완전 무효화, 자동 재시도 없음 (fail-close)
+          invalidateSession('scheduled_refresh_failed')
+        }
+      }, delay)
+    },
+    [performRefresh, invalidateSession],
+  )
+
+  // ─── 보호 API 401 → 세션 무효화 연결 ─────────────────────────────────────
+  // authFetch에서 refresh/exchange/logout 외의 경로가 401을 받으면 호출됨
+  useEffect(() => {
+    setUnauthorizedHandler((reason) => {
+      invalidateSession(reason)
+    })
+    return () => setUnauthorizedHandler(null)
+  }, [invalidateSession])
+
+  // ─── BroadcastChannel: 멀티탭 세션 동기화 ───────────────────────────────
+  // 탭 A가 로그아웃/세션 만료 → SESSION_INVALIDATED 브로드캐스트
+  // 탭 B, C가 수신 → 각자 invalidateSession 호출 → 모든 탭이 동시에 로그인 화면 전환
+  // BroadcastChannel은 송신 탭 자신에게는 발화하지 않으므로 이중 호출 없음
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return
+
+    const channel = new BroadcastChannel('qfeed_auth')
+    authChannelRef.current = channel
+
+    channel.onmessage = (event) => {
+      if (event.data?.type === 'SESSION_INVALIDATED') {
+        invalidateSession(event.data.reason ?? 'cross_tab_invalidation')
+      }
+    }
+
+    return () => {
+      channel.close()
+      authChannelRef.current = null
+    }
+  }, [invalidateSession])
+
+  // ─── 앱 진입 시 인증 초기화 ───────────────────────────────────────────────
   useEffect(() => {
     const initAuth = async () => {
       try {
-        const newToken = await refreshTokens()
+        const newToken = await performRefresh()
+        accessTokenRef.current = newToken
         setAccessToken(newToken)
         setUser(getUserFromToken(newToken))
         scheduleRefresh(newToken)
       } catch {
-        if (!accessTokenRef.current) {
-          setAccessToken(null)
-        }
+        // refresh 실패(만료/revoked/네트워크) → anonymous 상태 확정, 루프 없음
+        invalidateSession('init_failed')
       } finally {
         setIsLoading(false)
       }
     }
 
     initAuth()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -110,29 +196,32 @@ export function AuthProvider({ children }) {
     }
   }, [])
 
-  const login = useCallback((token, userData = null) => {
-    accessTokenRef.current = token
-    setAccessToken(token)
-    const resolvedUser = userData ?? getUserFromToken(token)
-    setUser(resolvedUser)
-    scheduleRefresh(token)
-  }, [scheduleRefresh])
+  // ─── 로그인 (OAuth 콜백 후 호출) ─────────────────────────────────────────
+  const login = useCallback(
+    (token, userData = null) => {
+      // 이전 무효화 상태를 완전히 초기화한 뒤 새 세션 시작
+      isInvalidatingRef.current = false
+      refreshInProgressRef.current = false
+      refreshPromiseRef.current = null
 
+      accessTokenRef.current = token
+      setAccessToken(token)
+      setUser(userData ?? getUserFromToken(token))
+      scheduleRefresh(token)
+    },
+    [scheduleRefresh],
+  )
+
+  // ─── 사용자 명시적 로그아웃 ───────────────────────────────────────────────
   const logout = useCallback(async () => {
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current)
-      refreshTimerRef.current = null
-    }
     try {
       await apiLogout()
     } catch {
-      // Ignore logout API errors
+      // 서버 로그아웃 실패해도 클라이언트 세션은 반드시 정리
     } finally {
-      setAccessToken(null)
-      setUser(null)
-      queryClient.clear()
+      invalidateSession('logout')
     }
-  }, [])
+  }, [invalidateSession])
 
   const value = {
     accessToken,
@@ -142,6 +231,7 @@ export function AuthProvider({ children }) {
     nickname,
     login,
     logout,
+    invalidateSession,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -3,6 +3,15 @@ const DEFAULT_ERROR_MESSAGE = '요청 처리에 실패했습니다.'
 // 끝의 슬래시 제거 (base + '/api/...' 조합 시 // 가 되지 않도록)
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080').replace(/\/+$/, '')
 
+// 401 응답 시 호출할 핸들러 (AuthContext에서 등록)
+// refresh/exchange/logout 경로는 각 호출자가 직접 처리하므로 제외
+let unauthorizedHandler = null
+const AUTH_BYPASS_PATHS = ['/api/auth/tokens', '/api/auth/oauth/exchange', '/api/auth/logout']
+
+export function setUnauthorizedHandler(handler) {
+  unauthorizedHandler = handler
+}
+
 export async function parseJsonSafe(response) {
   const contentType = response.headers.get('Content-Type') || ''
   if (response.status === 204 || !contentType.includes('application/json')) {
@@ -106,6 +115,15 @@ export async function authFetch(url, options = {}) {
     credentials: 'include',
     ...(signal && { signal }),
   })
+
+  // 보호 API에서 401이면 전역 세션 무효화 트리거
+  // refresh/exchange/logout 경로는 호출자가 직접 처리하므로 건너뜀
+  if (response.status === 401) {
+    const isAuthBypass = AUTH_BYPASS_PATHS.some((path) => url.includes(path))
+    if (!isAuthBypass && unauthorizedHandler) {
+      unauthorizedHandler('api_401')
+    }
+  }
 
   if (parseResponse) {
     return handleResponse(response)


### PR DESCRIPTION
## 배경
Refresh token 기반 자동 세션 복원 과정에서 401(revoked/reuse/expired) 시
재시도 루프 및 stale auth 상태 잔존으로 재로그인이 막히는 문제가 있었습니다.

## 변경 사항
- 앱 부팅 시 refresh 1회 시도 정책으로 단순화
- refresh 401 시 즉시 세션 무효화 + 로그인 화면 진입 허용
- 세션 무효화 플래그 도입으로 인터셉터 재호출 차단
- `/auth/tokens` 자체 실패는 재시도하지 않도록 정책 분리
- 요청당 refresh 재시도 1회 제한
- OAuth 시작 시 기존 인증 상태 선정리, 콜백 성공 시 신규 토큰으로 덮어쓰기
- 멀티탭 로그아웃 동기화(storage event)
- 세션 만료/보안 사유별 사용자 메시지 분리

## 기대 효과
- 401 발생 시 로그인 불가 상태(루프/교착) 제거
- 인증 실패 시 fail-close 동작으로 보안 및 정합성 강화
- 멀티탭 환경에서 세션 상태 일관성 개선
- 사용자에게 실패 사유를 명확히 안내하여 UX 혼란 감소