### PR TITLE
Feat/#178 notification api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@heroicons/react": "^2.2.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -1263,6 +1264,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.3.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@heroicons/react": "^2.2.0",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -24,7 +24,7 @@ export async function fetchNotifications({ cursor = null, size = 20, signal } = 
  * @param {number|string} notificationId
  */
 export async function markNotificationRead(notificationId) {
-  const response = await api.patch(`/api/notifications/${notificationId}/read`, {})
+  const response = await api.patch(`/api/notifications/${notificationId}`, {})
   return handleResponse(response)
 }
 

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -35,3 +35,21 @@ export async function markAllNotificationsRead() {
   const response = await api.patch('/api/notifications/read-all', {})
   return handleResponse(response)
 }
+
+/**
+ * 알림 수신 설정 조회
+ */
+export async function fetchNotificationPreferences() {
+  const response = await api.get('/api/notifications/preferences')
+  return handleResponse(response)
+}
+
+/**
+ * 알림 수신 설정 변경
+ * @param {string} type - 알림 타입 (예: 'ANSWER_FEEDBACK', 'REVISIT')
+ * @param {boolean} enabled
+ */
+export async function updateNotificationPreference(type, enabled) {
+  const response = await api.put(`/api/notifications/preferences/${type}`, { enabled })
+  return handleResponse(response)
+}

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -3,14 +3,14 @@ import { api, handleResponse } from '@/utils/apiUtils'
 /**
  * 알림 목록 조회
  * @param {Object} params
- * @param {string} [params.cursor] - 커서
- * @param {number} [params.limit=20] - 페이지 크기
+ * @param {string|null} [params.cursor] - 커서
+ * @param {number} [params.size=20] - 페이지 크기
  * @param {AbortSignal} [params.signal]
  */
-export async function fetchNotifications({ cursor, limit = 20, signal } = {}) {
+export async function fetchNotifications({ cursor = null, size = 20, signal } = {}) {
   const queryParams = new URLSearchParams()
-  if (cursor) queryParams.append('cursor', cursor)
-  if (limit) queryParams.append('limit', String(limit))
+  if (cursor != null) queryParams.append('cursor', cursor)
+  queryParams.append('size', String(size))
 
   const queryString = queryParams.toString()
   const url = `/api/notifications${queryString ? `?${queryString}` : ''}`

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-route
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/app/components/ui/sonner';
 import { AuthProvider, useAuth } from '@/context/AuthContext';
+import { UnreadNotificationProvider } from '@/context/UnreadNotificationContext';
 import { PracticeQuestionProvider } from '@/context/practiceQuestionContext.jsx';
 import { queryClient } from '@/lib/queryClient';
 import { sendPageView } from '@/utils/analytics';
@@ -116,9 +117,11 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AuthProvider>
-          <PracticeQuestionProvider>
-            <AppRoutes />
-          </PracticeQuestionProvider>
+          <UnreadNotificationProvider>
+            <PracticeQuestionProvider>
+              <AppRoutes />
+            </PracticeQuestionProvider>
+          </UnreadNotificationProvider>
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/src/app/components/AppHeader.jsx
+++ b/src/app/components/AppHeader.jsx
@@ -2,6 +2,28 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import svgPaths from "@/imports/svg-h6m3rufpzr";
 import { Settings, Bell } from 'lucide-react';
+import { useUnreadNotification } from '@/context/UnreadNotificationContext';
+
+function BellButton({ onNotification, isDark }) {
+    const { hasUnread } = useUnreadNotification()
+    return (
+        <button
+            onClick={onNotification}
+            className={`relative size-[32px] flex items-center justify-center rounded-full transition-colors cursor-pointer ${
+                isDark ? 'hover:bg-white/10' : 'hover:bg-gray-100'
+            }`}
+            aria-label={hasUnread ? '알림, 미읽음 있음' : '알림'}
+        >
+            <Bell className="w-5 h-5" />
+            {hasUnread && (
+                <span
+                    aria-hidden="true"
+                    className="absolute top-0.5 right-0.5 w-2 h-2 bg-red-500 rounded-full pointer-events-none"
+                />
+            )}
+        </button>
+    )
+}
 
 export const AppHeader = ({
     title,
@@ -96,13 +118,7 @@ export const AppHeader = ({
                             </button>
                         )}
                         {showNotifications && (
-                            <button
-                                onClick={onNotification}
-                                className={`relative size-[32px] flex items-center justify-center rounded-full transition-colors cursor-pointer ${isDark ? 'hover:bg-white/10' : 'hover:bg-gray-100'}`}
-                                aria-label="알림"
-                            >
-                                <Bell className="w-5 h-5" />
-                            </button>
+                            <BellButton onNotification={onNotification} isDark={isDark} />
                         )}
                     </>
                 )}

--- a/src/app/hooks/useNotificationPreferences.js
+++ b/src/app/hooks/useNotificationPreferences.js
@@ -1,0 +1,53 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { fetchNotificationPreferences, updateNotificationPreference } from '@/api/notificationApi'
+import { toast } from 'sonner'
+
+const QUERY_KEY = ['notification', 'preferences']
+
+// 배열 → { [type]: enabled } 맵 변환
+function toMap(list = []) {
+  return list.reduce((acc, item) => {
+    acc[item.notificationType] = item.enabled
+    return acc
+  }, {})
+}
+
+export function useNotificationPreferences() {
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const res = await fetchNotificationPreferences()
+      return toMap(res?.data ?? [])
+    },
+    staleTime: 30_000,
+  })
+
+  const prefMap = data ?? {}
+
+  const { mutate, isPending, variables } = useMutation({
+    mutationFn: ({ type, enabled }) => updateNotificationPreference(type, enabled),
+    onMutate: async ({ type, enabled }) => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEY })
+      const prev = queryClient.getQueryData(QUERY_KEY)
+      queryClient.setQueryData(QUERY_KEY, (old = {}) => ({ ...old, [type]: enabled }))
+      return { prev }
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev !== undefined) queryClient.setQueryData(QUERY_KEY, ctx.prev)
+      toast.error('알림 설정 변경에 실패했습니다.')
+    },
+    onSuccess: () => {
+      toast.success('알림 설정이 저장되었습니다.')
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+    },
+  })
+
+  // 현재 진행 중인 mutation의 type — 해당 Switch 비활성화에 사용
+  const pendingType = isPending ? variables?.type : null
+
+  return { prefMap, isLoading, mutate, pendingType }
+}

--- a/src/app/hooks/useNotificationsInfinite.js
+++ b/src/app/hooks/useNotificationsInfinite.js
@@ -12,7 +12,12 @@ export function useNotificationsInfinite() {
     queryKey: NOTIFICATIONS_QUERY_KEY,
     queryFn: async ({ pageParam = null }) => {
       const response = await fetchNotifications({ cursor: pageParam, size: PAGE_SIZE })
-      const { notifications: records = [], pagination = {} } = response?.data ?? {}
+      const { content: records = [], last = true, size = PAGE_SIZE } = response?.data ?? {}
+      const pagination = {
+        hasNext: !last,
+        nextCursor: !last && records.length ? records[records.length - 1].id : undefined,
+        size,
+      }
       return { records, pagination }
     },
     initialPageParam: null,

--- a/src/app/hooks/useNotificationsInfinite.js
+++ b/src/app/hooks/useNotificationsInfinite.js
@@ -3,7 +3,7 @@ import { fetchNotifications, markNotificationRead, markAllNotificationsRead } fr
 
 const PAGE_SIZE = 20
 
-export const NOTIFICATIONS_QUERY_KEY = ['notifications']
+export const NOTIFICATIONS_QUERY_KEY = ['notifications', 'cursor', PAGE_SIZE]
 
 export function useNotificationsInfinite() {
   const queryClient = useQueryClient()
@@ -11,8 +11,8 @@ export function useNotificationsInfinite() {
   const query = useInfiniteQuery({
     queryKey: NOTIFICATIONS_QUERY_KEY,
     queryFn: async ({ pageParam = null }) => {
-      const response = await fetchNotifications({ cursor: pageParam, limit: PAGE_SIZE })
-      const { records = [], pagination = {} } = response?.data ?? response ?? {}
+      const response = await fetchNotifications({ cursor: pageParam, size: PAGE_SIZE })
+      const { notifications: records = [], pagination = {} } = response?.data ?? {}
       return { records, pagination }
     },
     initialPageParam: null,

--- a/src/app/hooks/useUnreadNotificationSse.js
+++ b/src/app/hooks/useUnreadNotificationSse.js
@@ -1,0 +1,102 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { fetchEventSource } from '@microsoft/fetch-event-source'
+
+const SSE_URL = `${import.meta.env.VITE_API_BASE_URL ?? ''}/api/notifications/unread`
+const INITIAL_RETRY_MS = 1_000
+const MAX_RETRY_MS = 30_000
+
+class SseAuthError extends Error {}
+
+/**
+ * SSE 연결 관리 훅.
+ * Bearer 토큰 헤더 필요 — native EventSource 불가, fetchEventSource 사용.
+ *
+ * @param {{ accessToken: string|null, onMessage: (hasUnread: boolean) => void, invalidateSession: (reason: string) => void }} params
+ */
+export function useUnreadNotificationSse({ accessToken, onMessage, invalidateSession }) {
+  const onMessageRef = useRef(onMessage)
+  const invalidateRef = useRef(invalidateSession)
+  useLayoutEffect(() => {
+    onMessageRef.current = onMessage
+    invalidateRef.current = invalidateSession
+  })
+  const retryTimerRef = useRef(null)
+
+  useEffect(() => {
+    if (!accessToken) return
+
+    let backoff = INITIAL_RETRY_MS
+    let stopped = false
+    const ctrl = new AbortController()
+
+    function clearTimer() {
+      if (retryTimerRef.current != null) {
+        clearTimeout(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
+    }
+
+    async function connect() {
+      clearTimer()
+      try {
+        await fetchEventSource(SSE_URL, {
+          method: 'GET',
+          // Bearer 헤더 필수 — SSE도 동일한 JWT 인증 사용
+          headers: { Authorization: `Bearer ${accessToken}`, Accept: 'text/event-stream' },
+          credentials: 'include',
+          signal: ctrl.signal,
+          openWhenHidden: true,
+
+          async onopen(res) {
+            if (res.status === 401) {
+              stopped = true
+              invalidateRef.current('sse_401') // 전역 auth 처리에 위임
+              throw new SseAuthError()
+            }
+            if (!res.ok) throw new Error(`SSE_HTTP_${res.status}`)
+            backoff = INITIAL_RETRY_MS // 연결 성공 시 backoff 초기화
+          },
+
+          onmessage(evt) {
+            if (evt.event !== 'unread') return
+            try {
+              onMessageRef.current(evt.data === 'true')
+            } catch {
+              // 파싱 실패 시 무시 — 앱 크래시 방지
+            }
+          },
+
+          onclose() {
+            // 서버가 연결을 닫음 → retryable
+            if (!stopped && !ctrl.signal.aborted) scheduleRetry()
+          },
+
+          onerror() {
+            // fetchEventSource 내부 재시도 억제 — 직접 관리
+            return false
+          },
+        })
+      } catch (err) {
+        if (stopped || ctrl.signal.aborted) return
+        if (err instanceof SseAuthError) return // auth 실패, 재시도 없음
+        scheduleRetry()
+      }
+    }
+
+    function scheduleRetry() {
+      const delay = backoff
+      backoff = Math.min(backoff * 2, MAX_RETRY_MS)
+      retryTimerRef.current = setTimeout(() => {
+        if (!stopped && !ctrl.signal.aborted) connect()
+      }, delay)
+    }
+
+    connect()
+
+    return () => {
+      stopped = true
+      clearTimer()
+      ctrl.abort()
+    }
+  }, [accessToken]) // accessToken 변경(토큰 갱신) 시 재연결 — 최신 토큰 사용
+}

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -7,6 +7,7 @@ import { useRecommendedQuestion } from '@/app/hooks/useRecommendedQuestion';
 import { useWeeklyStats } from '@/app/hooks/useWeeklyStats';
 import { useQuestionCategories } from '@/app/hooks/useQuestionCategories';
 import { getQuestionCategoryLabel } from '@/app/constants/questionCategoryMeta';
+import { useUnreadNotification } from '@/context/UnreadNotificationContext';
 
 const TEXT_RECOMMENDATION_LOADING = '추천 질문을 불러오는 중...';
 const TEXT_RECOMMENDATION_ERROR = '추천 질문을 불러오지 못했습니다.';
@@ -111,6 +112,7 @@ const QuickAction = ({ icon, label, description, color = 'var(--primary-500)', o
 const Home = () => {
     const navigate = useNavigate();
     const { nickname } = useAuth();
+    const { hasUnread } = useUnreadNotification();
 
     const { data: weeklyStatsData } = useWeeklyStats();
     const { data: categoryData } = useQuestionCategories();
@@ -161,10 +163,13 @@ const Home = () => {
                         {SHOW_NOTIFICATIONS && (
                             <button
                                 className="relative flex items-center justify-center w-9 h-9 rounded-full hover:bg-black/10 transition-colors text-gray-900 flex-shrink-0"
-                                aria-label="알림"
+                                aria-label={hasUnread ? '알림, 미읽음 있음' : '알림'}
                                 onClick={() => navigate('/notifications')}
                             >
                                 <Bell className="w-5 h-5" />
+                                {hasUnread && (
+                                    <span aria-hidden="true" className="absolute top-0.5 right-0.5 w-2 h-2 bg-red-500 rounded-full pointer-events-none" />
+                                )}
                             </button>
                         )}
                     </div>

--- a/src/app/pages/NotificationMain.jsx
+++ b/src/app/pages/NotificationMain.jsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import debounce from 'lodash/debounce';
 import { useNavigate } from 'react-router-dom';
-import { Bell, MessageSquare, Star, Award, Info, Loader2 } from 'lucide-react';
+import { Bell, BellRing, Clock, MessageSquare, Star, Award, Info, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { AppHeader } from '@/app/components/AppHeader';
+import { formatRelativeTime } from '@/app/utils/notificationTime';
 import { useNotificationsInfinite } from '@/app/hooks/useNotificationsInfinite';
 import { useUnreadNotification } from '@/context/UnreadNotificationContext';
 
@@ -13,23 +14,13 @@ const TYPE_ICON = {
     ACHIEVEMENT: <Award size={18} />,
     RECOMMENDATION: <Star size={18} />,
     SYSTEM: <Info size={18} />,
+    ANSWER_FEEDBACK: <MessageSquare size={18} />,
+    REVISIT: <BellRing size={18} />,
+    NOTICE: <Info size={18} />,
+    PROJECT_REMINDER: <Clock size={18} />,
 };
 
 const getTypeIcon = (type) => TYPE_ICON[type] ?? <Bell size={18} />;
-
-// createdAt → 상대 시간 포맷
-const formatRelativeTime = (isoString) => {
-    if (!isoString) return '';
-    const diff = Date.now() - new Date(isoString).getTime();
-    const minutes = Math.floor(diff / 60_000);
-    if (minutes < 1) return '방금 전';
-    if (minutes < 60) return `${minutes}분 전`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}시간 전`;
-    const days = Math.floor(hours / 24);
-    if (days < 7) return `${days}일 전`;
-    return new Date(isoString).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' });
-};
 
 const NotificationItem = ({ notification, onRead }) => {
     const navigate = useNavigate();

--- a/src/app/pages/NotificationMain.jsx
+++ b/src/app/pages/NotificationMain.jsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import debounce from 'lodash/debounce';
 import { useNavigate } from 'react-router-dom';
 import { Bell, MessageSquare, Star, Award, Info, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -114,14 +115,21 @@ const NotificationMain = () => {
 
     const observerRef = useRef(null);
 
+    const debouncedFetchNext = useMemo(
+        () => debounce(() => fetchNextPage(), 300),
+        [fetchNextPage]
+    );
+
+    useEffect(() => () => debouncedFetchNext.cancel(), [debouncedFetchNext]);
+
     const observerCallback = useCallback(
         (entries) => {
             const [entry] = entries;
             if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
-                fetchNextPage();
+                debouncedFetchNext();
             }
         },
-        [hasNextPage, isFetchingNextPage, fetchNextPage]
+        [hasNextPage, isFetchingNextPage, debouncedFetchNext]
     );
 
     useEffect(() => {

--- a/src/app/pages/NotificationMain.jsx
+++ b/src/app/pages/NotificationMain.jsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bell, MessageSquare, Star, Award, Info, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { AppHeader } from '@/app/components/AppHeader';
 import { useNotificationsInfinite } from '@/app/hooks/useNotificationsInfinite';
+import { useUnreadNotification } from '@/context/UnreadNotificationContext';
 
 // notificationType 코드 → 아이콘 매핑
 const TYPE_ICON = {
@@ -32,8 +34,23 @@ const NotificationItem = ({ notification, onRead }) => {
     const navigate = useNavigate();
 
     const handleClick = () => {
-        if (!notification.read) onRead(notification.id);
-        if (notification.deeplink) navigate(notification.deeplink);
+        const { deeplink, read, id } = notification
+
+        if (deeplink) {
+            // 내부 경로만 허용 — '/'로 시작하지 않으면 차단
+            // http://, https://, javascript: 등 외부/위험 스킴 방지
+            if (!deeplink.startsWith('/')) {
+                toast.error('유효하지 않은 이동 경로')
+                return
+            }
+            // 읽음 처리(fire and forget) — 실패해도 이동 수행
+            if (!read) onRead(id)
+            navigate(deeplink)
+            return
+        }
+
+        // deeplink 없으면 읽음 처리만
+        if (!read) onRead(id)
     };
 
     return (
@@ -83,6 +100,7 @@ const NotificationItem = ({ notification, onRead }) => {
 };
 
 const NotificationMain = () => {
+    const { clearUnread } = useUnreadNotification()
     const {
         notifications,
         isLoading,
@@ -122,7 +140,7 @@ const NotificationMain = () => {
 
     const headerRight = hasUnread ? (
         <button
-            onClick={() => readAll()}
+            onClick={() => readAll(undefined, { onSuccess: clearUnread })}
             className="text-xs font-medium text-pink-500 hover:text-pink-600 px-2 py-1"
         >
             모두 읽기

--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -16,6 +16,7 @@ import {
     getQuestionTypeLabel,
 } from '@/app/constants/questionCategoryMeta';
 import { QUESTION_TYPES } from '@/app/constants/interviewTaxonomy';
+import { useUnreadNotification } from '@/context/UnreadNotificationContext';
 
 
 const SHOW_NOTIFICATIONS = import.meta.env.VITE_SHOW_NOTIFICATIONS === 'true';
@@ -32,6 +33,7 @@ const EMPTY_MAP = Object.freeze({});
 const PracticeMain = () => {
     const navigate = useNavigate();
     const { setSelectedQuestion } = usePracticeQuestion();
+    const { hasUnread } = useUnreadNotification();
     const [searchQuery, setSearchQuery] = useState(INITIAL_SEARCH_QUERY);
     const [debouncedQuery, setDebouncedQuery] = useState(INITIAL_SEARCH_QUERY);
     const [selectedType, setSelectedType] = useState(ALL_FILTER_VALUE);
@@ -159,10 +161,13 @@ const PracticeMain = () => {
                         {SHOW_NOTIFICATIONS && (
                             <button
                                 className="relative flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 transition-colors"
-                                aria-label="알림"
+                                aria-label={hasUnread ? '알림, 미읽음 있음' : '알림'}
                                 onClick={() => navigate('/notifications')}
                             >
                                 <Bell className="w-5 h-5 text-muted-foreground" />
+                                {hasUnread && (
+                                    <span aria-hidden="true" className="absolute top-0.5 right-0.5 w-2 h-2 bg-red-500 rounded-full pointer-events-none" />
+                                )}
                             </button>
                         )}
                     </div>

--- a/src/app/pages/PracticeMain.jsx
+++ b/src/app/pages/PracticeMain.jsx
@@ -160,6 +160,7 @@ const PracticeMain = () => {
                             <button
                                 className="relative flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 transition-colors"
                                 aria-label="알림"
+                                onClick={() => navigate('/notifications')}
                             >
                                 <Bell className="w-5 h-5 text-muted-foreground" />
                             </button>

--- a/src/app/pages/RealInterview.jsx
+++ b/src/app/pages/RealInterview.jsx
@@ -151,7 +151,7 @@ const RealInterview = () => {
 
     return (
         <div className="relative flex flex-col h-screen bg-background overflow-hidden max-w-lg mx-auto border-x border-transparent">
-            <AppHeader title="실전 면접" onBack={() => navigate('/')} showNotifications={SHOW_NOTIFICATIONS} />
+            <AppHeader title="실전 면접" onBack={() => navigate('/')} showNotifications={SHOW_NOTIFICATIONS} onNotification={() => navigate('/notifications')}/>
 
             <div className="flex-1 flex flex-col p-4 gap-4 pb-24 min-h-0">
                 <section className="rounded-2xl border border-primary-200/80 bg-white/85 p-4 shadow-[0_8px_22px_rgba(255,143,163,0.08)] backdrop-blur-sm">

--- a/src/app/pages/SettingMain.jsx
+++ b/src/app/pages/SettingMain.jsx
@@ -107,7 +107,7 @@ const SettingMain = () => {
 
     return (
         <div className="min-h-screen bg-[#FAFAFA] pb-12">
-            <AppHeader title="설정" onBack={() => navigate('/profile')} showNotifications={SHOW_NOTIFICATIONS} />
+            <AppHeader title="설정" onBack={() => navigate('/profile')} showNotifications={SHOW_NOTIFICATIONS} onNotification={() => navigate('/notifications')} />
 
             <div className="p-6 max-w-lg mx-auto space-y-6">
                 {settingGroups.map((group, groupIndex) => (

--- a/src/app/pages/SettingMain.jsx
+++ b/src/app/pages/SettingMain.jsx
@@ -19,6 +19,7 @@ import { useState } from 'react';
 import { AppHeader } from '@/app/components/AppHeader';
 import { deleteAccount } from '@/api/userApi';
 import { useFeedbackFormDialog } from '@/app/hooks/useFeedbackFormDialog';
+import { useNotificationPreferences } from '@/app/hooks/useNotificationPreferences';
 
 const SettingMain = () => {
 
@@ -28,7 +29,7 @@ const SettingMain = () => {
     const { logout } = useAuth();
     const [showLogoutDialog, setShowLogoutDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-    const [notifications, setNotifications] = useState(true);
+    const { prefMap, isLoading: prefLoading, mutate: updatePref, pendingType } = useNotificationPreferences();
     const { open: openFeedbackDialog, dialog: feedbackDialog } = useFeedbackFormDialog();
 
     const handleLogout = async () => {
@@ -58,8 +59,9 @@ const SettingMain = () => {
                     label: 'AI 평가 완료 알림',
                     action: (
                         <Switch
-                            checked={notifications}
-                            onCheckedChange={setNotifications}
+                            checked={prefMap['ANSWER_FEEDBACK'] ?? false}
+                            onCheckedChange={(enabled) => updatePref({ type: 'ANSWER_FEEDBACK', enabled })}
+                            disabled={pendingType === 'ANSWER_FEEDBACK' || prefLoading}
                         />
                     ),
                 },
@@ -68,8 +70,9 @@ const SettingMain = () => {
                     label: '접속 유도 알림',
                     action: (
                         <Switch
-                            checked={notifications}
-                            onCheckedChange={setNotifications}
+                            checked={prefMap['REVISIT'] ?? false}
+                            onCheckedChange={(enabled) => updatePref({ type: 'REVISIT', enabled })}
+                            disabled={pendingType === 'REVISIT' || prefLoading}
                         />
                     ),
                 },

--- a/src/app/utils/notificationTime.js
+++ b/src/app/utils/notificationTime.js
@@ -1,0 +1,27 @@
+/**
+ * 알림 상대 시간 포맷
+ * @param {string} isoString - ISO 8601 날짜 문자열
+ * @returns {string} 상대 시간 문자열
+ */
+export function formatRelativeTime(isoString) {
+    const ts = new Date(isoString).getTime();
+    if (!isoString || isNaN(ts)) return '오래 전';
+
+    const diff = Date.now() - ts;
+    if (diff < 0) return '방금 전';
+
+    const minutes = diff / 60_000;
+
+    if (minutes <= 10) return '방금 전';
+    if (minutes < 60) return `${Math.floor(minutes / 10) * 10}분 전`;
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}시간 전`;
+
+    const days = Math.floor(diff / 86_400_000);
+    if (days < 7) return `${days}일 전`;
+    if (days < 14) return '1주 전';
+    if (days < 21) return '2주 전';
+    if (days < 28) return '3주 전';
+    return '오래 전';
+}

--- a/src/context/UnreadNotificationContext.jsx
+++ b/src/context/UnreadNotificationContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useCallback, useContext, useState } from 'react'
+import { useAuth } from '@/context/AuthContext'
+import { useUnreadNotificationSse } from '@/app/hooks/useUnreadNotificationSse'
+
+const UnreadNotificationContext = createContext(null)
+
+export function UnreadNotificationProvider({ children }) {
+  const { accessToken, isAuthenticated, invalidateSession } = useAuth()
+  const [hasUnread, setHasUnread] = useState(false)
+
+  // 안정적인 참조 — 빈 deps로 메모이제이션하여 SSE effect 불필요 재실행 방지
+  const handleMessage = useCallback((value) => setHasUnread(value), [])
+
+  useUnreadNotificationSse({
+    accessToken: isAuthenticated ? accessToken : null, // 미인증 시 연결 안 함
+    onMessage: handleMessage,
+    invalidateSession,
+  })
+
+  // NotificationMain에서 모두 읽기 후 즉시 red dot 제거용
+  const clearUnread = useCallback(() => setHasUnread(false), [])
+
+  return (
+    <UnreadNotificationContext.Provider value={{ hasUnread, clearUnread }}>
+      {children}
+    </UnreadNotificationContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useUnreadNotification() {
+  const ctx = useContext(UnreadNotificationContext)
+  if (!ctx) return { hasUnread: false, clearUnread: () => {} } // Provider 외부 안전 fallback
+  return ctx
+}


### PR DESCRIPTION
## 요약
알림 도메인 FE 기능을 end-to-end로 연결했습니다.  
알림 진입, 알림 목록 조회/렌더링, 미읽음 SSE(red dot), 알림 정책 설정(조회/변경)까지 한 흐름으로 구성했습니다.

## 변경 내용

### 1) 알림 페이지 진입 연결
- Practice/RealInterview/Setting 화면의 알림 아이콘 클릭 시 알림 페이지 이동 연결

### 2) 알림 정책 API 연결
- `GET /api/notifications/preferences` 조회 연동
- `PUT /api/notifications/preferences/{type}` 변경 연동
- Setting 화면에서 토글 상태를 서버 값과 동기화
- 낙관적 업데이트 + 실패 시 롤백 처리

### 3) 미읽음 알림 SSE 연결
- `useUnreadNotificationSse` 훅 추가 (`@microsoft/fetch-event-source`)
- `UnreadNotificationContext`로 전역 상태 관리
- App/Header/Home/Practice/NotificationMain에서 red dot 반영
- 401 수신 시 기존 전역 세션 무효화 흐름에 위임

### 4) 알림 목록 조회 개선
- 알림 목록 훅을 cursor 기반 조회 흐름으로 반영
- NotificationMain의 infinite loading 동작 보완

### 5) 알림 목록 UI 퍼블리싱
- NotificationMain 아이콘/타이포/상태 표현 정리
- 생성시각 상대시간 포맷 유틸(`notificationTime`) 추가
- deeplink 유효성(`/` 시작) 검증 및 이동 처리

## 관련 커밋
- `bbc3bc3` feat:[#178] 알림 내역 조회 API 연결 및 UI 퍼블리싱
- `4db1cae` feat:[#178] 알림 내역 cursor 기반 조회로 변경
- `bb3e5a1` feat:[#178] 미 읽음 알림 내역 SSE 연결
- `06ca079` feat:[#178] 알림 정책 API 연결
- `ab595f0` feat:[#178] 알림 아이콘 클릭 시 알림 페이지 이동

## 영향 범위
- 알림 페이지 (`NotificationMain`)
- 설정 페이지 알림 수신정책 UI (`SettingMain`)
- 공통 헤더/홈/연습 화면 알림 아이콘(red dot)
- API 계층 (`notificationApi`) 및 알림 관련 훅

## 관련 이슈
- #178
